### PR TITLE
Slice 3: context-first allocation, one lifecycle idiom, and failures as values

### DIFF
--- a/allocate_ctx_test.go
+++ b/allocate_ctx_test.go
@@ -1,0 +1,548 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+//go:build !js
+
+package turn
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/netip"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pion/stun/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/the-sarge/turn/v5/internal/proto"
+)
+
+// observerConn is a caller-owned socket standing in for the silent-server
+// pattern: writes reach a server that never responds on its own, driving the
+// real transaction/retransmission machinery deterministically. It records
+// outbound datagrams and counts the deadline and close calls that the fork
+// must never make on a caller-owned socket. An optional gate blocks the Nth
+// and later writes, modeling a retransmit write stuck in caller-socket I/O.
+type observerConn struct {
+	deadlineCalls atomic.Int32
+	closeCalls    atomic.Int32
+	writeCount    atomic.Int32
+	blockFrom     int32         // 1-based write ordinal at which writes block; 0 = never
+	gate          chan struct{} // Closed to release blocked writes
+	blocked       chan struct{} // Signaled once a write is blocked on the gate
+
+	mu     sync.Mutex
+	writes [][]byte
+}
+
+func newObserverConn() *observerConn {
+	return &observerConn{
+		gate:    make(chan struct{}),
+		blocked: make(chan struct{}, 8),
+	}
+}
+
+func (o *observerConn) WriteTo(p []byte, _ net.Addr) (int, error) {
+	n := o.writeCount.Add(1)
+	if o.blockFrom > 0 && n >= o.blockFrom {
+		o.blocked <- struct{}{}
+		<-o.gate
+	}
+	o.mu.Lock()
+	o.writes = append(o.writes, append([]byte(nil), p...))
+	o.mu.Unlock()
+
+	return len(p), nil
+}
+
+func (o *observerConn) write(i int) []byte {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if i >= len(o.writes) {
+		return nil
+	}
+
+	return append([]byte(nil), o.writes[i]...)
+}
+
+func (o *observerConn) ReadFrom([]byte) (int, net.Addr, error) {
+	select {} // The tests feed inbound datagrams through HandleInbound directly.
+}
+
+func (o *observerConn) Close() error {
+	o.closeCalls.Add(1)
+
+	return nil
+}
+
+func (o *observerConn) LocalAddr() net.Addr {
+	return &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 5555}
+}
+
+func (o *observerConn) SetDeadline(time.Time) error {
+	o.deadlineCalls.Add(1)
+
+	return nil
+}
+
+func (o *observerConn) SetReadDeadline(time.Time) error {
+	o.deadlineCalls.Add(1)
+
+	return nil
+}
+
+func (o *observerConn) SetWriteDeadline(time.Time) error {
+	o.deadlineCalls.Add(1)
+
+	return nil
+}
+
+func testServerAddrPort() netip.AddrPort {
+	return netip.MustParseAddrPort("127.0.0.1:3478")
+}
+
+func newObservedClient(t *testing.T, conn *observerConn) *Client {
+	t.Helper()
+
+	cl, err := NewClient(&ClientConfig{
+		Conn:     conn,
+		Server:   testServerAddrPort(),
+		Username: "user",
+		Password: "secret",
+		RTO:      25 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	t.Cleanup(cl.Close)
+
+	return cl
+}
+
+func testServerNetAddr() net.Addr {
+	return net.UDPAddrFromAddrPort(testServerAddrPort())
+}
+
+// transactionID extracts the transaction ID from a recorded request datagram.
+func transactionID(t *testing.T, raw []byte) [stun.TransactionIDSize]byte {
+	t.Helper()
+
+	msg := &stun.Message{Raw: append([]byte(nil), raw...)}
+	require.NoError(t, msg.Decode())
+
+	return msg.TransactionID
+}
+
+// unauthorizedResponse builds the 401 challenge for the recorded
+// unauthenticated Allocate request, carrying the nonce and realm the client
+// needs for its authenticated attempt.
+func unauthorizedResponse(t *testing.T, req []byte) []byte {
+	t.Helper()
+
+	nonce := stun.NewNonce("test-nonce")
+	realm := stun.NewRealm("test-realm")
+	msg, err := stun.Build(
+		stun.NewTransactionIDSetter(transactionID(t, req)),
+		stun.NewType(stun.MethodAllocate, stun.ClassErrorResponse),
+		stun.ErrorCodeAttribute{Code: stun.CodeUnauthorized, Reason: []byte("Unauthorized")},
+		&nonce,
+		&realm,
+	)
+	require.NoError(t, err)
+
+	return msg.Raw
+}
+
+// allocateSuccessResponse builds the success for the recorded authenticated
+// Allocate request, reporting a canonical relayed address.
+func allocateSuccessResponse(t *testing.T, req []byte) []byte {
+	t.Helper()
+
+	msg, err := stun.Build(
+		stun.NewTransactionIDSetter(transactionID(t, req)),
+		stun.NewType(stun.MethodAllocate, stun.ClassSuccessResponse),
+		proto.RelayedAddress{IP: net.ParseIP("127.0.0.1"), Port: 40000},
+		proto.Lifetime{Duration: 10 * time.Minute},
+	)
+	require.NoError(t, err)
+
+	return msg.Raw
+}
+
+// allocateErrorResponse builds an error response with the given code for the
+// recorded authenticated Allocate request.
+func allocateErrorResponse(t *testing.T, req []byte, code stun.ErrorCode) []byte {
+	t.Helper()
+
+	msg, err := stun.Build(
+		stun.NewTransactionIDSetter(transactionID(t, req)),
+		stun.NewType(stun.MethodAllocate, stun.ClassErrorResponse),
+		stun.ErrorCodeAttribute{Code: code, Reason: []byte("error")},
+	)
+	require.NoError(t, err)
+
+	return msg.Raw
+}
+
+// awaitWrite waits until the observer has recorded at least n writes and
+// returns the raw datagram at index n-1.
+func awaitWrite(t *testing.T, conn *observerConn, n int32) []byte {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		return conn.writeCount.Load() >= n
+	}, 5*time.Second, 5*time.Millisecond, "request %d never left the socket", n)
+
+	return conn.write(int(n - 1))
+}
+
+// awaitRequestAfter waits for a request recorded at or after write index from
+// whose transaction ID differs from excludeID (skipping retransmits of the
+// excluded request), returning its raw datagram.
+func awaitRequestAfter(t *testing.T, conn *observerConn, from int32, excludeID [stun.TransactionIDSize]byte) []byte {
+	t.Helper()
+
+	var raw []byte
+	require.Eventually(t, func() bool {
+		count := conn.writeCount.Load()
+		for i := from; i < count; i++ {
+			candidate := conn.write(int(i))
+			if candidate == nil {
+				continue
+			}
+			if transactionID(t, candidate) != excludeID {
+				raw = candidate
+
+				return true
+			}
+		}
+
+		return false
+	}, 5*time.Second, 5*time.Millisecond, "expected request never left the socket")
+
+	return raw
+}
+
+// awaitAuthRequest feeds the 401 challenge for the first request and waits
+// for the authenticated Allocate request that follows it, returning its raw
+// datagram. Retransmits of the unauthenticated request share its transaction
+// ID and are skipped.
+func awaitAuthRequest(t *testing.T, cl *Client, conn *observerConn) []byte {
+	t.Helper()
+
+	first := awaitWrite(t, conn, 1)
+	require.NoError(t, cl.HandleInbound(unauthorizedResponse(t, first), testServerNetAddr()))
+
+	return awaitRequestAfter(t, conn, 1, transactionID(t, first))
+}
+
+func TestAllocateContext(t *testing.T) {
+	t.Run("cancel before send returns the cause without touching the socket", func(t *testing.T) {
+		conn := newObserverConn()
+		cl := newObservedClient(t, conn)
+
+		ctx, cancel := context.WithCancelCause(context.Background())
+		cause := errors.New("caller gave up before send") //nolint:err113 // test-local cause
+		cancel(cause)
+
+		alloc, err := cl.Allocate(ctx)
+		assert.Nil(t, alloc)
+		assert.ErrorIs(t, err, cause)
+		assert.Equal(t, int32(0), conn.writeCount.Load(), "canceled-before-send Allocate must not write")
+		assert.Equal(t, int32(0), conn.deadlineCalls.Load(), "the fork must never deadline the caller's socket")
+		assert.Equal(t, int32(0), conn.closeCalls.Load(), "the fork must never close the caller's socket")
+	})
+
+	t.Run("cancel during the unauthenticated wait returns promptly with the cause", func(t *testing.T) {
+		conn := newObserverConn()
+		cl := newObservedClient(t, conn)
+
+		ctx, cancel := context.WithCancelCause(context.Background())
+		defer cancel(nil)
+		result := make(chan error, 1)
+		go func() {
+			_, err := cl.Allocate(ctx)
+			result <- err
+		}()
+
+		awaitWrite(t, conn, 1)
+		cause := errors.New("caller gave up during unauthenticated wait") //nolint:err113 // test-local cause
+		start := time.Now()
+		cancel(cause)
+
+		select {
+		case err := <-result:
+			assert.ErrorIs(t, err, cause)
+			assert.Less(t, time.Since(start), 500*time.Millisecond,
+				"cancellation must return well inside the retransmission budget")
+		case <-time.After(2 * time.Second):
+			assert.Fail(t, "canceled Allocate did not return")
+		}
+		assert.Equal(t, int32(0), conn.deadlineCalls.Load(), "the fork must never deadline the caller's socket")
+		assert.Equal(t, int32(0), conn.closeCalls.Load(), "the fork must never close the caller's socket")
+	})
+
+	t.Run("cancel during the authenticated wait returns promptly with the cause", func(t *testing.T) {
+		conn := newObserverConn()
+		cl := newObservedClient(t, conn)
+
+		ctx, cancel := context.WithCancelCause(context.Background())
+		defer cancel(nil)
+		result := make(chan error, 1)
+		go func() {
+			_, err := cl.Allocate(ctx)
+			result <- err
+		}()
+
+		awaitAuthRequest(t, cl, conn)
+		cause := errors.New("caller gave up during authenticated wait") //nolint:err113 // test-local cause
+		start := time.Now()
+		cancel(cause)
+
+		select {
+		case err := <-result:
+			assert.ErrorIs(t, err, cause)
+			assert.Less(t, time.Since(start), 500*time.Millisecond,
+				"cancellation must return well inside the retransmission budget")
+		case <-time.After(2 * time.Second):
+			assert.Fail(t, "canceled Allocate did not return")
+		}
+		assert.Equal(t, int32(0), conn.deadlineCalls.Load(), "the fork must never deadline the caller's socket")
+		assert.Equal(t, int32(0), conn.closeCalls.Load(), "the fork must never close the caller's socket")
+	})
+
+	t.Run("a published success wins over cancellation", func(t *testing.T) {
+		conn := newObserverConn()
+		cl := newObservedClient(t, conn)
+
+		ctx, cancel := context.WithCancelCause(context.Background())
+		defer cancel(nil)
+		type allocateResult struct {
+			alloc *Allocation
+			err   error
+		}
+		result := make(chan allocateResult, 1)
+		go func() {
+			alloc, err := cl.Allocate(ctx)
+			result <- allocateResult{alloc, err}
+		}()
+
+		authReq := awaitAuthRequest(t, cl, conn)
+		// HandleInbound returns only after the success result is published to
+		// the transaction's buffered channel, so the cancellation below always
+		// races a result the producer already owns.
+		require.NoError(t, cl.HandleInbound(allocateSuccessResponse(t, authReq), testServerNetAddr()))
+		cancel(errors.New("canceled after the response was published")) //nolint:err113 // test-local cause
+
+		select {
+		case res := <-result:
+			assert.NoError(t, res.err, "a published success must win over cancellation")
+			assert.NotNil(t, res.alloc)
+			if res.alloc != nil {
+				assert.Equal(t, netip.MustParseAddrPort("127.0.0.1:40000"), res.alloc.RelayedAddr())
+				assert.NoError(t, res.alloc.Close(), "the raced Allocation must be closable")
+			}
+		case <-time.After(2 * time.Second):
+			assert.Fail(t, "Allocate did not return after the success response")
+		}
+	})
+}
+
+func TestAllocateCancelDuringBlockedRetransmit(t *testing.T) {
+	conn := newObserverConn()
+	conn.blockFrom = 2 // The initial send passes; the first retransmit blocks.
+	cl := newObservedClient(t, conn)
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	result := make(chan error, 1)
+	go func() {
+		_, err := cl.Allocate(ctx)
+		result <- err
+	}()
+
+	// Wait for the retransmit write to be blocked in caller-socket I/O.
+	select {
+	case <-conn.blocked:
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "retransmit write never started")
+	}
+
+	cause := errors.New("caller gave up while a retransmit was blocked") //nolint:err113 // test-local cause
+	start := time.Now()
+	cancel(cause)
+	select {
+	case err := <-result:
+		assert.ErrorIs(t, err, cause)
+		assert.Less(t, time.Since(start), 500*time.Millisecond,
+			"cancellation must not wait behind caller-socket I/O")
+	case <-time.After(2 * time.Second):
+		assert.Fail(t, "canceled Allocate did not return while a retransmit write was blocked")
+	}
+
+	// Release the blocked write: it must complete without re-arming the timer
+	// and without a further send.
+	close(conn.gate)
+	assert.Eventually(t, func() bool {
+		return conn.writeCount.Load() == 2
+	}, time.Second, 5*time.Millisecond, "released retransmit write did not complete")
+	time.Sleep(300 * time.Millisecond) // Several RTOs: a re-armed timer would have fired.
+	assert.Equal(t, int32(2), conn.writeCount.Load(),
+		"a retransmit completing after cancellation must not re-arm or send again")
+}
+
+func TestAllocateCancelProducerRace(t *testing.T) {
+	conn := newObserverConn()
+	conn.blockFrom = 2
+	cl := newObservedClient(t, conn)
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	result := make(chan error, 1)
+	go func() {
+		_, err := cl.Allocate(ctx)
+		result <- err
+	}()
+
+	select {
+	case <-conn.blocked:
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "retransmit write never started")
+	}
+
+	cause := errors.New("caller gave up mid-retransmit") //nolint:err113 // test-local cause
+	cancel(cause)
+	select {
+	case err := <-result:
+		assert.ErrorIs(t, err, cause)
+	case <-time.After(2 * time.Second):
+		assert.Fail(t, "canceled Allocate did not return")
+	}
+
+	// With the producer's socket write still blocked, Close and HandleInbound
+	// must remain callable: no producer blocks holding mutexTrMap.
+	closeDone := make(chan struct{})
+	go func() {
+		cl.Close()
+		close(closeDone)
+	}()
+	select {
+	case <-closeDone:
+	case <-time.After(2 * time.Second):
+		assert.Fail(t, "Client.Close blocked behind an in-flight retransmit write")
+	}
+
+	handled := make(chan error, 1)
+	go func() {
+		// A response for an unknown transaction is silently discarded.
+		unknown, err := stun.Build(
+			stun.TransactionID,
+			stun.NewType(stun.MethodAllocate, stun.ClassSuccessResponse),
+		)
+		if err != nil {
+			handled <- err
+
+			return
+		}
+		handled <- cl.HandleInbound(unknown.Raw, testServerNetAddr())
+	}()
+	select {
+	case err := <-handled:
+		assert.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		assert.Fail(t, "HandleInbound blocked behind an in-flight retransmit write")
+	}
+
+	close(conn.gate)
+}
+
+func TestAllocateCancelVsClientClose(t *testing.T) {
+	conn := newObserverConn()
+	cl := newObservedClient(t, conn)
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	result := make(chan error, 1)
+	go func() {
+		_, err := cl.Allocate(ctx)
+		result <- err
+	}()
+
+	awaitWrite(t, conn, 1)
+
+	// The closer removes and closes the transaction first; the cancellation
+	// that follows must lose: the truthful cause is the close.
+	cl.Close()
+	cause := errors.New("cancellation after close") //nolint:err113 // test-local cause
+	cancel(cause)
+
+	select {
+	case err := <-result:
+		assert.ErrorIs(t, err, net.ErrClosed, "a closed client must surface net.ErrClosed")
+		assert.NotErrorIs(t, err, cause, "closure must take precedence over the cancellation cause")
+	case <-time.After(2 * time.Second):
+		assert.Fail(t, "Allocate did not return after Client.Close")
+	}
+}
+
+func TestAllocateLateSuccessDiscarded(t *testing.T) {
+	conn := newObserverConn()
+	cl := newObservedClient(t, conn)
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	result := make(chan error, 1)
+	go func() {
+		_, err := cl.Allocate(ctx)
+		result <- err
+	}()
+
+	authReq := awaitAuthRequest(t, cl, conn)
+	cause := errors.New("caller gave up before the late success") //nolint:err113 // test-local cause
+	cancel(cause)
+	select {
+	case err := <-result:
+		assert.ErrorIs(t, err, cause)
+	case <-time.After(2 * time.Second):
+		assert.Fail(t, "canceled Allocate did not return")
+	}
+
+	// The delayed authenticated success arrives after Allocate returned: it
+	// must be discarded without blocking and without error.
+	done := make(chan error, 1)
+	go func() { done <- cl.HandleInbound(allocateSuccessResponse(t, authReq), testServerNetAddr()) }()
+	select {
+	case err := <-done:
+		assert.NoError(t, err, "a late success for a departed waiter is silently discarded")
+	case <-time.After(2 * time.Second):
+		assert.Fail(t, "HandleInbound blocked delivering a late success")
+	}
+
+	// Documented consequence: the orphaned server-side allocation can answer a
+	// same-Conn retry with 437 Allocation Mismatch, which surfaces as a value.
+	writesBefore := conn.writeCount.Load()
+	retryResult := make(chan error, 1)
+	go func() {
+		_, err := cl.Allocate(context.Background())
+		retryResult <- err
+	}()
+	retryFirst := awaitWrite(t, conn, writesBefore+1)
+	require.NoError(t, cl.HandleInbound(unauthorizedResponse(t, retryFirst), testServerNetAddr()))
+	retryAuth := awaitRequestAfter(t, conn, writesBefore+1, transactionID(t, retryFirst))
+
+	const codeAllocMismatch stun.ErrorCode = 437
+	require.NoError(t, cl.HandleInbound(allocateErrorResponse(t, retryAuth, codeAllocMismatch), testServerNetAddr()))
+
+	select {
+	case err := <-retryResult:
+		var turnErr *stun.TurnError
+		assert.ErrorAs(t, err, &turnErr, "the 437 must surface as a typed value")
+		if turnErr != nil {
+			assert.Equal(t, codeAllocMismatch, turnErr.ErrorCodeAttr.Code)
+		}
+	case <-time.After(2 * time.Second):
+		assert.Fail(t, "retry Allocate did not return")
+	}
+}

