### PR TITLE
docs: molding-program scope draft (for grilling)

### DIFF
--- a/docs/adr/2026-08-14-molding-program-scope.md
+++ b/docs/adr/2026-08-14-molding-program-scope.md
@@ -1,0 +1,51 @@
+# TURN Fork Molding Program — Scope
+
+**Status:** Draft for grilling. Nothing in this document is decided until it survives a grill/consider pass.
+**Date:** 2026-08-14
+**Baseline:** `main` @ `cca6b57` (payload = pion/turn#585 head `c7dcea7` + `4b818fc` transaction-wait abort + `/v5` module rename), published as tag `v5.0.13-gs.1` (at `e8db91a`, same payload).
+**Context:** `the-sarge/turn` is a permanent fork of `pion/turn`, per the fork-pivot amendment in wiremux's `docs/adr/2026-08-09-turn-carrier-prerequisites-plan.md` (GridSwarm/wiremux#1161). The goal of this program is to mold the fork into exactly what wiremux needs: cut unused surface, modernize, refactor, and optimize for wiremux's consumption alone.
+
+## Consumer contract
+
+Wiremux's sole planned consumer is the Slice 1.3 allocator/composite: root `Client` performing UDP allocation over a caller-owned `net.PacketConn`, `Client.PrepareUDPPeer` deterministic readiness, the lifetime ChannelData-only write invariant, waiter-local cancellation, and joined Pion-worker allocation close after socket-owner unblock. Wiremux does not consume the TURN server, TCP/TLS transports, ICE, or credential-generation helpers, and its track's acceptance criteria exclude them explicitly.
+
+## Inventory at baseline
+
+| Surface | Size (approx) | Consumer-contract role |
+|---|---|---|
+| root `client.go`, `errors.go`, `stun_conn.go` | ~950 LOC | **Keep** — the consumed API |
+| `internal/client` (UDP path: allocation, binding, client, periodic_timer, permission, transaction, trylock, udp_conn) | ~3,300 LOC | **Keep** — implements readiness, invariant, close-join |
+| `internal/proto` | ~2,300 LOC | **Keep** — wire encoding |
+| `internal/ipnet` | ~70 LOC | **Keep** |
+| `internal/client` TCP path (`tcp_alloc.go`, `tcp_conn.go`) | ~750 LOC | **Cut candidate** — TURN/TCP excluded from track |
+| root server (`server.go`, `server_config.go`, `relay_address_generator_*.go`, `lt_cred.go`) | ~1,000 LOC | **Cut candidate** (see D1) |
+| `internal/server`, `internal/allocation`, `internal/auth` | ~5,900 LOC | **Cut candidate** (see D1) |
+| `examples/` (23 packages), `e2e/` | — | **Cut candidate** — upstream demo surface |
+| `.github/workflows` (10 pion reusable-workflow configs), CodeQL, fuzz, release, renovate | — | **Replace** (see D4) |
+
+Direct dependencies at baseline: `pion/logging`, `pion/randutil`, `pion/stun/v3`, `pion/transport/v4`, `stretchr/testify`, `golang.org/x/sys`, `golang.org/x/time`. Server cuts likely orphan some of these (audit at cut time, e.g. `x/time` rate limiting and parts of `transport/v4`).
+
+## Open decisions (grill these first)
+
+- **D1 — Server as test fixture.** Wiremux's Slice 1.3 evidence plan records local-close receipts against a real TURN server; the fork's own client tests also spin the in-repo server. Cutting the server halves the repo but forces a fixture strategy: keep `internal/server`+`internal/allocation` as test-only code, pin an external fixture (e.g. upstream pion/turn as a test dependency), or rewrite fixtures against a minimal stub. This decision gates the size of the entire cut.
+- **D2 — Upstream security posture.** After divergence, pion/turn security fixes no longer arrive by merge. Decide the mechanism: watch upstream advisories and cherry-pick into the kept surface, or accept the fork as sole owner of its remaining ~6,600 LOC. The smaller the kept surface, the cheaper either answer.
+- **D3 — Versioning scheme.** `v5.0.13-gs.N` implies upstream-tracking semantics the fork no longer has. Once molding breaks API, decide: continue `-gs.N` pre-releases, move to `v5.1.0-gs.1`-style minors, or re-baseline the module as a clean `v5`/`v6` line. Wiremux pins exact versions either way, so this is a communication decision, not a compatibility one.
+- **D4 — CI replacement.** The ten inherited workflows call pion's reusable workflows (lint, API compat, e2e, fuzz, release, renovate) tuned to upstream's needs. Decide the fork's own gate: minimal (build, vet, race tests, gofmt) versus retaining API-compat and fuzz jobs against the kept surface. Ties into the portfolio CI standard.
+- **D5 — Pre-existing test failures.** `TestCreateTCPConnectionInvalid` (`internal/allocation`) and `TestConnectRequest` (`internal/server`) fail deterministically on macOS at baseline, before any fork changes. If D1 cuts these packages, the failures vanish with them; if not, triage them (a local `codex/duplicate-tcp-deadlock` branch touching `CreateTCPConnection` may be related).
+
+## Modernization and optimization axes (after the cut)
+
+- API: reshape `ClientConfig`/`Client` for the single wiremux consumer — context-first cancellation is already half-arrived via `PrepareUDPPeer`; extend it rather than keeping two idioms.
+- Allocations and hot path: the read pump and ChannelData encode/decode are wiremux's per-packet path; profile before optimizing, but `internal/proto` predates modern zero-copy idioms.
+- Dependency diet: each cut re-audits `go.mod`; target is the minimum set the kept surface needs.
+- Go modernity: baseline is `go 1.24`; adopt current idioms (range-over-int, `min`/`max`, structured logging decision vs `pion/logging`) as files are touched, not as a sweep.
+
+## Program shape (candidate, not committed)
+
+1. **Slice M0 — Cut and stabilize:** resolve D1, delete cut surface, replace CI (D4), green gate on the kept surface. No behavior change to kept code.
+2. **Slice M1 — Modernize the kept API** for the wiremux consumer (informed by Slice 1.3's adoption experience — sequencing with wiremux adoption is itself grillable: adopt `v5.0.13-gs.1` first, or land M0 first).
+3. **Slice M2 — Optimize the packet path** with profiles from real wiremux traffic.
+
+## Next step
+
+Grill this document (or run `ras consider` on it), resolve D1–D4, then package the surviving program through `architecture-handoff` into dispatchable slices. The two `notes/grill-*-CONTEXT.md` vocabulary files on `main` are the prepared ubiquitous-language context for those sessions.

--- a/docs/adr/2026-08-14-molding-program-scope.md
+++ b/docs/adr/2026-08-14-molding-program-scope.md
@@ -1,51 +1,48 @@
 # TURN Fork Molding Program — Scope
 
-**Status:** Draft for grilling. Nothing in this document is decided until it survives a grill/consider pass.
-**Date:** 2026-08-14
+**Status:** Grilled and resolved 2026-08-14. Decisions D1–D5 are settled below; ready for `architecture-handoff` packaging.
+**Date:** 2026-08-14 (drafted and grilled same day)
 **Baseline:** `main` @ `cca6b57` (payload = pion/turn#585 head `c7dcea7` + `4b818fc` transaction-wait abort + `/v5` module rename), published as tag `v5.0.13-gs.1` (at `e8db91a`, same payload).
-**Context:** `the-sarge/turn` is a permanent fork of `pion/turn`, per the fork-pivot amendment in wiremux's `docs/adr/2026-08-09-turn-carrier-prerequisites-plan.md` (GridSwarm/wiremux#1161). The goal of this program is to mold the fork into exactly what wiremux needs: cut unused surface, modernize, refactor, and optimize for wiremux's consumption alone.
+**Context:** `the-sarge/turn` is a permanent fork of `pion/turn`, per the fork-pivot amendment in wiremux's `docs/adr/2026-08-09-turn-carrier-prerequisites-plan.md` (GridSwarm/wiremux#1161). This program molds the fork into exactly what wiremux needs: cut unused surface, modernize, refactor, and optimize for wiremux's consumption alone.
+
+## Identity
+
+The fork is an **owned library** — wiremux's TURN client, full stop. Upstream is a read-only reference, never a compatibility target. See [the owned-library ADR](2026-08-14-owned-library-fork.md) for rationale and consequences (security posture, versioning, transitional fixture seam).
 
 ## Consumer contract
 
-Wiremux's sole planned consumer is the Slice 1.3 allocator/composite: root `Client` performing UDP allocation over a caller-owned `net.PacketConn`, `Client.PrepareUDPPeer` deterministic readiness, the lifetime ChannelData-only write invariant, waiter-local cancellation, and joined Pion-worker allocation close after socket-owner unblock. Wiremux does not consume the TURN server, TCP/TLS transports, ICE, or credential-generation helpers, and its track's acceptance criteria exclude them explicitly.
+Wiremux's sole consumer is the Slice 1.3 allocator/composite: root `Client` performing UDP allocation over a caller-owned `net.PacketConn`, `Client.PrepareUDPPeer` deterministic readiness, the lifetime ChannelData-only write invariant, waiter-local cancellation, and joined Pion-worker allocation close after socket-owner unblock. Wiremux does not consume the TURN server, TCP/TLS transports, ICE, or credential-generation helpers.
 
-## Inventory at baseline
+## Resolved decisions
 
-| Surface | Size (approx) | Consumer-contract role |
-|---|---|---|
-| root `client.go`, `errors.go`, `stun_conn.go` | ~950 LOC | **Keep** — the consumed API |
-| `internal/client` (UDP path: allocation, binding, client, periodic_timer, permission, transaction, trylock, udp_conn) | ~3,300 LOC | **Keep** — implements readiness, invariant, close-join |
-| `internal/proto` | ~2,300 LOC | **Keep** — wire encoding |
-| `internal/ipnet` | ~70 LOC | **Keep** |
-| `internal/client` TCP path (`tcp_alloc.go`, `tcp_conn.go`) | ~750 LOC | **Cut candidate** — TURN/TCP excluded from track |
-| root server (`server.go`, `server_config.go`, `relay_address_generator_*.go`, `lt_cred.go`) | ~1,000 LOC | **Cut candidate** (see D1) |
-| `internal/server`, `internal/allocation`, `internal/auth` | ~5,900 LOC | **Cut candidate** (see D1) |
-| `examples/` (23 packages), `e2e/` | — | **Cut candidate** — upstream demo surface |
-| `.github/workflows` (10 pion reusable-workflow configs), CodeQL, fuzz, release, renovate | — | **Replace** (see D4) |
+- **D1 — Server cut with transitional upstream fixture.** Delete the server half entirely. Verified: `internal/client` tests (all PR-585 work) and `close_latency_test.go` are mock-based; only root `client_test.go` (8 `NewServer` uses) and `e2e/` touch the in-repo server. Root integration tests keep their server fixture by pinning upstream `github.com/pion/turn/v5@v5.0.12` as a **test-only** dependency — no import collision thanks to the module rename. This seam is transitional: exit criterion is fork-owned receipt coverage (wiremux Slice 1.3 receipts plus any minimal fork fixture), after which the upstream test dependency is dropped.
+- **D2 — Security posture: watch proto-only.** Watch upstream `pion/turn` releases solely for `internal/proto` (wire-parsing) changes and port those; ignore upstream client-side fixes — the fork's client had already diverged before the pivot. Dependency CVEs (`pion/stun`, `pion/transport`, `x/crypto`) flow through normal dependency updates.
+- **D3 — Versioning: `v5.N.0-gs.1` minors.** M0 tags `v5.1.0-gs.1`; each milestone bumps the minor; the `-gs` suffix is permanent so Go's version selection never auto-upgrades the consumer — every wiremux bump is deliberate.
+- **D4 — CI: portfolio standard plus proto fuzz.** Replace all ten inherited pion reusable-workflow configs by running the `standardize-github-ci` audit/plan/implement flow against the fork inside M0, with one fork-specific addition: retain a fuzz job over `internal/proto`, the complement of D2's proto-focused security bet.
+- **D5 — Pre-existing macOS failures: dissolved by D1.** `TestCreateTCPConnectionInvalid` (`internal/allocation`) and `TestConnectRequest` (`internal/server`) are deleted with their packages.
 
-Direct dependencies at baseline: `pion/logging`, `pion/randutil`, `pion/stun/v3`, `pion/transport/v4`, `stretchr/testify`, `golang.org/x/sys`, `golang.org/x/time`. Server cuts likely orphan some of these (audit at cut time, e.g. `x/time` rate limiting and parts of `transport/v4`).
+## Sequencing
 
-## Open decisions (grill these first)
+Wiremux Slice 1.3 adopts `v5.0.13-gs.1` **now** — its adoption audit covers the pre-cut tree (the post-M0 re-pin is a cheap deletion-heavy re-audit), and its consumer experience is the required input for M1. M0 follows adoption kickoff; M1 does not start until Slice 1.3 merges.
 
-- **D1 — Server as test fixture.** Wiremux's Slice 1.3 evidence plan records local-close receipts against a real TURN server; the fork's own client tests also spin the in-repo server. Cutting the server halves the repo but forces a fixture strategy: keep `internal/server`+`internal/allocation` as test-only code, pin an external fixture (e.g. upstream pion/turn as a test dependency), or rewrite fixtures against a minimal stub. This decision gates the size of the entire cut.
-- **D2 — Upstream security posture.** After divergence, pion/turn security fixes no longer arrive by merge. Decide the mechanism: watch upstream advisories and cherry-pick into the kept surface, or accept the fork as sole owner of its remaining ~6,600 LOC. The smaller the kept surface, the cheaper either answer.
-- **D3 — Versioning scheme.** `v5.0.13-gs.N` implies upstream-tracking semantics the fork no longer has. Once molding breaks API, decide: continue `-gs.N` pre-releases, move to `v5.1.0-gs.1`-style minors, or re-baseline the module as a clean `v5`/`v6` line. Wiremux pins exact versions either way, so this is a communication decision, not a compatibility one.
-- **D4 — CI replacement.** The ten inherited workflows call pion's reusable workflows (lint, API compat, e2e, fuzz, release, renovate) tuned to upstream's needs. Decide the fork's own gate: minimal (build, vet, race tests, gofmt) versus retaining API-compat and fuzz jobs against the kept surface. Ties into the portfolio CI standard.
-- **D5 — Pre-existing test failures.** `TestCreateTCPConnectionInvalid` (`internal/allocation`) and `TestConnectRequest` (`internal/server`) fail deterministically on macOS at baseline, before any fork changes. If D1 cuts these packages, the failures vanish with them; if not, triage them (a local `codex/duplicate-tcp-deadlock` branch touching `CreateTCPConnection` may be related).
+## Cut and keep lists (M0)
 
-## Modernization and optimization axes (after the cut)
+**Delete:** `server.go`, `server_config.go`, `relay_address_generator_range.go`, `relay_address_generator_static.go`, `relay_address_generator_none.go`, `lt_cred.go` (no non-example consumer), root `stun_conn.go` (consumed only by server and TCP/TLS examples), `internal/server`, `internal/allocation`, `internal/auth`, `internal/client/tcp_alloc.go`, `internal/client/tcp_conn.go` plus the TCP-allocation entry points in root `client.go`, all of `examples/`, all of `e2e/`, and the ten inherited `.github/workflows` configs (replaced per D4).
 
-- API: reshape `ClientConfig`/`Client` for the single wiremux consumer — context-first cancellation is already half-arrived via `PrepareUDPPeer`; extend it rather than keeping two idioms.
-- Allocations and hot path: the read pump and ChannelData encode/decode are wiremux's per-packet path; profile before optimizing, but `internal/proto` predates modern zero-copy idioms.
-- Dependency diet: each cut re-audits `go.mod`; target is the minimum set the kept surface needs.
-- Go modernity: baseline is `go 1.24`; adopt current idioms (range-over-int, `min`/`max`, structured logging decision vs `pion/logging`) as files are touched, not as a sweep.
+**Keep:** root `client.go` (UDP paths) and `errors.go`; `internal/client` UDP path (`allocation.go`, `binding.go`, `client.go`, `errors.go`, `periodic_timer.go`, `permission.go`, `transaction.go`, `trylock.go`, `udp_conn.go`); `internal/proto` wholesale (trimming deferred past M0); `internal/ipnet`. Approximately 6,600 LOC.
 
-## Program shape (candidate, not committed)
+**Dependency re-audit at cut time:** expect `golang.org/x/time` and parts of `pion/transport/v4` to become removable; `stretchr/testify` stays; upstream `pion/turn/v5` enters as test-only.
 
-1. **Slice M0 — Cut and stabilize:** resolve D1, delete cut surface, replace CI (D4), green gate on the kept surface. No behavior change to kept code.
-2. **Slice M1 — Modernize the kept API** for the wiremux consumer (informed by Slice 1.3's adoption experience — sequencing with wiremux adoption is itself grillable: adopt `v5.0.13-gs.1` first, or land M0 first).
-3. **Slice M2 — Optimize the packet path** with profiles from real wiremux traffic.
+## Program shape
 
-## Next step
+1. **Slice M0 — Cut and stabilize:** execute the cut and keep lists, land portfolio CI with proto fuzz, green gate on the kept surface, tag `v5.1.0-gs.1`. No behavior change to kept code.
+2. **Slice M1 — Modernize the kept API** for the one consumer (context-first cancellation is already half-arrived via `PrepareUDPPeer`; extend rather than keep two idioms). Gated on Slice 1.3 merging — its adoption experience defines M1's content.
+3. **Slice M2 — Optimize the packet path** (read pump, ChannelData encode/decode in `internal/proto`). Gated on profiles from real wiremux traffic; no speculative optimization.
 
-Grill this document (or run `ras consider` on it), resolve D1–D4, then package the surviving program through `architecture-handoff` into dispatchable slices. The two `notes/grill-*-CONTEXT.md` vocabulary files on `main` are the prepared ubiquitous-language context for those sessions.
+## Tracking
+
+The program is packaged through `architecture-handoff`: program issues live in `the-sarge/turn` (wiremux issues remain consumer-side only), mirrored to OmniFocus per that workflow.
+
+## Grill record
+
+Grilled 2026-08-14 (fork-identity, D1–D5, sequencing all put to the owner; facts verified against the tree at `cca6b57`). Superseded draft framing: the original draft treated the fixture problem as gating "the size of the entire cut" — verification showed the mock-based test coverage already carries the PR-585 surface, shrinking D1 to the root integration tests and wiremux receipts only.

--- a/docs/adr/2026-08-14-owned-library-fork.md
+++ b/docs/adr/2026-08-14-owned-library-fork.md
@@ -1,0 +1,9 @@
+# The fork is an owned library, not a tracked fork
+
+`the-sarge/turn` exists to be wiremux's TURN client library; after the 2026-08-14 fork pivot we decided it is fully owned — free to break API, delete surface, and diverge from `pion/turn` without limit — rather than a trimmed fork that preserves upstream shape for cheap patch flow. Wiremux pins exact `-gs` pre-release versions, so divergence costs the one consumer nothing, and the alternative (upstream compatibility) would have blocked the entire molding program's purpose.
+
+## Consequences
+
+- Upstream is a read-only reference. Security posture is deliberately narrow: we watch upstream releases for `internal/proto` (wire-parsing) changes only; client-side upstream fixes are ignored because the client had already diverged (pion/turn#585 plus the `4b818fc` transaction-wait abort live only here). Dependency CVEs still arrive through normal dependency updates.
+- Versioning: minors bump per milestone (`v5.1.0-gs.1`, `v5.2.0-gs.1`, …) and the `-gs` suffix is permanent — Go never auto-selects pre-releases, so every consumer bump is deliberate.
+- The upstream `pion/turn/v5` test-only dependency (integration-test server fixture, possible only because the module rename removed the import-path collision) is a transitional seam, not a compatibility statement; it exits when fork-owned receipt coverage replaces it.


### PR DESCRIPTION
## Summary
- Kicks off planning for the molding program: cutting `the-sarge/turn` down to exactly what wiremux needs, then modernizing and optimizing the kept surface.
- Evidence-based inventory: keep the consumed client UDP path (`client.go`, `internal/client` UDP files, `internal/proto`, `internal/ipnet`, ~6,600 LOC); cut candidates are the server half (~6,900 LOC), client TCP path, 23 example packages, `e2e`, and the inherited pion CI.
- Five open decisions (D1 server-as-test-fixture, D2 upstream security posture, D3 versioning scheme, D4 CI replacement, D5 pre-existing macOS test failures) are flagged as grill-first gates — nothing is committed by this doc.
- Candidate program shape: M0 cut+stabilize, M1 modernize API, M2 optimize packet path.

## Baseline
`main` @ `cca6b57`, published tag `v5.0.13-gs.1` (verified resolvable via `go get`).

## Next step
Grill the doc or run `ras consider` on it, resolve D1–D4, then `architecture-handoff` into dispatchable slices.