--- a/allocation.go
+++ b/allocation.go
@@ -47,7 +47,11 @@ func (a *Allocation) PreparePeer(ctx context.Context, peer netip.AddrPort) error
 
 // ReadFrom reads one relayed datagram, copying the payload into p. It returns
 // the number of bytes copied and the canonical source peer, blocking until a
-// datagram arrives or the allocation closes.
+// datagram arrives or the allocation closes. Datagrams arriving while the
+// receive queue is full are dropped, matching UDP semantics. After the
+// allocation closes, ReadFrom returns net.ErrClosed, wrapped with the
+// terminal cause when the allocation sealed itself (for example
+// ErrAllocationRefreshFailed).
 func (a *Allocation) ReadFrom(p []byte) (int, netip.AddrPort, error) {
 	return a.conn.ReadFrom(p)
 }
@@ -65,6 +69,12 @@ func (a *Allocation) WriteTo(payload []byte, peer netip.AddrPort) (int, error) {
 // Close releases the allocation on the server and unblocks pending ReadFrom
 // and WriteTo calls. It returns only after allocation-owned goroutines have
 // finished; it never closes or deadlines the caller-owned base socket.
+//
+// Close always joins, then returns: the lifetime-0 release error (or nil)
+// when this call performed the release — a socket-close cause satisfies
+// errors.Is(err, net.ErrClosed); the recorded terminal cause (for example
+// ErrAllocationRefreshFailed wrapping the underlying failure) when the
+// allocation had already sealed itself; net.ErrClosed on repeated calls.
 func (a *Allocation) Close() error {
 	return a.conn.Close()
 }

--- a/allocation_test.go
+++ b/allocation_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pion/logging"
 	"github.com/pion/stun/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -73,7 +72,6 @@ func newAllocHarness(t *testing.T) *allocHarness {
 		Integrity:     stun.NewShortTermIntegrity("pass"),
 		Nonce:         stun.NewNonce("nonce"),
 		Lifetime:      time.Hour,
-		Log:           logging.NewDefaultLoggerFactory().NewLogger("test"),
 	})
 	t.Cleanup(func() { _ = conn.Close() })
 
@@ -213,10 +211,10 @@ func TestAllocateRejectsInvalidRelayedAddress(t *testing.T) {
 		Password: "pass",
 	})
 	require.NoError(t, err)
-	require.NoError(t, turnClient.Listen())
+	startTestPump(t, turnClient, clientSock)
 	defer turnClient.Close()
 
-	alloc, err := turnClient.Allocate()
+	alloc, err := turnClient.Allocate(context.Background())
 	assert.ErrorIs(t, err, ErrInvalidRelayedAddress)
 	assert.Nil(t, alloc)
 
@@ -232,13 +230,20 @@ func TestAllocateRejectsInvalidRelayedAddress(t *testing.T) {
 }
 
 // TestDeletedSurfaceDoesNotResolve pins the negative API contract: the moved
-// PrepareUDPPeer and the deleted deadline/LocalAddr surface must not resolve.
+// PrepareUDPPeer, the deleted deadline/LocalAddr surface, the deleted Listen
+// second idiom, and the removed LoggerFactory seam must not resolve.
 func TestDeletedSurfaceDoesNotResolve(t *testing.T) {
 	_, ok := reflect.TypeFor[*Client]().MethodByName("PrepareUDPPeer")
 	assert.False(t, ok, "Client.PrepareUDPPeer moved to Allocation.PreparePeer")
 
 	for _, name := range []string{"SetReadDeadline", "SetWriteDeadline", "SetDeadline", "LocalAddr"} {
-		_, ok := reflect.TypeFor[*Allocation]().MethodByName(name)
-		assert.False(t, ok, "Allocation must not expose %s", name)
+		_, found := reflect.TypeFor[*Allocation]().MethodByName(name)
+		assert.False(t, found, "Allocation must not expose %s", name)
 	}
+
+	_, ok = reflect.TypeFor[*Client]().MethodByName("Listen")
+	assert.False(t, ok, "Client.Listen is deleted: the consumer owns the read pump")
+
+	_, ok = reflect.TypeFor[ClientConfig]().FieldByName("LoggerFactory")
+	assert.False(t, ok, "ClientConfig.LoggerFactory is deleted: the module does not log")
 }

--- a/client.go
+++ b/client.go
@@ -5,6 +5,7 @@
 package turn
 
 import (
+	"context"
 	b64 "encoding/base64"
 	"fmt"
 	"math"
@@ -13,7 +14,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pion/logging"
 	"github.com/pion/stun/v3"
 	"github.com/the-sarge/turn/v5/internal/client"
 	"github.com/the-sarge/turn/v5/internal/proto"
@@ -41,12 +41,11 @@ type ClientConfig struct {
 	// canonical: a unicast IPv4 or IPv6 literal (IPv4-mapped IPv6 is
 	// rejected; use the IPv4 literal), no zone, nonzero port. The client
 	// performs no name resolution.
-	Server        netip.AddrPort
-	Username      string
-	Password      string //nolint:gosec // runtime credential, not hardcoded.
-	RTO           time.Duration
-	Conn          net.PacketConn // Listening socket (net.PacketConn)
-	LoggerFactory logging.LoggerFactory
+	Server   netip.AddrPort
+	Username string
+	Password string //nolint:gosec // runtime credential, not hardcoded.
+	RTO      time.Duration
+	Conn     net.PacketConn // Caller-owned socket; the caller runs the read pump.
 
 	// PermissionTimeout sets the refresh interval of permissions. Defaults to 2 minutes.
 	PermissionRefreshInterval time.Duration
@@ -61,18 +60,16 @@ type Client struct {
 	server     netip.AddrPort // Read-only; canonical, the inbound admission comparand
 	serverAddr net.Addr       // Read-only; server as the transaction destination on conn
 
-	username      stun.Username          // Read-only
-	password      string                 // Read-only
-	realm         stun.Realm             // Read-only
-	integrity     stun.MessageIntegrity  // Read-only
-	trMap         *client.TransactionMap // Thread-safe
-	rto           time.Duration          // Read-only
-	relayedConn   *client.UDPConn        // Protected by mutex ***
-	allocTryLock  client.TryLock         // Thread-safe
-	listenTryLock client.TryLock         // Thread-safe
-	mutex         sync.RWMutex           // Thread-safe
-	mutexTrMap    sync.Mutex             // Thread-safe
-	log           logging.LeveledLogger  // Read-only
+	username     stun.Username          // Read-only
+	password     string                 // Read-only
+	realm        stun.Realm             // Read-only
+	integrity    stun.MessageIntegrity  // Read-only
+	trMap        *client.TransactionMap // Thread-safe
+	rto          time.Duration          // Read-only
+	relayedConn  *client.UDPConn        // Protected by mutex ***
+	allocTryLock client.TryLock         // Thread-safe
+	mutex        sync.RWMutex           // Thread-safe
+	mutexTrMap   sync.Mutex             // Thread-safe
 
 	// REQUESTED-ADDRESS-FAMILY attribute for allocations (RFC 6156)
 	requestedAddressFamily proto.RequestedAddressFamily
@@ -106,18 +103,10 @@ func inferAddressFamilyFromConn(
 // for TURN allocations. It follows this priority:
 //  1. Try to infer from the PacketConn's local address
 //  2. Fall back to IPv4 default per RFC 6156
-func getRequestedAddressFamily(
-	log logging.LeveledLogger,
-	conn net.PacketConn,
-) proto.RequestedAddressFamily {
-	// Try to infer from the PacketConn
+func getRequestedAddressFamily(conn net.PacketConn) proto.RequestedAddressFamily {
 	if inferred, err := inferAddressFamilyFromConn(conn); err == nil {
-		log.Debugf("Inferred address family %v from connection", inferred)
-
 		return inferred
 	}
-
-	log.Debugf("Could not infer address family, defaulting to IPv4")
 
 	// Default to IPv4 per RFC 6156
 	return proto.RequestedFamilyIPv4
@@ -145,13 +134,6 @@ func appendRequestedAddressFamily(
 // config.Server. Server is validated once here and becomes the single
 // comparand for inbound admission and the destination of every transaction.
 func NewClient(config *ClientConfig) (*Client, error) {
-	loggerFactory := config.LoggerFactory
-	if loggerFactory == nil {
-		loggerFactory = logging.NewDefaultLoggerFactory()
-	}
-
-	log := loggerFactory.NewLogger("turnc")
-
 	if config.Conn == nil {
 		return nil, errNilConn
 	}
@@ -166,9 +148,6 @@ func NewClient(config *ClientConfig) (*Client, error) {
 		rto = config.RTO
 	}
 
-	// Determine the requested address family (RFC 6156)
-	requestedAddressFamily := getRequestedAddressFamily(log, config.Conn)
-
 	client := &Client{
 		conn:                      config.Conn,
 		server:                    server,
@@ -177,8 +156,7 @@ func NewClient(config *ClientConfig) (*Client, error) {
 		password:                  config.Password,
 		trMap:                     client.NewTransactionMap(),
 		rto:                       rto,
-		log:                       log,
-		requestedAddressFamily:    requestedAddressFamily,
+		requestedAddressFamily:    getRequestedAddressFamily(config.Conn),
 		permissionRefreshInterval: config.PermissionRefreshInterval,
 		bindingRefreshInterval:    config.bindingRefreshInterval,
 		bindingCheckInterval:      config.bindingCheckInterval,
@@ -192,39 +170,9 @@ func (c *Client) writeTo(data []byte, to net.Addr) (int, error) {
 	return c.conn.WriteTo(data, to)
 }
 
-// Listen will have this client start listening on the conn provided via the config.
-// This is optional. If not used, you will need to call HandleInbound method
-// to supply incoming data, instead.
-func (c *Client) Listen() error {
-	if err := c.listenTryLock.Lock(); err != nil {
-		return fmt.Errorf("%w: %s", errAlreadyListening, err.Error())
-	}
-
-	go func() {
-		buf := make([]byte, maxDataBufferSize)
-		for {
-			n, from, err := c.conn.ReadFrom(buf)
-			if err != nil {
-				c.log.Debugf("Failed to read: %s. Exiting loop", err)
-
-				break
-			}
-
-			err = c.HandleInbound(buf[:n], from)
-			if err != nil {
-				c.log.Debugf("Failed to handle inbound message: %s. Exiting loop", err)
-
-				break
-			}
-		}
-
-		c.listenTryLock.Unlock()
-	}()
-
-	return nil
-}
-
-// Close closes this client.
+// Close closes this client: every pending transaction is closed and its
+// waiter woken with an error wrapping net.ErrClosed. Close is idempotent and
+// never touches the caller-owned socket.
 func (c *Client) Close() {
 	c.mutexTrMap.Lock()
 	defer c.mutexTrMap.Unlock()
@@ -241,7 +189,7 @@ func (c *Client) abortPendingTransactionsTo(to net.Addr) {
 	c.trMap.CloseAndDeleteAllTo(to)
 }
 
-func (c *Client) sendAllocateRequest(protocol proto.Protocol) ( //nolint:cyclop
+func (c *Client) sendAllocateRequest(ctx context.Context, protocol proto.Protocol) ( //nolint:cyclop
 	relayed proto.RelayedAddress,
 	lifetime proto.Lifetime,
 	nonce stun.Nonce,
@@ -263,7 +211,7 @@ func (c *Client) sendAllocateRequest(protocol proto.Protocol) ( //nolint:cyclop
 		return relayed, lifetime, nonce, err
 	}
 
-	trRes, err := c.performTransaction(msg, c.serverAddr, false)
+	trRes, err := c.performAllocateTransaction(ctx, msg)
 	if err != nil {
 		return relayed, lifetime, nonce, err
 	}
@@ -302,7 +250,7 @@ func (c *Client) sendAllocateRequest(protocol proto.Protocol) ( //nolint:cyclop
 		return relayed, lifetime, nonce, err
 	}
 
-	trRes, err = c.performTransaction(msg, c.serverAddr, false)
+	trRes, err = c.performAllocateTransaction(ctx, msg)
 	if err != nil {
 		return relayed, lifetime, nonce, err
 	}
@@ -340,9 +288,23 @@ func (c *Client) sendAllocateRequest(protocol proto.Protocol) ( //nolint:cyclop
 // canonicalized once here and becomes authoritative for RelayedAddr; if it
 // cannot be canonicalized, the allocation is released with a lifetime-0
 // Refresh and Allocate returns ErrInvalidRelayedAddress.
-func (c *Client) Allocate() (*Allocation, error) {
+//
+// Canceling ctx wakes only this caller: Allocate returns context.Cause(ctx)
+// promptly without touching the caller-owned socket. A cancellation that
+// lands after the request left the socket may orphan a server-side
+// allocation until its lifetime expires, and a retried Allocate on the same
+// Conn may then receive 437 Allocation Mismatch; use a fresh socket per
+// Allocate attempt. If the client is closed while Allocate waits, the closed
+// error (wrapping net.ErrClosed) takes precedence over cancellation.
+func (c *Client) Allocate(ctx context.Context) (*Allocation, error) {
+	if ctx == nil {
+		return nil, errNilContext
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, context.Cause(ctx)
+	}
 	if err := c.allocTryLock.Lock(); err != nil {
-		return nil, fmt.Errorf("%w: %s", errOneAllocateOnly, err.Error())
+		return nil, fmt.Errorf("%w: %w", errOneAllocateOnly, err)
 	}
 	defer c.allocTryLock.Unlock()
 
@@ -351,7 +313,7 @@ func (c *Client) Allocate() (*Allocation, error) {
 		return nil, fmt.Errorf("%w: %s", ErrAlreadyAllocated, relayedConn.LocalAddr().String())
 	}
 
-	relayed, lifetime, nonce, err := c.sendAllocateRequest(proto.ProtoUDP)
+	relayed, lifetime, nonce, err := c.sendAllocateRequest(ctx, proto.ProtoUDP)
 	if err != nil {
 		return nil, err
 	}
@@ -372,7 +334,6 @@ func (c *Client) Allocate() (*Allocation, error) {
 		Integrity:                 c.integrity,
 		Nonce:                     nonce,
 		Lifetime:                  lifetime.Duration,
-		Log:                       c.log,
 		PermissionRefreshInterval: c.permissionRefreshInterval,
 		BindingRefreshInterval:    c.bindingRefreshInterval,
 		BindingCheckInterval:      c.bindingCheckInterval,
@@ -394,9 +355,10 @@ func (c *Client) Allocate() (*Allocation, error) {
 	return newAllocation(relayedConn, canonicalRelayed), nil
 }
 
-// performTransaction performs STUN transaction.
-func (c *Client) performTransaction(msg *stun.Message, to net.Addr, ignoreResult bool) (client.TransactionResult,
-	error,
+// startTransaction registers a new transaction, sends its request once on
+// the caller-owned socket, and arms the retransmission timer.
+func (c *Client) startTransaction(msg *stun.Message, to net.Addr, ignoreResult bool) (
+	string, *client.Transaction, error,
 ) {
 	trKey := b64.StdEncoding.EncodeToString(msg.TransactionID[:])
 
@@ -413,13 +375,24 @@ func (c *Client) performTransaction(msg *stun.Message, to net.Addr, ignoreResult
 
 	c.trMap.Insert(trKey, tr)
 
-	c.log.Tracef("Start %s transaction %s to %s", msg.Type, trKey, tr.To)
 	_, err := c.conn.WriteTo(tr.Raw, to)
 	if err != nil {
-		return client.TransactionResult{}, err
+		return "", nil, err
 	}
 
 	tr.StartRtxTimer(c.onRtxTimeout)
+
+	return trKey, tr, nil
+}
+
+// performTransaction performs STUN transaction.
+func (c *Client) performTransaction(msg *stun.Message, to net.Addr, ignoreResult bool) (client.TransactionResult,
+	error,
+) {
+	_, tr, err := c.startTransaction(msg, to, ignoreResult)
+	if err != nil {
+		return client.TransactionResult{}, err
+	}
 
 	// If ignoreResult is true, get the transaction going and return immediately
 	if ignoreResult {
@@ -427,6 +400,62 @@ func (c *Client) performTransaction(msg *stun.Message, to net.Addr, ignoreResult
 	}
 
 	res := tr.WaitForResult()
+	if res.Err != nil {
+		return res, res.Err
+	}
+
+	return res, nil
+}
+
+// performAllocateTransaction runs one Allocate transaction with a cancelable
+// wait. Map membership under mutexTrMap is the single linearization point:
+// whichever of the waiter, a producer, or a closer removes the transaction
+// from the map owns its result channel's fate.
+func (c *Client) performAllocateTransaction(ctx context.Context, msg *stun.Message) (
+	client.TransactionResult, error,
+) {
+	if err := ctx.Err(); err != nil {
+		return client.TransactionResult{}, context.Cause(ctx)
+	}
+
+	trKey, tr, err := c.startTransaction(msg, c.serverAddr, false)
+	if err != nil {
+		return client.TransactionResult{}, err
+	}
+
+	select {
+	case res, ok := <-tr.ResultCh():
+		return finishTransactionWait(res, ok)
+	case <-ctx.Done():
+	}
+
+	// Canceled: if the transaction is still in the map, this waiter owns it,
+	// removes it, and returns the cancellation cause. If it is absent, some
+	// producer or closer already owns it, so consume the channel: a published
+	// result means the response wins; a closed empty channel means the client
+	// closed, and closure takes precedence over cancellation.
+	c.mutexTrMap.Lock()
+	if _, owned := c.trMap.Find(trKey); owned {
+		tr.StopRtxTimer()
+		c.trMap.Delete(trKey)
+		tr.Close()
+		c.mutexTrMap.Unlock()
+
+		return client.TransactionResult{}, context.Cause(ctx)
+	}
+	c.mutexTrMap.Unlock()
+
+	res, ok := <-tr.ResultCh()
+
+	return finishTransactionWait(res, ok)
+}
+
+// finishTransactionWait translates a consumed result-channel outcome: a
+// closed empty channel means the client closed the transaction.
+func finishTransactionWait(res client.TransactionResult, ok bool) (client.TransactionResult, error) {
+	if !ok {
+		return res, fmt.Errorf("turn: client closed: %w", net.ErrClosed)
+	}
 	if res.Err != nil {
 		return res, res.Err
 	}
@@ -476,7 +505,7 @@ func (c *Client) handleSTUNMessage(data []byte, from net.Addr) error { //nolint:
 
 	msg := &stun.Message{Raw: raw}
 	if err := msg.Decode(); err != nil {
-		return fmt.Errorf("%w: %s", errFailedToDecodeSTUN, err.Error())
+		return fmt.Errorf("%w: %w", errFailedToDecodeSTUN, err)
 	}
 
 	if msg.Type.Class == stun.ClassRequest {
@@ -502,17 +531,13 @@ func (c *Client) handleSTUNMessage(data []byte, from net.Addr) error { //nolint:
 				return err
 			}
 
-			c.log.Tracef("Data indication received from %s", source)
-
 			relayedConn := c.relayedUDPConn()
 			if relayedConn == nil {
-				c.log.Debug("No relayed conn allocated")
-
 				return nil // Silently discard
 			}
 			relayedConn.HandleInbound(data, source)
 		default:
-			c.log.Debug("Received unsupported STUN method")
+			// Unsupported indication methods are silently discarded.
 		}
 
 		return nil
@@ -529,24 +554,21 @@ func (c *Client) handleSTUNMessage(data []byte, from net.Addr) error { //nolint:
 	tr, ok := c.trMap.Find(trKey)
 	if !ok {
 		c.mutexTrMap.Unlock()
-		// Silently discard
-		c.log.Debugf("No transaction for %s", msg)
 
-		return nil
+		return nil // Silently discard: the transaction's waiter has departed.
 	}
 
-	// End the transaction
+	// End the transaction: removal under the lock takes ownership, and the
+	// publish to the buffered result channel never blocks.
 	tr.StopRtxTimer()
 	c.trMap.Delete(trKey)
 	c.mutexTrMap.Unlock()
 
-	if !tr.WriteResult(client.TransactionResult{
+	tr.WriteResult(client.TransactionResult{
 		Msg:     msg,
 		From:    from,
 		Retries: tr.Retries(),
-	}) {
-		c.log.Debugf("No listener for %s", msg)
-	}
+	})
 
 	return nil
 }
@@ -562,8 +584,6 @@ func (c *Client) handleChannelData(data []byte) error {
 
 	relayedConn := c.relayedUDPConn()
 	if relayedConn == nil {
-		c.log.Debug("No relayed conn allocated")
-
 		return nil // Silently discard
 	}
 
@@ -572,48 +592,59 @@ func (c *Client) handleChannelData(data []byte) error {
 		return fmt.Errorf("%w: %d", errChannelBindNotFound, int(chData.Number))
 	}
 
-	c.log.Tracef("Channel data received from %s (ch=%d)", addr.String(), int(chData.Number))
-
 	relayedConn.HandleInbound(chData.Data, addr)
 
 	return nil
 }
 
+// onRtxTimeout runs on the transaction's timer goroutine. Exhaustion and
+// re-arm decisions happen under mutexTrMap, but the retransmit socket write
+// does not, so cancellation promptness never waits behind caller-socket I/O.
+// A write already in flight when the transaction changes owner completes
+// harmlessly: ownership is re-checked before publishing or re-arming.
 func (c *Client) onRtxTimeout(trKey string, nRtx int) {
 	c.mutexTrMap.Lock()
-	defer c.mutexTrMap.Unlock()
-
 	tr, ok := c.trMap.Find(trKey)
 	if !ok {
+		c.mutexTrMap.Unlock()
+
 		return // Already gone
 	}
 
 	if nRtx == maxRtxCount {
-		// All retransmissions failed
+		// All retransmissions failed: this producer takes ownership and
+		// publishes to the buffered result channel without blocking.
 		c.trMap.Delete(trKey)
-		if !tr.WriteResult(client.TransactionResult{
-			Err: fmt.Errorf("%w %s", errAllRetransmissionsFailed, trKey),
-		}) {
-			c.log.Debug("No listener for transaction")
-		}
+		c.mutexTrMap.Unlock()
+		tr.WriteResult(client.TransactionResult{
+			Err: fmt.Errorf("%w: transaction %s", ErrTransactionTimeout, trKey),
+		})
 
 		return
 	}
+	c.mutexTrMap.Unlock()
 
-	c.log.Tracef("Retransmitting transaction %s to %s (nRtx=%d)",
-		trKey, tr.To, nRtx)
 	_, err := c.conn.WriteTo(tr.Raw, tr.To)
+
+	c.mutexTrMap.Lock()
+	if _, owned := c.trMap.Find(trKey); !owned {
+		// A waiter, closer, or response producer took the transaction while
+		// the write was in flight: neither publish nor re-arm.
+		c.mutexTrMap.Unlock()
+
+		return
+	}
 	if err != nil {
 		c.trMap.Delete(trKey)
-		if !tr.WriteResult(client.TransactionResult{
-			Err: fmt.Errorf("%w %s", errFailedToRetransmitTransaction, trKey),
-		}) {
-			c.log.Debug("No listener for transaction")
-		}
+		c.mutexTrMap.Unlock()
+		tr.WriteResult(client.TransactionResult{
+			Err: fmt.Errorf("%w: transaction %s: %w", errFailedToRetransmitTransaction, trKey, err),
+		})
 
 		return
 	}
 	tr.StartRtxTimer(c.onRtxTimeout)
+	c.mutexTrMap.Unlock()
 }
 
 func (c *Client) setRelayedUDPConn(conn *client.UDPConn) {

--- a/client_test.go
+++ b/client_test.go
@@ -6,6 +6,7 @@
 package turn
 
 import (
+	"context"
 	b64 "encoding/base64"
 	"net"
 	"net/netip"
@@ -13,7 +14,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pion/logging"
 	"github.com/pion/stun/v3"
 	pionturn "github.com/pion/turn/v5"
 	"github.com/stretchr/testify/assert"
@@ -188,9 +188,9 @@ func TestClientNonceExpiration(t *testing.T) {
 		Password: "pass",
 	})
 	assert.NoError(t, err)
-	assert.NoError(t, client.Listen())
+	startTestPump(t, client, conn)
 
-	allocation, err := client.Allocate()
+	allocation, err := client.Allocate(context.Background())
 	assert.NoError(t, err)
 
 	_, err = allocation.WriteTo([]byte{0x00}, netip.MustParseAddrPort("127.0.0.1:8080"))
@@ -225,15 +225,13 @@ func TestInferAddressFamilyFromConn(t *testing.T) {
 }
 
 func TestGetRequestedAddressFamily(t *testing.T) {
-	log := logging.NewDefaultLoggerFactory().NewLogger("test")
-
 	t.Run("Infer IPv4 from connection", func(t *testing.T) {
 		conn, err := net.ListenPacket("udp4", "0.0.0.0:0") //nolint:noctx
 		assert.NoError(t, err)
 		defer conn.Close() //nolint:errcheck
 
 		// Should infer IPv4 from connection
-		family := getRequestedAddressFamily(log, conn)
+		family := getRequestedAddressFamily(conn)
 		assert.Equal(t, proto.RequestedFamilyIPv4, family)
 	})
 
@@ -243,7 +241,7 @@ func TestGetRequestedAddressFamily(t *testing.T) {
 		defer conn.Close() //nolint:errcheck
 
 		// Should infer IPv6 from connection
-		family := getRequestedAddressFamily(log, conn)
+		family := getRequestedAddressFamily(conn)
 		assert.Equal(t, proto.RequestedFamilyIPv6, family)
 	})
 }
@@ -335,9 +333,9 @@ func TestClientE2E(t *testing.T) {
 			bindingCheckInterval:      time.Millisecond * 50,
 		})
 		assert.NoError(t, err)
-		assert.NoError(t, client.Listen())
+		startTestPump(t, client, stunClientConn)
 
-		allocation, err := client.Allocate()
+		allocation, err := client.Allocate(context.Background())
 		assert.NoError(t, err)
 
 		remotePeerConn, err := net.ListenPacket("udp4", "0.0.0.0:0") // nolint: noctx

--- a/close_latency_test.go
+++ b/close_latency_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pion/logging"
 	"github.com/pion/stun/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -33,15 +32,14 @@ func newSilentServerAllocation(t *testing.T, withAbort bool) *client.UDPConn {
 	require.NoError(t, err)
 
 	cl, err := NewClient(&ClientConfig{
-		Conn:          clientSock,
-		Server:        netip.MustParseAddrPort(serverSock.LocalAddr().String()),
-		Username:      "user",
-		Password:      "secret",
-		RTO:           25 * time.Millisecond,
-		LoggerFactory: logging.NewDefaultLoggerFactory(),
+		Conn:     clientSock,
+		Server:   netip.MustParseAddrPort(serverSock.LocalAddr().String()),
+		Username: "user",
+		Password: "secret",
+		RTO:      25 * time.Millisecond,
 	})
 	require.NoError(t, err)
-	require.NoError(t, cl.Listen())
+	startTestPump(t, cl, clientSock)
 
 	config := &client.AllocationConfig{
 		WriteTo:            cl.writeTo,
@@ -54,7 +52,6 @@ func newSilentServerAllocation(t *testing.T, withAbort bool) *client.UDPConn {
 		Integrity:          stun.NewShortTermIntegrity("secret"),
 		Nonce:              stun.NewNonce("nonce"),
 		Lifetime:           time.Hour,
-		Log:                logging.NewDefaultLoggerFactory().NewLogger("test"),
 	}
 	if withAbort {
 		config.AbortTransactions = func() {

--- a/docs/adr/2026-08-14-turn-molding-program.md
+++ b/docs/adr/2026-08-14-turn-molding-program.md
@@ -1,6 +1,6 @@
 # TURN Fork Molding Program — 2026-08-14
 
-**Status:** Accepted; Track 1 complete (`v5.1.0-gs.1`); Track 2 in progress (Slices 1-2 complete, PRs #25 and #27; Slices 3 and 4 on the frontier); Track 3 gated, plan pending
+**Status:** Accepted; Track 1 complete (`v5.1.0-gs.1`); Track 2 in progress (Slices 1-3 complete, PRs #25, #27, and #29; Slice 4 on the frontier); Track 3 gated, plan pending
 
 ## What this is
 
@@ -21,7 +21,7 @@ The program that molds `the-sarge/turn` into wiremux's minimal owned TURN client
 | # | Track | Plan | Parent issue | Blocked by | Slices | Status |
 |---|---|---|---|---|---|---|
 | 1 | Cut and stabilize (M0) | [plan](2026-08-14-cut-and-stabilize-plan.md) | the-sarge/turn#3 | None | 2 | Complete: PR #8, PR #14; `v5.1.0-gs.1` published |
-| 2 | Modernize the kept API (M1) | [plan](2026-08-15-modernize-kept-api-plan.md) | the-sarge/turn#19 | Track 1 (complete); wiremux Slice 1.3 (complete, GridSwarm/wiremux#1162) | 5 | FRONTIER — Slices 1 (PR #25) and 2 (PR #27) complete; Slices 3 and 4 dispatchable (parallel-safe); 5 after 3 and 4 |
+| 2 | Modernize the kept API (M1) | [plan](2026-08-15-modernize-kept-api-plan.md) | the-sarge/turn#19 | Track 1 (complete); wiremux Slice 1.3 (complete, GridSwarm/wiremux#1162) | 5 | FRONTIER — Slices 1 (PR #25), 2 (PR #27), and 3 (PR #29) complete; Slice 4 dispatchable; 5 after 4 |
 | 3 | Optimize the packet path (M2) | plan pending | pending | Track 2; profiles from production wiremux traffic | TBD | GATED — requires a future `$architecture-handoff` run once its gate opens; no speculative optimization |
 
 Cross-track slice edges: the transitional upstream-fixture seam introduced by Track 1 Slice 2 is removed by Track 2 Slice 5. Track 2 order: 1→2→{3‖4}→5 (1→2 and 2→{3,4} are sequencing edges on the same functions; 3 and 4 are parallel-safe after 2; {3,4}→5 is genuine; each slice independently green). Track 2 Slice 5 tags `v5.2.0-gs.1` and files the wiremux adoption issue; wiremux-side adoption is consumer work outside this program. Recommended starter: Track 2 Slice 1.

--- a/docs/adr/2026-08-15-modernize-kept-api-plan.md
+++ b/docs/adr/2026-08-15-modernize-kept-api-plan.md
@@ -1,7 +1,7 @@
 # Modernize the Kept API (M1) Implementation Plan
 
 **Date:** 2026-08-15
-**Status:** Accepted; Slice 1 complete (PR #25); Slice 2 complete (PR #27); Slices 3-5 pending
+**Status:** Accepted; Slice 1 complete (PR #25); Slice 2 complete (PR #27); Slice 3 complete (PR #29); Slices 4-5 pending
 **Track:** 2 of 3 in the 2026-08-14 TURN fork molding program
 **Depends on:** Track 1 (complete: `v5.1.0-gs.1` at `1ee874e`) and wiremux Slice 1.3 (complete: GridSwarm/wiremux#1162 merged as `ccd61c4`) — both gates are open
 **Related:** [Program index](2026-08-14-turn-molding-program.md), [Molding program scope](2026-08-14-molding-program-scope.md) (D1–D5, program shape M1), [Owned-library ADR](2026-08-14-owned-library-fork.md), [Cut and stabilize plan](2026-08-14-cut-and-stabilize-plan.md) (transitional fixture seam), [Prepared-only writes ADR](2026-08-15-prepared-only-writes.md), [Fork-owned fixture ADR](2026-08-15-fork-owned-test-fixture.md), wiremux consumer contract `docs/adr/2026-08-09-turn-carrier-prerequisites-plan.md` (GridSwarm/wiremux, Slice 1.3 and the 2026-08-14 fork-pivot amendment)
@@ -58,11 +58,11 @@ Kept protocol behavior that M1 preserves byte-for-byte on the wire: Allocate cha
 |---|---|---|---|---|
 | 1 | complete (PR #25) | Client-side surface cut to the consumer's crossing; `Server netip.AddrPort`; server-source admission in `HandleInbound`; protocol internals unexported; `pion/transport` no longer a direct dependency | None | n/a |
 | 2 | complete (PR #27) | Exported `*Allocation` with `netip` data plane and `PreparePeer`; deadline surface deleted; server-reported relayed address validated | 1 | n/a |
-| 3 | new | `Allocate(ctx)` with non-blocking producers; `Listen` deleted; `pion/logging` removed with a per-site ledger; allocation-refresh failure terminalizes with a cause; `net.ErrClosed`, `%w`, exported sentinels | 2 | n/a |
+| 3 | complete (PR #29) | `Allocate(ctx)` with non-blocking producers; `Listen` deleted; `pion/logging` removed with a per-site ledger; allocation-refresh failure terminalizes with a cause; `net.ErrClosed`, `%w`, exported sentinels | 2 | n/a |
 | 4 | new | Prepared-only `WriteTo`; Send-indication path deleted; ChannelData-only invariant structural | 2 | n/a |
 | 5 | new | Exported `turntest` fixture; root tests re-pointed; upstream `pion/turn/v5` dropped; README refreshed; tag `v5.2.0-gs.1`; wiremux adoption issue filed | 3, 4 | Upstream `pion/turn/v5@v5.0.12` test-only fixture (Track 1 Slice 2 seam) |
 
-Edges 1→2 and 2→{3,4} are sequencing edges on the same functions, not correctness dependencies: Slice 2 introduces the `Allocation` type whose `WriteTo`/`Close`/`ReadFrom` Slices 3 and 4 then change in place, so writing them once against Slice 2's signatures avoids rewriting the same functions twice and line-conflicting PRs on `internal/client/udp_conn.go`. Slices 3 and 4 are parallel-safe after Slice 2 merges: their overlap is one `errClosed` line inside `WriteTo` (`udp_conn.go:471`) and root-test hunks, with rebase cost bounded to those. Edge {3,4}→5 is genuine: the fixture is written once against the final client behavior, and the tag requires every M1 slice merged. Each slice is independently green and mergeable at its own position. Frontier now: Slices 3 and 4 (parallel-safe). Frontier after Slices 3 and 4: Slice 5.
+Edges 1→2 and 2→{3,4} are sequencing edges on the same functions, not correctness dependencies: Slice 2 introduces the `Allocation` type whose `WriteTo`/`Close`/`ReadFrom` Slices 3 and 4 then change in place, so writing them once against Slice 2's signatures avoids rewriting the same functions twice and line-conflicting PRs on `internal/client/udp_conn.go`. Slices 3 and 4 are parallel-safe after Slice 2 merges: their overlap is one `errClosed` line inside `WriteTo` (`udp_conn.go:471`) and root-test hunks, with rebase cost bounded to those. Edge {3,4}→5 is genuine: the fixture is written once against the final client behavior, and the tag requires every M1 slice merged. Each slice is independently green and mergeable at its own position. Frontier now: Slice 4. Frontier after Slice 4: Slice 5.
 
 ## Implementation Slices
 

--- a/errors.go
+++ b/errors.go
@@ -3,7 +3,41 @@
 
 package turn
 
-import "errors"
+import (
+	"errors"
+	"net"
+
+	"github.com/the-sarge/turn/v5/internal/client"
+)
+
+// ErrClosed is net.ErrClosed: errors.Is(err, ErrClosed) on any error from
+// this package means the client or allocation is closed, or a wrapped cause
+// was itself a socket close — never a synthetic stand-in for another failure.
+var ErrClosed = net.ErrClosed
+
+// ErrTransactionTimeout reports a STUN transaction whose retransmissions
+// were all exhausted without a server response.
+var ErrTransactionTimeout = errors.New("turn: transaction timeout: all retransmissions failed")
+
+// ErrAllocationRefreshFailed reports a permanent allocation-refresh failure:
+// an exhausted refresh transaction, a well-formed non-438 error response, or
+// stale-nonce retry exhaustion. The allocation seals itself with this cause;
+// pending waiters wake, every subsequent operation returns ErrClosed wrapped
+// with it, and the caller's Close returns it.
+var ErrAllocationRefreshFailed = client.ErrAllocationRefreshFailed
+
+// ErrPermissionRefreshFailed reports a permission refresh that kept failing
+// after retries. Prepared peers terminalize with it: their writes fail
+// rather than ever falling back to Send indications.
+var ErrPermissionRefreshFailed = client.ErrPermissionRefreshFailed
+
+// ErrChannelBindFailed reports a channel binding that could not be
+// established or has failed for a prepared peer.
+var ErrChannelBindFailed = client.ErrChannelBindFailed
+
+// ErrChannelBindingExpired reports a confirmed channel binding whose
+// server-side lifetime expired before the write.
+var ErrChannelBindingExpired = client.ErrChannelBindingExpired
 
 // ErrAlreadyAllocated is returned by Allocate when the client already owns a
 // live allocation. Close that allocation before allocating again.
@@ -23,9 +57,8 @@ var (
 	errNilConn       = errors.New("turn: conn cannot not be nil")
 	errInvalidServer = errors.New(
 		"turn: Server must be a canonical netip.AddrPort (unicast, unmapped, zone-free, nonzero port)")
-	errAlreadyListening              = errors.New("turn: already listening")
+	errNilContext                    = errors.New("turn: context must not be nil")
 	errFailedToRetransmitTransaction = errors.New("turn: failed to retransmit transaction")
-	errAllRetransmissionsFailed      = errors.New("all retransmissions failed for")
 	errChannelBindNotFound           = errors.New("no binding found for channel")
 	errOneAllocateOnly               = errors.New("only one Allocate() caller is allowed")
 	errUnexpectedServerDatagram      = errors.New("turn: datagram from server is neither STUN nor ChannelData")

--- a/errors.go
+++ b/errors.go
@@ -17,7 +17,7 @@ var ErrClosed = net.ErrClosed
 
 // ErrTransactionTimeout reports a STUN transaction whose retransmissions
 // were all exhausted without a server response.
-var ErrTransactionTimeout = errors.New("turn: transaction timeout: all retransmissions failed")
+var ErrTransactionTimeout = client.ErrTransactionTimeout
 
 // ErrAllocationRefreshFailed reports a permanent allocation-refresh failure:
 // an exhausted refresh transaction, a well-formed non-438 error response, or

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/the-sarge/turn/v5
 go 1.24.0
 
 require (
-	github.com/pion/logging v0.2.4
 	github.com/pion/stun/v3 v3.1.6
 	github.com/pion/turn/v5 v5.0.12
 	github.com/stretchr/testify v1.11.1
@@ -12,6 +11,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pion/dtls/v3 v3.1.4 // indirect
+	github.com/pion/logging v0.2.4 // indirect
 	github.com/pion/randutil v0.1.0 // indirect
 	github.com/pion/transport/v4 v4.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/internal/client/allocation.go
+++ b/internal/client/allocation.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pion/logging"
 	"github.com/pion/stun/v3"
 	"github.com/the-sarge/turn/v5/internal/proto"
 )
@@ -31,7 +30,6 @@ type AllocationConfig struct {
 	Username                  stun.Username
 	Realm                     stun.Realm
 	Lifetime                  time.Duration
-	Log                       logging.LeveledLogger
 	PermissionRefreshInterval time.Duration
 	BindingRefreshInterval    time.Duration
 	BindingCheckInterval      time.Duration
@@ -56,25 +54,29 @@ type allocation struct {
 	refreshAllocTimer *PeriodicTimer        // Thread-safe
 	refreshPermsTimer *PeriodicTimer        // Thread-safe
 	mutex             sync.RWMutex          // Thread-safe
-	log               logging.LeveledLogger // Read-only
 
 	// onPermRefreshFailure, when set, observes a permission refresh that kept
 	// failing after retries. Read-only after construction.
 	onPermRefreshFailure func(error)
+
+	// onAllocRefreshFailure, when set, observes a permanent allocation-refresh
+	// failure: one exhausted refresh transaction, one well-formed non-438
+	// error response, or stale-nonce retry exhaustion. Read-only after
+	// construction.
+	onAllocRefreshFailure func(error)
 
 	// abortTransactions, when set, interrupts the allocation's pending
 	// transaction waits. Read-only after construction.
 	abortTransactions func()
 }
 
+// setNonceFromMsg updates the nonce from a 438 response carrying one. A 438
+// without a NONCE leaves the stale nonce standing, so the retry loop exhausts
+// and the failure reaches the caller's disposition as a value.
 func (a *allocation) setNonceFromMsg(msg *stun.Message) {
-	// Update nonce
 	var nonce stun.Nonce
 	if err := nonce.GetFrom(msg); err == nil {
 		a.setNonce(nonce)
-		a.log.Debug("Refresh allocation: 438, got new nonce.")
-	} else {
-		a.log.Warn("Refresh allocation: 438 but no nonce.")
 	}
 }
 
@@ -90,22 +92,17 @@ func (a *allocation) refreshAllocation(lifetime time.Duration, dontWait bool) er
 		stun.Fingerprint,
 	)
 	if err != nil {
-		return fmt.Errorf("%w: %s", errFailedToBuildRefreshRequest, err.Error())
+		return fmt.Errorf("%w: %w", errFailedToBuildRefreshRequest, err)
 	}
 
-	a.log.Debugf("Send refresh request (dontWait=%v)", dontWait)
 	trRes, err := a.performTransaction(msg, a.serverAddr, dontWait)
 	if err != nil {
-		return fmt.Errorf("%w: %s", errFailedToRefreshAllocation, err.Error())
+		return fmt.Errorf("%w: %w", errFailedToRefreshAllocation, err)
 	}
 
 	if dontWait {
-		a.log.Debug("Refresh request sent")
-
 		return nil
 	}
-
-	a.log.Debug("Refresh request sent, and waiting response")
 
 	res := trRes.Msg
 	if res.Type.Class == stun.ClassErrorResponse {
@@ -117,7 +114,12 @@ func (a *allocation) refreshAllocation(lifetime time.Duration, dontWait bool) er
 				return errTryAgain
 			}
 
-			return err
+			// A well-formed non-438 error response is a permanent refresh
+			// rejection: surface it as a typed value.
+			return &stun.TurnError{
+				StunMessageType: res.Type,
+				ErrorCodeAttr:   code,
+			}
 		}
 
 		return fmt.Errorf("%s", res.Type) //nolint:err113
@@ -126,11 +128,10 @@ func (a *allocation) refreshAllocation(lifetime time.Duration, dontWait bool) er
 	// Getting lifetime from response
 	var updatedLifetime proto.Lifetime
 	if err := updatedLifetime.GetFrom(res); err != nil {
-		return fmt.Errorf("%w: %s", errFailedToGetLifetime, err.Error())
+		return fmt.Errorf("%w: %w", errFailedToGetLifetime, err)
 	}
 
 	a.setLifetime(updatedLifetime.Duration)
-	a.log.Debugf("Updated lifetime: %d seconds", int(a.lifetime().Seconds()))
 
 	return nil
 }
@@ -138,54 +139,52 @@ func (a *allocation) refreshAllocation(lifetime time.Duration, dontWait bool) er
 func (a *allocation) refreshPermissions() error {
 	addrs := a.permMap.addrs()
 	if len(addrs) == 0 {
-		a.log.Debug("No permission to refresh")
-
 		return nil
 	}
 	if err := a.CreatePermissions(addrs...); err != nil {
-		if errors.Is(err, errTryAgain) {
-			return errTryAgain
-		}
-		a.log.Errorf("Fail to refresh permissions: %s", err)
-
 		return err
 	}
-	a.log.Debug("Refresh permissions successful")
 
 	return nil
 }
 
 func (a *allocation) onRefreshTimers(id int) {
-	a.log.Debugf("Refresh timer %d expired", id)
 	switch id {
 	case timerIDRefreshAlloc:
-		var err error
-		lifetime := a.lifetime()
-		// Limit the max retries on errTryAgain to 3
-		// when stale nonce returns, sencond retry should succeed
-		for range maxRetryAttempts {
-			err = a.refreshAllocation(lifetime, false)
-			if !errors.Is(err, errTryAgain) {
-				break
-			}
-		}
-		if err != nil {
-			a.log.Warnf("Failed to refresh allocation: %s", err)
-		}
+		a.refreshAllocationWithRetries()
 	case timerIDRefreshPerms:
-		var err error
-		for range maxRetryAttempts {
-			err = a.refreshPermissions()
-			if !errors.Is(err, errTryAgain) {
-				break
-			}
+		a.refreshPermissionsWithRetries()
+	}
+}
+
+func (a *allocation) refreshAllocationWithRetries() {
+	var err error
+	lifetime := a.lifetime()
+	// Limit the max retries on errTryAgain to 3
+	// when stale nonce returns, sencond retry should succeed
+	for range maxRetryAttempts {
+		err = a.refreshAllocation(lifetime, false)
+		if !errors.Is(err, errTryAgain) {
+			break
 		}
-		if err != nil {
-			a.log.Warnf("Failed to refresh permissions: %s", err)
-			if a.onPermRefreshFailure != nil {
-				a.onPermRefreshFailure(err)
-			}
+	}
+	if err != nil && a.onAllocRefreshFailure != nil {
+		// The periodic schedule at lifetime/2 offers no effective retry
+		// before server expiry: a standing failure is permanent.
+		a.onAllocRefreshFailure(err)
+	}
+}
+
+func (a *allocation) refreshPermissionsWithRetries() {
+	var err error
+	for range maxRetryAttempts {
+		err = a.refreshPermissions()
+		if !errors.Is(err, errTryAgain) {
+			break
 		}
+	}
+	if err != nil && a.onPermRefreshFailure != nil {
+		a.onPermRefreshFailure(err)
 	}
 }
 
@@ -200,7 +199,6 @@ func (a *allocation) setNonce(nonce stun.Nonce) {
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
 
-	a.log.Debugf("Set new nonce with %d bytes", len(nonce))
 	a._nonce = nonce
 }
 

--- a/internal/client/errors.go
+++ b/internal/client/errors.go
@@ -12,6 +12,9 @@ import (
 // Exported sentinels: the failure classes a consumer can act on. The root
 // package re-exports them.
 var (
+	// ErrTransactionTimeout reports a STUN transaction whose retransmissions
+	// were all exhausted without a server response.
+	ErrTransactionTimeout = errors.New("transaction timeout: all retransmissions failed")
 	// ErrAllocationRefreshFailed reports a permanent allocation-refresh
 	// failure. The allocation seals itself with this cause: pending waiters
 	// wake, and every subsequent operation returns net.ErrClosed wrapped with

--- a/internal/client/errors.go
+++ b/internal/client/errors.go
@@ -3,15 +3,37 @@
 
 package client
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+	"net"
+)
+
+// Exported sentinels: the failure classes a consumer can act on. The root
+// package re-exports them.
+var (
+	// ErrAllocationRefreshFailed reports a permanent allocation-refresh
+	// failure. The allocation seals itself with this cause: pending waiters
+	// wake, and every subsequent operation returns net.ErrClosed wrapped with
+	// it.
+	ErrAllocationRefreshFailed = errors.New("allocation refresh failed")
+	// ErrPermissionRefreshFailed reports a permission refresh that kept
+	// failing after retries; prepared bindings for the allocation terminalize
+	// with it.
+	ErrPermissionRefreshFailed = errors.New("permission refresh failed")
+	// ErrChannelBindFailed reports a channel binding that could not be
+	// established or has failed.
+	ErrChannelBindFailed = errors.New("channel bind failed")
+	// ErrChannelBindingExpired reports a confirmed channel binding whose
+	// server-side lifetime has expired.
+	ErrChannelBindingExpired = errors.New("confirmed channel binding expired")
+)
 
 var (
 	errFake                                = errors.New("fake error")
 	errTryAgain                            = errors.New("try again")
-	errClosed                              = errors.New("use of closed network connection")
-	errAlreadyClosed                       = errors.New("already closed")
 	errDoubleLock                          = errors.New("try-lock is already locked")
-	errTransactionClosed                   = errors.New("transaction closed")
+	errTransactionClosed                   = fmt.Errorf("transaction closed: %w", net.ErrClosed)
 	errWaitForResultOnNonResultTransaction = errors.New("WaitForResult called on non-result transaction")
 	errFailedToBuildRefreshRequest         = errors.New("failed to build refresh request")
 	errFailedToRefreshAllocation           = errors.New("failed to refresh allocation")
@@ -19,9 +41,6 @@ var (
 	errCannotBindChannel                   = errors.New("cannot bind channel")
 	errChannelBindBadRequest               = errors.New("channel bind bad request")
 	errChannelBindTransactionFailed        = errors.New("channel bind transaction failed")
-	errChannelBindFailed                   = errors.New("channel bind failed")
-	errChannelBindingExpired               = errors.New("confirmed channel binding expired")
-	errPermissionRefreshFailed             = errors.New("permission refresh failed")
 	errNilContext                          = errors.New("context must not be nil")
 )
 

--- a/internal/client/prepare_test.go
+++ b/internal/client/prepare_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pion/logging"
 	"github.com/pion/stun/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/the-sarge/turn/v5/internal/proto"
@@ -99,7 +98,6 @@ func newPrepareHarness(t *testing.T, gateBinds bool) *prepareHarness {
 		Integrity:          stun.NewShortTermIntegrity("pass"),
 		Nonce:              stun.NewNonce("nonce"),
 		Lifetime:           time.Hour,
-		Log:                logging.NewDefaultLoggerFactory().NewLogger("test"),
 	})
 	t.Cleanup(func() { _ = harness.conn.Close() })
 
@@ -290,11 +288,11 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 
 		writesBefore := harness.writeCount()
 		_, err := harness.conn.WriteTo([]byte("data"), harness.peer)
-		assert.ErrorIs(t, err, errPermissionRefreshFailed)
+		assert.ErrorIs(t, err, ErrPermissionRefreshFailed)
 		assert.Equal(t, writesBefore, harness.writeCount(),
 			"failed write for a prepared peer must not emit anything (no Send indication fallback)")
 
-		assert.ErrorIs(t, harness.conn.PreparePeer(context.Background(), harness.peer), errPermissionRefreshFailed,
+		assert.ErrorIs(t, harness.conn.PreparePeer(context.Background(), harness.peer), ErrPermissionRefreshFailed,
 			"readiness must be terminal after permission refresh failure")
 	})
 
@@ -335,7 +333,7 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 		// The waiter unblocks promptly; Close must keep waiting for the worker.
 		select {
 		case err := <-prepareResult:
-			assert.ErrorIs(t, err, errClosed)
+			assert.ErrorIs(t, err, net.ErrClosed)
 		case <-time.After(2 * time.Second):
 			assert.Fail(t, "PreparePeer waiter did not unblock on close")
 		}

--- a/internal/client/refresh_failure_test.go
+++ b/internal/client/refresh_failure_test.go
@@ -6,8 +6,10 @@ package client
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"net/netip"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -120,10 +122,10 @@ func TestRefreshFailureTerminalizes(t *testing.T) {
 		{
 			name: "exhausted refresh transaction",
 			waited: func() (TransactionResult, error) {
-				return TransactionResult{}, errFake
+				return TransactionResult{}, fmt.Errorf("%w: transaction test", ErrTransactionTimeout)
 			},
 			wantWaited: 1,
-			underlying: errFake,
+			underlying: ErrTransactionTimeout,
 		},
 		{
 			name: "well-formed non-438 error response",
@@ -203,6 +205,46 @@ func TestRefreshFailureTerminalizes(t *testing.T) {
 				"the caller's Close after a self-seal must not emit a second lifetime-0 refresh")
 		})
 	}
+}
+
+func TestConcurrentCallerCloses(t *testing.T) {
+	harness := newRefreshFailureHarness(t, func() (TransactionResult, error) {
+		return TransactionResult{}, errFake
+	}, nil)
+	conn := harness.conn
+
+	const closers = 4
+	results := make([]error, closers)
+	var start, done sync.WaitGroup
+	start.Add(1)
+	done.Add(closers)
+	for i := range closers {
+		go func() {
+			defer done.Done()
+			start.Wait()
+			results[i] = conn.Close()
+		}()
+	}
+	start.Done()
+	done.Wait()
+
+	var nilCount, closedCount int
+	for _, err := range results {
+		switch {
+		case err == nil:
+			nilCount++
+		case errors.Is(err, net.ErrClosed):
+			closedCount++
+		default:
+			assert.Failf(t, "unexpected concurrent Close result", "err: %v", err)
+		}
+	}
+	assert.Equal(t, 1, nilCount,
+		"exactly one concurrent caller Close observes the successful release")
+	assert.Equal(t, closers-1, closedCount,
+		"every duplicate caller Close returns net.ErrClosed")
+	assert.Equal(t, int32(1), harness.emitCount.Load(),
+		"concurrent caller Closes must yield exactly one lifetime-0 emission")
 }
 
 func TestRefreshFailureSealVsCloseRace(t *testing.T) {

--- a/internal/client/refresh_failure_test.go
+++ b/internal/client/refresh_failure_test.go
@@ -1,0 +1,257 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package client
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/netip"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pion/stun/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// refreshFailureHarness drives a NewUDPConn whose allocation refreshes fail
+// under a scripted mock, observing the terminal seal and the lifetime-0
+// deallocation emission.
+type refreshFailureHarness struct {
+	conn *UDPConn
+
+	// waitedRefresh scripts the outcome of a waited (dontWait=false) Refresh
+	// transaction. Read on every waited refresh.
+	waitedRefresh func() (TransactionResult, error)
+	// emitErr, when non-nil, fails the lifetime-0 (dontWait=true) emission.
+	emitErr error
+
+	waitedCount atomic.Int32
+	emitCount   atomic.Int32
+}
+
+func newRefreshFailureHarness(
+	t *testing.T, waited func() (TransactionResult, error), emitErr error,
+) *refreshFailureHarness {
+	t.Helper()
+
+	harness := &refreshFailureHarness{waitedRefresh: waited, emitErr: emitErr}
+	mock := &mockClient{
+		performTransaction: func(msg *stun.Message, _ net.Addr, dontWait bool) (TransactionResult, error) {
+			switch msg.Type.Method {
+			case stun.MethodRefresh:
+				if dontWait {
+					harness.emitCount.Add(1)
+					if harness.emitErr != nil {
+						return TransactionResult{}, harness.emitErr
+					}
+
+					return TransactionResult{}, nil
+				}
+				harness.waitedCount.Add(1)
+
+				return harness.waitedRefresh()
+			case stun.MethodCreatePermission:
+				return TransactionResult{Msg: stun.MustBuild(
+					stun.NewType(stun.MethodCreatePermission, stun.ClassSuccessResponse),
+				)}, nil
+			case stun.MethodChannelBind:
+				return TransactionResult{Msg: stun.MustBuild(
+					stun.NewType(stun.MethodChannelBind, stun.ClassSuccessResponse),
+				)}, nil
+			default:
+				return TransactionResult{}, errFake
+			}
+		},
+		writeTo: func(data []byte, _ net.Addr) (int, error) {
+			return len(data), nil
+		},
+	}
+
+	harness.conn = NewUDPConn(&AllocationConfig{
+		WriteTo:            mock.WriteTo,
+		PerformTransaction: mock.PerformTransaction,
+		OnDeallocated:      mock.OnDeallocated,
+		RelayedAddr:        &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 54321},
+		ServerAddr:         &net.UDPAddr{IP: net.ParseIP("10.0.0.1"), Port: 3478},
+		Username:           stun.NewUsername("user"),
+		Realm:              stun.NewRealm("realm"),
+		Integrity:          stun.NewShortTermIntegrity("pass"),
+		Nonce:              stun.NewNonce("nonce"),
+		Lifetime:           time.Hour, // The periodic timer never fires inside a test.
+	})
+
+	return harness
+}
+
+func turnErrorResponse(code stun.ErrorCode) *stun.Message {
+	return stun.MustBuild(
+		stun.NewType(stun.MethodRefresh, stun.ClassErrorResponse),
+		stun.ErrorCodeAttribute{Code: code, Reason: []byte("error")},
+	)
+}
+
+func staleNonceResponse() *stun.Message {
+	return stun.MustBuild(
+		stun.NewType(stun.MethodRefresh, stun.ClassErrorResponse),
+		stun.ErrorCodeAttribute{Code: stun.CodeStaleNonce, Reason: []byte("Stale Nonce")},
+		stun.NewNonce("fresh-nonce"),
+	)
+}
+
+func TestRefreshFailureTerminalizes(t *testing.T) {
+	peer := netip.MustParseAddrPort("127.0.0.1:1234")
+
+	tests := []struct {
+		name string
+		// waited scripts every waited refresh outcome.
+		waited func() (TransactionResult, error)
+		// wantWaited is the number of waited refresh transactions the retry
+		// loop is expected to run before the failure is permanent.
+		wantWaited int32
+		// underlying, when non-nil, must appear in the recorded terminal cause.
+		underlying error
+		// wantTurnError asserts the cause carries a typed *stun.TurnError.
+		wantTurnError bool
+	}{
+		{
+			name: "exhausted refresh transaction",
+			waited: func() (TransactionResult, error) {
+				return TransactionResult{}, errFake
+			},
+			wantWaited: 1,
+			underlying: errFake,
+		},
+		{
+			name: "well-formed non-438 error response",
+			waited: func() (TransactionResult, error) {
+				return TransactionResult{Msg: turnErrorResponse(stun.CodeServerError)}, nil
+			},
+			wantWaited:    1,
+			wantTurnError: true,
+		},
+		{
+			name: "stale-nonce retry exhaustion",
+			waited: func() (TransactionResult, error) {
+				return TransactionResult{Msg: staleNonceResponse()}, nil
+			},
+			wantWaited: maxRetryAttempts,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			harness := newRefreshFailureHarness(t, tt.waited, nil)
+			conn := harness.conn
+
+			// A blocked reader must wake when the allocation terminalizes.
+			readResult := make(chan error, 1)
+			go func() {
+				_, _, err := conn.ReadFrom(make([]byte, 64))
+				readResult <- err
+			}()
+			time.Sleep(50 * time.Millisecond) // Let the reader block.
+
+			// The refresh timer fires against a permanently failing server.
+			conn.onRefreshTimers(timerIDRefreshAlloc)
+
+			assert.Equal(t, tt.wantWaited, harness.waitedCount.Load(),
+				"unexpected number of waited refresh transactions")
+			assert.Equal(t, int32(1), harness.emitCount.Load(),
+				"a refresh-failure seal must emit exactly one lifetime-0 refresh")
+
+			select {
+			case err := <-readResult:
+				assert.ErrorIs(t, err, net.ErrClosed, "post-seal ReadFrom must wrap net.ErrClosed")
+				assert.ErrorIs(t, err, ErrAllocationRefreshFailed, "post-seal ReadFrom must carry the terminal cause")
+			case <-time.After(2 * time.Second):
+				assert.Fail(t, "blocked ReadFrom did not wake on the refresh-failure seal")
+			}
+
+			_, err := conn.WriteTo([]byte("data"), peer)
+			assert.ErrorIs(t, err, net.ErrClosed)
+			assert.ErrorIs(t, err, ErrAllocationRefreshFailed)
+
+			err = conn.PreparePeer(context.Background(), peer)
+			assert.ErrorIs(t, err, net.ErrClosed)
+			assert.ErrorIs(t, err, ErrAllocationRefreshFailed)
+
+			// The caller's Close joins and returns the recorded terminal cause,
+			// wrapping only the underlying failure — never a synthetic
+			// net.ErrClosed.
+			closeErr := conn.Close()
+			require.Error(t, closeErr)
+			assert.ErrorIs(t, closeErr, ErrAllocationRefreshFailed)
+			assert.NotErrorIs(t, closeErr, net.ErrClosed,
+				"the terminal cause must wrap the underlying failure, not a synthetic net.ErrClosed")
+			if tt.underlying != nil {
+				assert.ErrorIs(t, closeErr, tt.underlying)
+			}
+			if tt.wantTurnError {
+				var turnErr *stun.TurnError
+				assert.ErrorAs(t, closeErr, &turnErr,
+					"a well-formed error response must surface as a typed *stun.TurnError")
+			}
+
+			assert.ErrorIs(t, conn.Close(), net.ErrClosed,
+				"a repeated caller Close returns net.ErrClosed")
+
+			assert.Equal(t, int32(1), harness.emitCount.Load(),
+				"the caller's Close after a self-seal must not emit a second lifetime-0 refresh")
+		})
+	}
+}
+
+func TestRefreshFailureSealVsCloseRace(t *testing.T) {
+	harness := newRefreshFailureHarness(t, func() (TransactionResult, error) {
+		return TransactionResult{}, errFake
+	}, nil)
+	conn := harness.conn
+
+	sealDone := make(chan struct{})
+	closeResult := make(chan error, 1)
+	go func() {
+		conn.onRefreshTimers(timerIDRefreshAlloc)
+		close(sealDone)
+	}()
+	go func() { closeResult <- conn.Close() }()
+
+	select {
+	case <-sealDone:
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "refresh-failure seal did not complete")
+	}
+	var closeErr error
+	select {
+	case closeErr = <-closeResult:
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "Close did not return")
+	}
+
+	assert.Equal(t, int32(1), harness.emitCount.Load(),
+		"a refresh-failure seal racing a caller Close must yield exactly one lifetime-0 emission")
+	if closeErr != nil {
+		// The self-seal won: Close observed the one recorded terminal cause.
+		assert.ErrorIs(t, closeErr, ErrAllocationRefreshFailed)
+	}
+}
+
+func TestSelfSealEmissionFailureJoinsCause(t *testing.T) {
+	emitErr := errors.New("lifetime-0 write failed") //nolint:err113 // test-local cause
+	harness := newRefreshFailureHarness(t, func() (TransactionResult, error) {
+		return TransactionResult{}, errFake
+	}, emitErr)
+	conn := harness.conn
+
+	conn.onRefreshTimers(timerIDRefreshAlloc)
+
+	closeErr := conn.Close()
+	require.Error(t, closeErr)
+	assert.ErrorIs(t, closeErr, ErrAllocationRefreshFailed,
+		"the caller's Close must observe the refresh-failure cause")
+	assert.ErrorIs(t, closeErr, emitErr,
+		"a failed self-seal emission must be joined into the terminal cause")
+}

--- a/internal/client/transaction.go
+++ b/internal/client/transaction.go
@@ -48,7 +48,10 @@ type Transaction struct {
 func NewTransaction(config *TransactionConfig) *Transaction {
 	var resultCh chan TransactionResult
 	if !config.IgnoreResult {
-		resultCh = make(chan TransactionResult)
+		// Capacity 1 makes every producer non-blocking: the transaction map's
+		// delete-under-lock discipline guarantees at most one write per
+		// transaction, so a producer never blocks on a departed waiter.
+		resultCh = make(chan TransactionResult, 1)
 	}
 
 	return &Transaction{
@@ -88,7 +91,9 @@ func (t *Transaction) StopRtxTimer() {
 	}
 }
 
-// WriteResult writes the result to the result channel.
+// WriteResult publishes the result to the buffered result channel. Only the
+// producer that removed the transaction from its map may call it, so the
+// write never blocks and never races a close.
 func (t *Transaction) WriteResult(res TransactionResult) bool {
 	if t.resultCh == nil {
 		return false
@@ -97,6 +102,13 @@ func (t *Transaction) WriteResult(res TransactionResult) bool {
 	t.resultCh <- res
 
 	return true
+}
+
+// ResultCh exposes the result channel for select-based waits. A received
+// value is a published result; a closed empty channel means a closer removed
+// the transaction.
+func (t *Transaction) ResultCh() <-chan TransactionResult {
+	return t.resultCh
 }
 
 // WaitForResult waits for the transaction result.

--- a/internal/client/udp_conn.go
+++ b/internal/client/udp_conn.go
@@ -96,7 +96,7 @@ func NewUDPConn(config *AllocationConfig) *UDPConn {
 	// never Close, because this runs on the refresh timer goroutine, which
 	// must not join itself (the ChannelBind-400 path documents the same rule).
 	conn.onAllocRefreshFailure = func(err error) {
-		_, _ = conn.startClose(fmt.Errorf("%w: %w", ErrAllocationRefreshFailed, err))
+		conn.startClose(fmt.Errorf("%w: %w", ErrAllocationRefreshFailed, err))
 	}
 
 	conn.refreshAllocTimer = NewPeriodicTimer(
@@ -497,12 +497,15 @@ func (c *UDPConn) WriteTo(payload []byte, addr netip.AddrPort) (int, error) { //
 // allocation had already sealed itself (refresh failure or ChannelBind 400);
 // net.ErrClosed on a repeated caller Close.
 func (c *UDPConn) Close() error {
+	// The caller-duplicate decision and the seal-ownership decision happen in
+	// one closeMutex hold, so concurrent caller Closes cannot disagree about
+	// which of them performed the seal: exactly one caller observes the
+	// emission result and every duplicate returns net.ErrClosed.
 	c.closeMutex.Lock()
 	repeat := c.callerClosed
 	c.callerClosed = true
+	first, emitErr := c.startCloseLocked(nil)
 	c.closeMutex.Unlock()
-
-	first, emitErr := c.startClose(nil)
 
 	c.refreshAllocTimer.StopAndWait()
 	c.refreshPermsTimer.StopAndWait()
@@ -530,10 +533,15 @@ func (c *UDPConn) Close() error {
 // caller Close yields exactly one lifetime-0 emission and one recorded
 // terminal cause, and a seal attempt after the allocation is already sealed
 // (such as an in-flight refresh aborted by Close) records nothing.
-func (c *UDPConn) startClose(cause error) (bool, error) {
+func (c *UDPConn) startClose(cause error) {
 	c.closeMutex.Lock()
 	defer c.closeMutex.Unlock()
 
+	_, _ = c.startCloseLocked(cause)
+}
+
+// startCloseLocked is startClose's body; it requires closeMutex to be held.
+func (c *UDPConn) startCloseLocked(cause error) (bool, error) {
 	c.refreshAllocTimer.Stop()
 	c.refreshPermsTimer.Stop()
 	c.checkBindingsTimer.Stop()
@@ -793,7 +801,7 @@ func bindingStateWasReady(state bindingState) bool {
 // caller's Close still joins every worker and observes the recorded cause; a
 // failed lifetime-0 emission is joined into that cause by startClose.
 func (c *UDPConn) closeAfterChannelBindBadRequest(bindErr error) {
-	_, _ = c.startClose(fmt.Errorf("%w: %w", ErrChannelBindFailed, bindErr))
+	c.startClose(fmt.Errorf("%w: %w", ErrChannelBindFailed, bindErr))
 }
 
 func (c *UDPConn) bind(bound *binding) error {

--- a/internal/client/udp_conn.go
+++ b/internal/client/udp_conn.go
@@ -51,6 +51,15 @@ type UDPConn struct {
 	closeMutex             sync.Mutex        // Thread-safe; also gates workerWG.Add vs close
 	workerWG               sync.WaitGroup    // Joins bind/permission workers on Close
 	bindingRefreshInterval time.Duration     // Read-only
+
+	// terminalCause is the recorded cause of a self-seal (refresh failure or
+	// ChannelBind 400), set exactly once inside startClose's guarded arm.
+	// Protected by closeMutex; nil when the caller performed the seal.
+	terminalCause error
+	// callerClosed records that the caller's Close has run, so a repeated
+	// caller Close returns net.ErrClosed. Protected by closeMutex.
+	callerClosed bool
+
 	allocation
 }
 
@@ -75,7 +84,6 @@ func NewUDPConn(config *AllocationConfig) *UDPConn {
 			integrity:         config.Integrity,
 			_nonce:            config.Nonce,
 			_lifetime:         config.Lifetime,
-			log:               config.Log,
 			abortTransactions: config.AbortTransactions,
 		},
 	}
@@ -84,8 +92,12 @@ func NewUDPConn(config *AllocationConfig) *UDPConn {
 		conn.bindingRefreshInterval = config.BindingRefreshInterval
 	}
 	conn.onPermRefreshFailure = conn.failPreparedBindings
-
-	conn.log.Debugf("Initial lifetime: %d seconds", int(conn.lifetime().Seconds()))
+	// A permanent refresh failure terminalizes the allocation: startClose,
+	// never Close, because this runs on the refresh timer goroutine, which
+	// must not join itself (the ChannelBind-400 path documents the same rule).
+	conn.onAllocRefreshFailure = func(err error) {
+		_, _ = conn.startClose(fmt.Errorf("%w: %w", ErrAllocationRefreshFailed, err))
+	}
 
 	conn.refreshAllocTimer = NewPeriodicTimer(
 		timerIDRefreshAlloc,
@@ -119,15 +131,9 @@ func NewUDPConn(config *AllocationConfig) *UDPConn {
 		bindingCheckInterval,
 	)
 
-	if conn.refreshAllocTimer.Start() {
-		conn.log.Debugf("Started refresh allocation timer")
-	}
-	if conn.refreshPermsTimer.Start() {
-		conn.log.Debugf("Started refresh permission timer")
-	}
-	if conn.checkBindingsTimer.Start() {
-		conn.log.Debugf("Started check bindings timer")
-	}
+	conn.refreshAllocTimer.Start()
+	conn.refreshPermsTimer.Start()
+	conn.checkBindingsTimer.Start()
 
 	return conn
 }
@@ -146,12 +152,7 @@ func (c *UDPConn) ReadFrom(p []byte) (int, netip.AddrPort, error) {
 		return n, ibData.from, nil
 
 	case <-c.closeCh:
-		return 0, netip.AddrPort{}, &net.OpError{
-			Op:   "read",
-			Net:  c.LocalAddr().Network(),
-			Addr: c.LocalAddr(),
-			Err:  errClosed,
-		}
+		return 0, netip.AddrPort{}, c.closedErr()
 	}
 }
 
@@ -186,7 +187,7 @@ func (c *UDPConn) PreparePeer(ctx context.Context, peer netip.AddrPort) error {
 		return context.Cause(ctx)
 	}
 	if c.isClosed() {
-		return errClosed
+		return c.closedErr()
 	}
 
 	if err := c.awaitPermission(ctx, peer); err != nil {
@@ -207,7 +208,7 @@ func (c *UDPConn) awaitPermission(ctx context.Context, peer netip.AddrPort) erro
 
 		done := c.ensurePermissionAttempt(perm, peer)
 		if done == nil {
-			return errClosed
+			return c.closedErr()
 		}
 
 		select {
@@ -215,7 +216,7 @@ func (c *UDPConn) awaitPermission(ctx context.Context, peer netip.AddrPort) erro
 		case <-ctx.Done():
 			return context.Cause(ctx)
 		case <-c.closeCh:
-			return errClosed
+			return c.closedErr()
 		}
 
 		if perm.state() == permStatePermitted {
@@ -252,7 +253,7 @@ func (c *UDPConn) ensurePermissionAttempt(perm *permission, peer netip.AddrPort)
 		var err error
 		for range maxRetryAttempts {
 			if c.isClosed() {
-				err = errClosed
+				err = net.ErrClosed
 
 				break
 			}
@@ -291,10 +292,10 @@ func (c *UDPConn) awaitBinding(ctx context.Context, bound *binding) error { //no
 				return err
 			}
 			if c.isClosed() {
-				return errClosed
+				return c.closedErr()
 			}
 
-			return errChannelBindFailed
+			return ErrChannelBindFailed
 		}
 
 		select {
@@ -302,7 +303,7 @@ func (c *UDPConn) awaitBinding(ctx context.Context, bound *binding) error { //no
 		case <-ctx.Done():
 			return context.Cause(ctx)
 		case <-c.closeCh:
-			return errClosed
+			return c.closedErr()
 		}
 
 		if final, err := bindingResult(bound); final {
@@ -322,9 +323,9 @@ func (c *UDPConn) awaitBinding(ctx context.Context, bound *binding) error { //no
 func bindingResult(bound *binding) (bool, error) {
 	if bound.ok() {
 		if time.Since(bound.refreshedAt()) >= channelBindingLifetime {
-			bound.terminalize(errChannelBindingExpired)
+			bound.terminalize(ErrChannelBindingExpired)
 
-			return true, errChannelBindingExpired
+			return true, ErrChannelBindingExpired
 		}
 		bound.prepared.Store(true)
 
@@ -335,7 +336,7 @@ func bindingResult(bound *binding) (bool, error) {
 			return true, err
 		}
 
-		return true, errChannelBindFailed
+		return true, ErrChannelBindFailed
 	}
 
 	return false, nil
@@ -390,7 +391,7 @@ func (c *UDPConn) addWorker() bool {
 func (c *UDPConn) failPreparedBindings(err error) {
 	for _, bound := range c.bindingMgr.all() {
 		if bound.prepared.Load() {
-			bound.terminalize(fmt.Errorf("%w: %w", errPermissionRefreshFailed, err))
+			bound.terminalize(fmt.Errorf("%w: %w", ErrPermissionRefreshFailed, err))
 		}
 	}
 }
@@ -401,12 +402,7 @@ func (c *UDPConn) failPreparedBindings(err error) {
 func (c *UDPConn) WriteTo(payload []byte, addr netip.AddrPort) (int, error) { //nolint:gocognit,cyclop
 	var err error
 	if c.isClosed() {
-		return 0, &net.OpError{
-			Op:   "write",
-			Net:  c.LocalAddr().Network(),
-			Addr: c.LocalAddr(),
-			Err:  errClosed,
-		}
+		return 0, c.closedErr()
 	}
 
 	// Check if we have a permission for the destination IP addr
@@ -442,14 +438,14 @@ func (c *UDPConn) WriteTo(payload []byte, addr netip.AddrPort) (int, error) { //
 	// falling back to Send indications.
 	if bound.prepared.Load() {
 		if bound.ok() && time.Since(bound.refreshedAt()) >= channelBindingLifetime {
-			bound.terminalize(errChannelBindingExpired)
+			bound.terminalize(ErrChannelBindingExpired)
 		}
 		if !bound.ok() {
 			if bindErr := bound.bindErr(); bindErr != nil {
 				return 0, bindErr
 			}
 
-			return 0, errChannelBindFailed
+			return 0, ErrChannelBindFailed
 		}
 	}
 
@@ -495,24 +491,46 @@ func (c *UDPConn) WriteTo(payload []byte, addr netip.AddrPort) (int, error) { //
 // bind/permission workers) have finished. It never closes or sets deadlines on
 // the caller-owned base socket, so a worker blocked on that socket is joined
 // only once the caller unblocks its I/O.
+//
+// Close always joins, then returns: the lifetime-0 emission error (or nil)
+// when this caller performed the seal; the recorded terminal cause when the
+// allocation had already sealed itself (refresh failure or ChannelBind 400);
+// net.ErrClosed on a repeated caller Close.
 func (c *UDPConn) Close() error {
-	first, err := c.startClose()
+	c.closeMutex.Lock()
+	repeat := c.callerClosed
+	c.callerClosed = true
+	c.closeMutex.Unlock()
+
+	first, emitErr := c.startClose(nil)
 
 	c.refreshAllocTimer.StopAndWait()
 	c.refreshPermsTimer.StopAndWait()
 	c.checkBindingsTimer.StopAndWait()
 	c.workerWG.Wait()
 
-	if !first {
-		return errAlreadyClosed
+	if first {
+		return emitErr
+	}
+	if repeat {
+		return net.ErrClosed
 	}
 
-	return err
+	c.closeMutex.Lock()
+	defer c.closeMutex.Unlock()
+
+	return c.terminalCause
 }
 
 // startClose makes the allocation refuse new work and emits the deallocate
-// refresh. It performs no joins, so allocation-owned workers may call it safely.
-func (c *UDPConn) startClose() (bool, error) {
+// refresh. It performs no joins, so allocation-owned workers may call it
+// safely; a worker seal passes its cause, the caller's Close passes nil.
+//
+// The closeCh select is the double-emission guard: a self-seal racing a
+// caller Close yields exactly one lifetime-0 emission and one recorded
+// terminal cause, and a seal attempt after the allocation is already sealed
+// (such as an in-flight refresh aborted by Close) records nothing.
+func (c *UDPConn) startClose(cause error) (bool, error) {
 	c.closeMutex.Lock()
 	defer c.closeMutex.Unlock()
 
@@ -535,7 +553,31 @@ func (c *UDPConn) startClose() (bool, error) {
 
 	c.onDeallocated(c.relayedAddr)
 
-	return true, c.refreshAllocation(0, true /* dontWait=true */)
+	emitErr := c.refreshAllocation(0, true /* dontWait=true */)
+	if cause != nil {
+		// Self-seal: record the terminal cause; a failed lifetime-0 emission
+		// is joined into it so the caller's Close can still observe it.
+		c.terminalCause = cause
+		if emitErr != nil {
+			c.terminalCause = errors.Join(cause, emitErr)
+		}
+	}
+
+	return true, emitErr
+}
+
+// closedErr is the operation error for a sealed allocation: net.ErrClosed,
+// wrapped with the recorded terminal cause when the allocation sealed itself.
+func (c *UDPConn) closedErr() error {
+	c.closeMutex.Lock()
+	cause := c.terminalCause
+	c.closeMutex.Unlock()
+
+	if cause != nil {
+		return fmt.Errorf("%w: %w", net.ErrClosed, cause)
+	}
+
+	return net.ErrClosed
 }
 
 // LocalAddr returns the local network address.
@@ -624,7 +666,8 @@ func (c *UDPConn) HandleInbound(data []byte, from netip.AddrPort) {
 	select {
 	case c.readCh <- &inboundData{data: copied, from: from}:
 	default:
-		c.log.Warnf("Receive buffer full")
+		// The receive queue is full: the datagram is dropped, matching UDP
+		// semantics. Documented on Allocation.ReadFrom.
 	}
 }
 
@@ -673,7 +716,7 @@ func (c *UDPConn) bindChannel(bound *binding, startState bindingState) error {
 	var err error
 	for range maxRetryAttempts {
 		if c.isClosed() {
-			return errClosed
+			return net.ErrClosed
 		}
 		if err = c.bind(bound); !errors.Is(err, errTryAgain) {
 			break
@@ -704,7 +747,6 @@ func (c *UDPConn) handleBindChannelError(bound *binding, startState bindingState
 		return true
 	}
 
-	c.log.Warnf("Failed to bind channel %d: %s", bound.number, err)
 	if errors.Is(err, errChannelBindTransactionFailed) {
 		if bindingStateWasReady(startState) {
 			bound.setState(bindingStateReadyUnknown)
@@ -717,7 +759,7 @@ func (c *UDPConn) handleBindChannelError(bound *binding, startState bindingState
 
 	bound.setState(bindingStateFailed)
 	if errors.Is(err, errChannelBindBadRequest) {
-		c.closeAfterChannelBindBadRequest(bound)
+		c.closeAfterChannelBindBadRequest(err)
 	}
 
 	return false
@@ -736,11 +778,6 @@ func (c *UDPConn) recoverChannelBindBadRequest(bound *binding, startState bindin
 	// server may still have the old binding, and switching channels would be
 	// worse because it can trigger "same peer with different channel number" (like what we get from Coturn).
 	// This Keep the saved mapping usable and retry refresh later.
-	c.log.Warnf(
-		"ChannelBind returned 400 for saved binding %s on channel %d; keeping binding ready",
-		bound.addr,
-		bound.number,
-	)
 	bound.setState(bindingStateReady)
 
 	return true
@@ -750,18 +787,13 @@ func bindingStateWasReady(state bindingState) bool {
 	return state == bindingStateReady || state == bindingStateReadyUnknown
 }
 
-func (c *UDPConn) closeAfterChannelBindBadRequest(bound *binding) {
-	c.log.Warnf(
-		"ChannelBind rejected with 400 for %s on channel %d; closing TURN allocation",
-		bound.addr,
-		bound.number,
-	)
-
-	// startClose, not Close: this runs on a Pion-owned bind worker, which must
-	// not join itself. The caller's Close still joins every worker.
-	if _, err := c.startClose(); err != nil {
-		c.log.Warnf("Failed to close TURN allocation after ChannelBind 400: %s", err)
-	}
+// closeAfterChannelBindBadRequest terminalizes the whole allocation after a
+// ChannelBind 400 on a fresh binding: startClose, not Close, because this
+// runs on an allocation-owned bind worker, which must not join itself. The
+// caller's Close still joins every worker and observes the recorded cause; a
+// failed lifetime-0 emission is joined into that cause by startClose.
+func (c *UDPConn) closeAfterChannelBindBadRequest(bindErr error) {
+	_, _ = c.startClose(fmt.Errorf("%w: %w", ErrChannelBindFailed, bindErr))
 }
 
 func (c *UDPConn) bind(bound *binding) error {
@@ -791,8 +823,6 @@ func (c *UDPConn) bind(bound *binding) error {
 	if res.Type.Class == stun.ClassErrorResponse {
 		return c.handleChannelBindErrorResponse(res)
 	}
-
-	c.log.Debugf("Channel binding successful: %s %d", bound.addr, bound.number)
 
 	// Success.
 	return nil

--- a/internal/client/udp_conn_test.go
+++ b/internal/client/udp_conn_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pion/logging"
 	"github.com/pion/stun/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/the-sarge/turn/v5/internal/proto"
@@ -22,7 +21,6 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		return UDPConn{
 			allocation: allocation{
 				clientHooks: client.hooks(),
-				log:         logging.NewDefaultLoggerFactory().NewLogger("test"),
 			},
 			bindingMgr:             bm,
 			bindingRefreshInterval: defaultBindingRefreshInterval,
@@ -293,7 +291,6 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 			Integrity:          stun.NewShortTermIntegrity("pass"),
 			Nonce:              stun.NewNonce("nonce"),
 			Lifetime:           time.Hour,
-			Log:                logging.NewDefaultLoggerFactory().NewLogger("test"),
 		})
 		defer func() { _ = conn.Close() }()
 
@@ -331,7 +328,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		}
 
 		_, err := conn.WriteTo([]byte("still closed"), peerAddr)
-		assert.ErrorIs(t, err, errClosed)
+		assert.ErrorIs(t, err, net.ErrClosed)
 	})
 
 	t.Run("ChannelBind 400 after unknown binding closes allocation", func(t *testing.T) {
@@ -372,7 +369,6 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 			Integrity:          stun.NewShortTermIntegrity("pass"),
 			Nonce:              stun.NewNonce("nonce"),
 			Lifetime:           time.Hour,
-			Log:                logging.NewDefaultLoggerFactory().NewLogger("test"),
 		})
 		defer func() { _ = conn.Close() }()
 
@@ -431,7 +427,6 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 			Integrity:          stun.NewShortTermIntegrity("pass"),
 			Nonce:              stun.NewNonce("nonce"),
 			Lifetime:           time.Hour,
-			Log:                logging.NewDefaultLoggerFactory().NewLogger("test"),
 		})
 		defer func() { _ = conn.Close() }()
 
@@ -542,7 +537,6 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 				realm:       stun.NewRealm("realm"),
 				integrity:   stun.NewShortTermIntegrity("pass"),
 				_nonce:      stun.NewNonce("nonce"),
-				log:         logging.NewDefaultLoggerFactory().NewLogger("test"),
 			},
 			bindingMgr: newBindingManager(),
 		}
@@ -591,7 +585,6 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 				realm:       stun.NewRealm("realm"),
 				integrity:   stun.NewShortTermIntegrity("pass"),
 				_nonce:      stun.NewNonce("nonce"),
-				log:         logging.NewDefaultLoggerFactory().NewLogger("test"),
 			},
 			bindingMgr: bm,
 		}

--- a/pump_test.go
+++ b/pump_test.go
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+//go:build !js
+
+package turn
+
+import (
+	"net"
+	"testing"
+)
+
+// startTestPump runs the read pump the deleted Client.Listen used to provide:
+// it reads datagrams from conn and feeds them to cl.HandleInbound until a
+// read fails (normally because the test closed the socket). Production
+// consumers own their read pump by contract; the fork's own tests use this
+// helper.
+func startTestPump(t *testing.T, cl *Client, conn net.PacketConn) {
+	t.Helper()
+
+	go func() {
+		buf := make([]byte, maxDataBufferSize)
+		for {
+			n, from, err := conn.ReadFrom(buf)
+			if err != nil {
+				return
+			}
+			if err := cl.HandleInbound(buf[:n], from); err != nil {
+				return
+			}
+		}
+	}()
+}


### PR DESCRIPTION
One-PR implementation of **Slice 3 — Context-first allocation, one lifecycle idiom, and failures as values** from the M1 plan.

- **Plan:** `docs/adr/2026-08-15-modernize-kept-api-plan.md` — slice heading "Slice 3 — Context-first allocation, one lifecycle idiom, and failures as values"
- **Plan commit:** `4d779e51dbdc04d5a77bf53aac23b405d588cee7`
- **Parent:** #19
- Closes #22

## What this delivers

- `Allocate(ctx context.Context) (*Allocation, error)`: buffered (capacity-1) transaction result channel so a producer never blocks on a departed waiter; the waiter selects on `ctx.Done()`; map membership under `mutexTrMap` is the single linearization point; a published response wins over cancellation; a closed channel returns the closed error wrapping `net.ErrClosed` (closure precedence over cancellation); `onRtxTimeout` performs the retransmit socket write outside the lock with ownership re-checked before publishing or re-arming, so cancellation never waits behind caller-socket I/O. No socket interruption: zero deadline/close calls on the caller's conn, asserted by observer.
- `Listen()`, `listenTryLock`, `errAlreadyListening` deleted; the fork's tests use an unexported `startTestPump` helper (verification aid).
- `pion/logging` removed per the slice's per-site ledger; it remains `// indirect` via `pion/stun/v3`. Ledger reconciliation: 36 non-test log sites at branch base (`client.go` 13, `udp_conn.go` 10, `allocation.go` 13; Slices 1–2 had already removed 5 of the 41 recorded at `2d30274`), all dispositioned, none silently kept.
- Permanent allocation-refresh failure terminalizes the allocation: fixes `refreshAllocation`'s error-response branch (previously returned nil for every well-formed non-438 error), which now returns a typed `*stun.TurnError`; the seal runs through `startClose` (third caller, alongside caller close and ChannelBind-400) with cause `ErrAllocationRefreshFailed` recorded inside the guarded `closeCh` arm; a failed lifetime-0 emission is joined into the terminal cause; post-seal `ReadFrom`/`WriteTo`/`PreparePeer` return `net.ErrClosed` wrapped with the cause; `Allocation.Close` always joins then returns the emission error, the recorded terminal cause, or `net.ErrClosed` on repeat.
- `net.ErrClosed` replaces `errClosed`/`errAlreadyClosed`; error wraps converted to `%w`; exported sentinels: `ErrClosed`, `ErrTransactionTimeout`, `ErrAllocationRefreshFailed`, `ErrPermissionRefreshFailed`, `ErrChannelBindFailed`, `ErrChannelBindingExpired`.

## Evidence

New tests per the slice's evidence budget: `TestAllocateContext` (cancel-before-send, both waits, published-success-wins), `TestAllocateCancelDuringBlockedRetransmit`, `TestAllocateCancelProducerRace`, `TestAllocateCancelVsClientClose`, `TestAllocateLateSuccessDiscarded` (including the documented same-Conn 437 retry consequence), `TestRefreshFailureTerminalizes` (timeout / non-438 TurnError / stale-nonce exhaustion), `TestRefreshFailureSealVsCloseRace` (exactly one lifetime-0 emission), `TestSelfSealEmissionFailureJoinsCause`. Negative API pins extended for `Client.Listen` and `ClientConfig.LoggerFactory`.

Guard mutations (one per enforcement owner, applied and reverted): removing the `ctx.Done()` select arm fails the cancellation test; removing the refresh-failure `startClose` call fails the terminalization test.

Preservation: `TestPreparePeer`, `TestUDPConn`, `TestCloseInterruptsTransactionWaits`, root `TestClientNonceExpiration`/`TestClientE2E` unchanged in asserted behavior. `task check`, `task race`, `task docs-check` green; `go mod tidy` clean.