### PR TITLE
Slice 4: prepared-only writes; delete the Send-indication path

### DIFF
--- a/allocation.go
+++ b/allocation.go
@@ -56,7 +56,13 @@ func (a *Allocation) ReadFrom(p []byte) (int, netip.AddrPort, error) {
 	return a.conn.ReadFrom(p)
 }
 
-// WriteTo writes a packet with payload to peer via the relay.
+// WriteTo writes payload to peer via the relay as ChannelData over the
+// channel binding PreparePeer confirmed. Writes are prepared-only: a peer for
+// which PreparePeer has not succeeded on this allocation returns
+// ErrNotPrepared with zero network output; a prepared binding that has since
+// expired or failed returns its cause (for example ErrChannelBindingExpired
+// or ErrPermissionRefreshFailed) with zero network output. WriteTo never
+// creates a permission, starts a binding, or sends a Send indication.
 func (a *Allocation) WriteTo(payload []byte, peer netip.AddrPort) (int, error) {
 	canonical, ok := canonicalAddrPort(peer, canonicalUnmap)
 	if !ok {

--- a/client_test.go
+++ b/client_test.go
@@ -193,7 +193,9 @@ func TestClientNonceExpiration(t *testing.T) {
 	allocation, err := client.Allocate(context.Background())
 	assert.NoError(t, err)
 
-	_, err = allocation.WriteTo([]byte{0x00}, netip.MustParseAddrPort("127.0.0.1:8080"))
+	peer := netip.MustParseAddrPort("127.0.0.1:8080")
+	assert.NoError(t, allocation.PreparePeer(context.Background(), peer))
+	_, err = allocation.WriteTo([]byte{0x00}, peer)
 	assert.NoError(t, err)
 
 	// Shutdown
@@ -274,134 +276,113 @@ func TestAppendRequestedAddressFamily(t *testing.T) {
 	})
 }
 
-type channelBindFilterConn struct {
-	net.PacketConn
-
-	doFilter bool
-}
-
-func (c *channelBindFilterConn) ReadFrom(p []byte) (n int, addr net.Addr, err error) {
-	for {
-		n, addr, err = c.PacketConn.ReadFrom(p)
-
-		if c.doFilter {
-			stunMsg := &stun.Message{Raw: p[:n]}
-			if err := stunMsg.Decode(); err == nil && stunMsg.Type.Method == stun.MethodChannelBind {
-				continue
-			}
-		}
-
-		return
-	}
-}
-
+// TestClientE2E is the ChannelData-path preservation gate against the upstream
+// fixture: after PreparePeer, every outbound relayed datagram travels as
+// ChannelData over the confirmed binding, and inbound relayed datagrams are
+// delivered to ReadFrom.
 func TestClientE2E(t *testing.T) {
-	doTest := func(disableChannelBind bool) {
-		udpListener, err := net.ListenPacket("udp4", "127.0.0.1:0") // nolint: noctx
-		require.NoError(t, err)
+	udpListener, err := net.ListenPacket("udp4", "127.0.0.1:0") // nolint: noctx
+	require.NoError(t, err)
 
-		server, err := pionturn.NewServer(pionturn.ServerConfig{
-			AuthHandler: func(ra *pionturn.RequestAttributes) (userID string, key []byte, ok bool) {
-				return ra.Username, pionturn.GenerateAuthKey(ra.Username, ra.Realm, "pass"), true
-			},
-			PacketConnConfigs: []pionturn.PacketConnConfig{
-				{
-					PacketConn: &channelBindFilterConn{udpListener, disableChannelBind},
-					RelayAddressGenerator: &pionturn.RelayAddressGeneratorStatic{
-						RelayAddress: net.ParseIP("127.0.0.1"),
-						Address:      "0.0.0.0",
-					},
+	server, err := pionturn.NewServer(pionturn.ServerConfig{
+		AuthHandler: func(ra *pionturn.RequestAttributes) (userID string, key []byte, ok bool) {
+			return ra.Username, pionturn.GenerateAuthKey(ra.Username, ra.Realm, "pass"), true
+		},
+		PacketConnConfigs: []pionturn.PacketConnConfig{
+			{
+				PacketConn: udpListener,
+				RelayAddressGenerator: &pionturn.RelayAddressGeneratorStatic{
+					RelayAddress: net.ParseIP("127.0.0.1"),
+					Address:      "0.0.0.0",
 				},
 			},
-			Realm:              "pion.ly",
-			AllocationLifetime: time.Second,
-			PermissionTimeout:  time.Millisecond * 100,
-			ChannelBindTimeout: time.Millisecond * 100,
-		})
-		assert.NoError(t, err)
+		},
+		Realm:              "pion.ly",
+		AllocationLifetime: time.Second,
+		PermissionTimeout:  time.Millisecond * 100,
+		ChannelBindTimeout: time.Millisecond * 100,
+	})
+	assert.NoError(t, err)
 
-		stunClientConn, err := net.ListenPacket("udp4", "0.0.0.0:0") // nolint: noctx
-		assert.NoError(t, err)
+	stunClientConn, err := net.ListenPacket("udp4", "0.0.0.0:0") // nolint: noctx
+	assert.NoError(t, err)
 
-		client, err := NewClient(&ClientConfig{
-			Conn:                      stunClientConn,
-			Server:                    netip.MustParseAddrPort(udpListener.LocalAddr().String()),
-			Username:                  "foo",
-			Password:                  "pass",
-			PermissionRefreshInterval: time.Millisecond * 50,
-			bindingRefreshInterval:    time.Millisecond * 50,
-			bindingCheckInterval:      time.Millisecond * 50,
-		})
-		assert.NoError(t, err)
-		startTestPump(t, client, stunClientConn)
+	client, err := NewClient(&ClientConfig{
+		Conn:                      stunClientConn,
+		Server:                    netip.MustParseAddrPort(udpListener.LocalAddr().String()),
+		Username:                  "foo",
+		Password:                  "pass",
+		PermissionRefreshInterval: time.Millisecond * 50,
+		bindingRefreshInterval:    time.Millisecond * 50,
+		bindingCheckInterval:      time.Millisecond * 50,
+	})
+	assert.NoError(t, err)
+	startTestPump(t, client, stunClientConn)
 
-		allocation, err := client.Allocate(context.Background())
-		assert.NoError(t, err)
+	allocation, err := client.Allocate(context.Background())
+	assert.NoError(t, err)
 
-		remotePeerConn, err := net.ListenPacket("udp4", "0.0.0.0:0") // nolint: noctx
-		assert.NoError(t, err)
+	remotePeerConn, err := net.ListenPacket("udp4", "0.0.0.0:0") // nolint: noctx
+	assert.NoError(t, err)
 
-		remotePeerAddr, ok := remotePeerConn.LocalAddr().(*net.UDPAddr)
-		assert.True(t, ok)
+	remotePeerAddr, ok := remotePeerConn.LocalAddr().(*net.UDPAddr)
+	assert.True(t, ok)
 
-		relayedAddr := allocation.RelayedAddr()
+	relayedAddr := allocation.RelayedAddr()
 
-		sendPackets := func(write func([]byte) error, read func([]byte) (int, error)) {
-			const expectedPktCount = 25
-			expectedPacket := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+	sendPackets := func(write func([]byte) error, read func([]byte) (int, error)) {
+		const expectedPktCount = 25
+		expectedPacket := []byte{0xDE, 0xAD, 0xBE, 0xEF}
 
-			pktCount := atomic.Uint32{}
-			go func() {
-				buff := make([]byte, len(expectedPacket))
-				for pktCount.Load() < expectedPktCount {
-					i, readErr := read(buff)
-					assert.NoError(t, readErr)
-
-					assert.Equal(t, expectedPacket, buff[:i])
-					pktCount.Add(1)
-				}
-			}()
+		pktCount := atomic.Uint32{}
+		go func() {
+			buff := make([]byte, len(expectedPacket))
 			for pktCount.Load() < expectedPktCount {
-				assert.NoError(t, write(expectedPacket))
+				i, readErr := read(buff)
+				assert.NoError(t, readErr)
 
-				time.Sleep(time.Millisecond * 25)
+				assert.Equal(t, expectedPacket, buff[:i])
+				pktCount.Add(1)
 			}
+		}()
+		for pktCount.Load() < expectedPktCount {
+			assert.NoError(t, write(expectedPacket))
+
+			time.Sleep(time.Millisecond * 25)
 		}
-
-		peer := netip.AddrPortFrom(netip.MustParseAddr("127.0.0.1"), uint16(remotePeerAddr.Port)) //nolint:gosec // test port
-		sendPackets(
-			func(p []byte) error {
-				_, writeErr := allocation.WriteTo(p, peer)
-
-				return writeErr
-			},
-			func(p []byte) (int, error) {
-				n, _, readErr := remotePeerConn.ReadFrom(p)
-
-				return n, readErr
-			},
-		)
-		relayedUDP := net.UDPAddrFromAddrPort(relayedAddr)
-		sendPackets(
-			func(p []byte) error {
-				_, writeErr := remotePeerConn.WriteTo(p, relayedUDP)
-
-				return writeErr
-			},
-			func(p []byte) (int, error) {
-				n, _, readErr := allocation.ReadFrom(p)
-
-				return n, readErr
-			},
-		)
-
-		// Shutdown
-		assert.NoError(t, remotePeerConn.Close())
-		assert.NoError(t, allocation.Close())
-		assert.NoError(t, stunClientConn.Close())
-		assert.NoError(t, server.Close())
 	}
 
-	doTest(true)
-	doTest(false)
+	peer := netip.AddrPortFrom(netip.MustParseAddr("127.0.0.1"), uint16(remotePeerAddr.Port)) //nolint:gosec // test port
+	require.NoError(t, allocation.PreparePeer(context.Background(), peer))
+	sendPackets(
+		func(p []byte) error {
+			_, writeErr := allocation.WriteTo(p, peer)
+
+			return writeErr
+		},
+		func(p []byte) (int, error) {
+			n, _, readErr := remotePeerConn.ReadFrom(p)
+
+			return n, readErr
+		},
+	)
+	relayedUDP := net.UDPAddrFromAddrPort(relayedAddr)
+	sendPackets(
+		func(p []byte) error {
+			_, writeErr := remotePeerConn.WriteTo(p, relayedUDP)
+
+			return writeErr
+		},
+		func(p []byte) (int, error) {
+			n, _, readErr := allocation.ReadFrom(p)
+
+			return n, readErr
+		},
+	)
+
+	// Shutdown
+	assert.NoError(t, remotePeerConn.Close())
+	assert.NoError(t, allocation.Close())
+	assert.NoError(t, stunClientConn.Close())
+	assert.NoError(t, server.Close())
 }

--- a/client_test.go
+++ b/client_test.go
@@ -155,8 +155,9 @@ func TestHandleInboundAdmitsOnlyServer(t *testing.T) {
 }
 
 // Create an allocation, and then delete all nonces
-// The subsequent Write on the allocation will cause a CreatePermission
-// which will be forced to handle a stale nonce response.
+// The subsequent PreparePeer on the allocation will cause a CreatePermission
+// and ChannelBind which will be forced to handle a stale nonce response; the
+// write that follows travels as ChannelData over the confirmed binding.
 func TestClientNonceExpiration(t *testing.T) {
 	udpListener, err := net.ListenPacket("udp4", "127.0.0.1:0") // nolint: noctx
 	require.NoError(t, err)

--- a/docs/adr/2026-08-14-turn-molding-program.md
+++ b/docs/adr/2026-08-14-turn-molding-program.md
@@ -1,6 +1,6 @@
 # TURN Fork Molding Program — 2026-08-14
 
-**Status:** Accepted; Track 1 complete (`v5.1.0-gs.1`); Track 2 in progress (Slices 1-3 complete, PRs #25, #27, and #29; Slice 4 on the frontier); Track 3 gated, plan pending
+**Status:** Accepted; Track 1 complete (`v5.1.0-gs.1`); Track 2 in progress (Slices 1-4 complete, PRs #25, #27, #29, and #32; Slice 5 on the frontier); Track 3 gated, plan pending
 
 ## What this is
 
@@ -21,7 +21,7 @@ The program that molds `the-sarge/turn` into wiremux's minimal owned TURN client
 | # | Track | Plan | Parent issue | Blocked by | Slices | Status |
 |---|---|---|---|---|---|---|
 | 1 | Cut and stabilize (M0) | [plan](2026-08-14-cut-and-stabilize-plan.md) | the-sarge/turn#3 | None | 2 | Complete: PR #8, PR #14; `v5.1.0-gs.1` published |
-| 2 | Modernize the kept API (M1) | [plan](2026-08-15-modernize-kept-api-plan.md) | the-sarge/turn#19 | Track 1 (complete); wiremux Slice 1.3 (complete, GridSwarm/wiremux#1162) | 5 | FRONTIER — Slices 1 (PR #25), 2 (PR #27), and 3 (PR #29) complete; Slice 4 dispatchable; 5 after 4 |
+| 2 | Modernize the kept API (M1) | [plan](2026-08-15-modernize-kept-api-plan.md) | the-sarge/turn#19 | Track 1 (complete); wiremux Slice 1.3 (complete, GridSwarm/wiremux#1162) | 5 | FRONTIER — Slices 1 (PR #25), 2 (PR #27), 3 (PR #29), and 4 (PR #32) complete; Slice 5 dispatchable |
 | 3 | Optimize the packet path (M2) | plan pending | pending | Track 2; profiles from production wiremux traffic | TBD | GATED — requires a future `$architecture-handoff` run once its gate opens; no speculative optimization |
 
 Cross-track slice edges: the transitional upstream-fixture seam introduced by Track 1 Slice 2 is removed by Track 2 Slice 5. Track 2 order: 1→2→{3‖4}→5 (1→2 and 2→{3,4} are sequencing edges on the same functions; 3 and 4 are parallel-safe after 2; {3,4}→5 is genuine; each slice independently green). Track 2 Slice 5 tags `v5.2.0-gs.1` and files the wiremux adoption issue; wiremux-side adoption is consumer work outside this program. Recommended starter: Track 2 Slice 1.

--- a/docs/adr/2026-08-15-modernize-kept-api-plan.md
+++ b/docs/adr/2026-08-15-modernize-kept-api-plan.md
@@ -1,7 +1,7 @@
 # Modernize the Kept API (M1) Implementation Plan
 
 **Date:** 2026-08-15
-**Status:** Accepted; Slice 1 complete (PR #25); Slice 2 complete (PR #27); Slice 3 complete (PR #29); Slices 4-5 pending
+**Status:** Accepted; Slice 1 complete (PR #25); Slice 2 complete (PR #27); Slice 3 complete (PR #29); Slice 4 complete (PR #32); Slice 5 pending
 **Track:** 2 of 3 in the 2026-08-14 TURN fork molding program
 **Depends on:** Track 1 (complete: `v5.1.0-gs.1` at `1ee874e`) and wiremux Slice 1.3 (complete: GridSwarm/wiremux#1162 merged as `ccd61c4`) — both gates are open
 **Related:** [Program index](2026-08-14-turn-molding-program.md), [Molding program scope](2026-08-14-molding-program-scope.md) (D1–D5, program shape M1), [Owned-library ADR](2026-08-14-owned-library-fork.md), [Cut and stabilize plan](2026-08-14-cut-and-stabilize-plan.md) (transitional fixture seam), [Prepared-only writes ADR](2026-08-15-prepared-only-writes.md), [Fork-owned fixture ADR](2026-08-15-fork-owned-test-fixture.md), wiremux consumer contract `docs/adr/2026-08-09-turn-carrier-prerequisites-plan.md` (GridSwarm/wiremux, Slice 1.3 and the 2026-08-14 fork-pivot amendment)
@@ -59,10 +59,10 @@ Kept protocol behavior that M1 preserves byte-for-byte on the wire: Allocate cha
 | 1 | complete (PR #25) | Client-side surface cut to the consumer's crossing; `Server netip.AddrPort`; server-source admission in `HandleInbound`; protocol internals unexported; `pion/transport` no longer a direct dependency | None | n/a |
 | 2 | complete (PR #27) | Exported `*Allocation` with `netip` data plane and `PreparePeer`; deadline surface deleted; server-reported relayed address validated | 1 | n/a |
 | 3 | complete (PR #29) | `Allocate(ctx)` with non-blocking producers; `Listen` deleted; `pion/logging` removed with a per-site ledger; allocation-refresh failure terminalizes with a cause; `net.ErrClosed`, `%w`, exported sentinels | 2 | n/a |
-| 4 | new | Prepared-only `WriteTo`; Send-indication path deleted; ChannelData-only invariant structural | 2 | n/a |
+| 4 | complete (PR #32) | Prepared-only `WriteTo`; Send-indication path deleted; ChannelData-only invariant structural | 2 | n/a |
 | 5 | new | Exported `turntest` fixture; root tests re-pointed; upstream `pion/turn/v5` dropped; README refreshed; tag `v5.2.0-gs.1`; wiremux adoption issue filed | 3, 4 | Upstream `pion/turn/v5@v5.0.12` test-only fixture (Track 1 Slice 2 seam) |
 
-Edges 1→2 and 2→{3,4} are sequencing edges on the same functions, not correctness dependencies: Slice 2 introduces the `Allocation` type whose `WriteTo`/`Close`/`ReadFrom` Slices 3 and 4 then change in place, so writing them once against Slice 2's signatures avoids rewriting the same functions twice and line-conflicting PRs on `internal/client/udp_conn.go`. Slices 3 and 4 are parallel-safe after Slice 2 merges: their overlap is one `errClosed` line inside `WriteTo` (`udp_conn.go:471`) and root-test hunks, with rebase cost bounded to those. Edge {3,4}→5 is genuine: the fixture is written once against the final client behavior, and the tag requires every M1 slice merged. Each slice is independently green and mergeable at its own position. Frontier now: Slice 4. Frontier after Slice 4: Slice 5.
+Edges 1→2 and 2→{3,4} are sequencing edges on the same functions, not correctness dependencies: Slice 2 introduces the `Allocation` type whose `WriteTo`/`Close`/`ReadFrom` Slices 3 and 4 then change in place, so writing them once against Slice 2's signatures avoids rewriting the same functions twice and line-conflicting PRs on `internal/client/udp_conn.go`. Slices 3 and 4 are parallel-safe after Slice 2 merges: their overlap is one `errClosed` line inside `WriteTo` (`udp_conn.go:471`) and root-test hunks, with rebase cost bounded to those. Edge {3,4}→5 is genuine: the fixture is written once against the final client behavior, and the tag requires every M1 slice merged. Each slice is independently green and mergeable at its own position. Frontier now: Slice 5 (all of its blockers, Slices 3 and 4, are complete).
 
 ## Implementation Slices
 

--- a/errors.go
+++ b/errors.go
@@ -39,6 +39,11 @@ var ErrChannelBindFailed = client.ErrChannelBindFailed
 // server-side lifetime expired before the write.
 var ErrChannelBindingExpired = client.ErrChannelBindingExpired
 
+// ErrNotPrepared reports a WriteTo to a peer for which PreparePeer has not
+// succeeded on this allocation. Nothing is sent: writes are ChannelData over
+// a prepared binding or fail with zero network output.
+var ErrNotPrepared = client.ErrNotPrepared
+
 // ErrAlreadyAllocated is returned by Allocate when the client already owns a
 // live allocation. Close that allocation before allocating again.
 var ErrAlreadyAllocated = errors.New("turn: already allocated")

--- a/internal/client/errors.go
+++ b/internal/client/errors.go
@@ -30,6 +30,9 @@ var (
 	// ErrChannelBindingExpired reports a confirmed channel binding whose
 	// server-side lifetime has expired.
 	ErrChannelBindingExpired = errors.New("confirmed channel binding expired")
+	// ErrNotPrepared reports a write to a peer that has no prepared,
+	// confirmed channel binding: nothing was sent.
+	ErrNotPrepared = errors.New("peer not prepared: no confirmed channel binding")
 )
 
 var (

--- a/internal/client/prepare_test.go
+++ b/internal/client/prepare_test.go
@@ -352,3 +352,86 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 		}
 	})
 }
+
+// TestWriteToPreparedOnly is the finite state table for the prepared-only
+// write invariant: a write to a peer emits ChannelData or fails with zero
+// network output. Only the prepared-and-ready state produces a datagram, and
+// that datagram is ChannelData; no state creates a permission or starts a
+// bind on the write path.
+func TestWriteToPreparedOnly(t *testing.T) {
+	tests := []struct {
+		name         string
+		arrange      func(t *testing.T, harness *prepareHarness)
+		wantErr      error
+		wantWrites   int  // datagrams emitted by the WriteTo under test
+		wantNoServer bool // no permission or bind transaction may run at all
+	}{
+		{
+			name:         "unprepared peer",
+			arrange:      func(*testing.T, *prepareHarness) {},
+			wantErr:      ErrNotPrepared,
+			wantWrites:   0,
+			wantNoServer: true,
+		},
+		{
+			name: "prepared and ready",
+			arrange: func(t *testing.T, harness *prepareHarness) {
+				t.Helper()
+				assert.NoError(t, harness.conn.PreparePeer(context.Background(), harness.peer))
+			},
+			wantErr:    nil,
+			wantWrites: 1,
+		},
+		{
+			name: "prepared then terminal",
+			arrange: func(t *testing.T, harness *prepareHarness) {
+				t.Helper()
+				assert.NoError(t, harness.conn.PreparePeer(context.Background(), harness.peer))
+				harness.failPerms.Store(true)
+				harness.conn.onRefreshTimers(timerIDRefreshPerms)
+			},
+			wantErr:    ErrPermissionRefreshFailed,
+			wantWrites: 0,
+		},
+		{
+			name: "closed",
+			arrange: func(t *testing.T, harness *prepareHarness) {
+				t.Helper()
+				assert.NoError(t, harness.conn.PreparePeer(context.Background(), harness.peer))
+				assert.NoError(t, harness.conn.Close())
+			},
+			wantErr:    net.ErrClosed,
+			wantWrites: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			harness := newPrepareHarness(t, false)
+			tt.arrange(t, harness)
+
+			writesBefore := harness.writeCount()
+			n, err := harness.conn.WriteTo([]byte("payload"), harness.peer)
+			writes := harness.writeCount() - writesBefore
+
+			if tt.wantErr == nil {
+				assert.NoError(t, err)
+				assert.Equal(t, len("payload"), n)
+			} else {
+				assert.ErrorIs(t, err, tt.wantErr)
+				assert.Equal(t, 0, n, "a failed write reports zero bytes")
+			}
+			assert.Equal(t, tt.wantWrites, writes, "network output count")
+			if writes > 0 {
+				assert.True(t, proto.IsChannelData(harness.lastWrite()),
+					"the only datagram a write may emit is ChannelData")
+			}
+			if tt.wantNoServer {
+				assert.Equal(t, int32(0), harness.permCount.Load(),
+					"WriteTo must not create a permission")
+				assert.Equal(t, int32(0), harness.bindCount.Load(),
+					"WriteTo must not start a bind")
+			}
+		})
+	}
+}

--- a/internal/client/udp_conn.go
+++ b/internal/client/udp_conn.go
@@ -386,8 +386,8 @@ func (c *UDPConn) addWorker() bool {
 }
 
 // failPreparedBindings terminalizes every prepared binding: once a peer is
-// prepared, losing its permission must fail writes rather than fall back to
-// Send indications.
+// prepared, losing its permission must fail its writes with the recorded
+// cause; there is no other write path to fall back to.
 func (c *UDPConn) failPreparedBindings(err error) {
 	for _, bound := range c.bindingMgr.all() {
 		if bound.prepared.Load() {
@@ -396,93 +396,36 @@ func (c *UDPConn) failPreparedBindings(err error) {
 	}
 }
 
-// WriteTo writes a packet with payload to the canonical peer addr. Writes to
-// a prepared peer use its channel binding or fail; writes to an unprepared
-// peer may fall back to Send indications while a binding is established.
-func (c *UDPConn) WriteTo(payload []byte, addr netip.AddrPort) (int, error) { //nolint:gocognit,cyclop
-	var err error
+// WriteTo writes payload to the canonical peer addr as ChannelData over the
+// peer's prepared channel binding. It is the single guard of the prepared-only
+// write invariant: a peer that PreparePeer has not confirmed on this
+// allocation gets ErrNotPrepared with zero network output; a prepared binding
+// that has since expired or failed returns its recorded cause with zero
+// network output. WriteTo never creates a permission, starts a bind, or emits
+// anything other than ChannelData — no Send-indication constructor exists in
+// this client.
+func (c *UDPConn) WriteTo(payload []byte, addr netip.AddrPort) (int, error) {
 	if c.isClosed() {
 		return 0, c.closedErr()
 	}
 
-	// Check if we have a permission for the destination IP addr
-	perm, ok := c.permMap.find(addr)
-	if !ok {
-		perm = &permission{}
-		c.permMap.insert(addr, perm)
-	}
-
-	for range maxRetryAttempts {
-		// c.createPermission() would block, per destination IP (, or perm),
-		// until the perm state becomes "requested". Purpose of this is to
-		// guarantee the order of packets (within the same perm).
-		// Note that CreatePermission transaction may not be complete before
-		// all the data transmission. This is done assuming that the request
-		// will be most likely successful and we can tolerate some loss of
-		// UDP packet (or reorder), inorder to minimize the latency in most cases.
-		if err = c.createPermission(perm, addr); !errors.Is(err, errTryAgain) {
-			break
-		}
-	}
-	if err != nil {
-		return 0, err
-	}
-
-	// Bind channel
 	bound, ok := c.bindingMgr.findByAddr(addr)
-	if !ok {
-		bound = c.bindingMgr.create(addr)
+	if !ok || !bound.prepared.Load() {
+		return 0, ErrNotPrepared
 	}
 
-	// A prepared peer promised ChannelData-only writes: fail instead of ever
-	// falling back to Send indications.
-	if bound.prepared.Load() {
-		if bound.ok() && time.Since(bound.refreshedAt()) >= channelBindingLifetime {
-			bound.terminalize(ErrChannelBindingExpired)
-		}
-		if !bound.ok() {
-			if bindErr := bound.bindErr(); bindErr != nil {
-				return 0, bindErr
-			}
-
-			return 0, ErrChannelBindFailed
-		}
+	if bound.ok() && time.Since(bound.refreshedAt()) >= channelBindingLifetime {
+		bound.terminalize(ErrChannelBindingExpired)
 	}
-
-	//nolint:nestif
 	if !bound.ok() {
-		// Try to establish an initial binding with the server.
-		// Writes still occur via indications meanwhile.
-		c.maybeBind(bound)
-
-		// Send data using SendIndication
-		peerAddr := peerAddress(addr)
-		var msg *stun.Message
-		msg, err = stun.Build(
-			stun.TransactionID,
-			stun.NewType(stun.MethodSend, stun.ClassIndication),
-			proto.Data(payload),
-			peerAddr,
-			stun.Fingerprint,
-		)
-		if err != nil {
-			return 0, err
+		if bindErr := bound.bindErr(); bindErr != nil {
+			return 0, bindErr
 		}
 
-		if _, err = c.writeTo(msg.Raw, c.serverAddr); err != nil {
-			return 0, err
-		}
-
-		return len(payload), nil
+		return 0, ErrChannelBindFailed
 	}
 
-	// Binding is ready beyond this point, so send over it.
-	_, err = c.sendChannelData(payload, bound.number)
-	if err != nil {
-		return 0, err
-	}
-
-	return len(payload), nil
+	return c.sendChannelData(payload, bound.number)
 }
 
 // Close closes the connection.

--- a/internal/client/udp_conn_test.go
+++ b/internal/client/udp_conn_test.go
@@ -495,6 +495,8 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		bm := newBindingManager()
 		binding := bm.create(addr)
 		binding.setState(bindingStateReady)
+		binding.setRefreshedAt(time.Now())
+		binding.prepared.Store(true)
 
 		conn := UDPConn{
 			allocation: allocation{
@@ -506,54 +508,8 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 
 		buf := []byte("Hello")
 		n, err := conn.WriteTo(buf, addr)
-		assert.NoError(t, err, "should fail")
-		assert.Equal(t, len(buf), n)
-	})
-
-	t.Run("WriteTo() returns real payload length", func(t *testing.T) {
-		var writtenData []byte
-		client := &mockClient{
-			performTransaction: func(*stun.Message, net.Addr, bool) (TransactionResult, error) {
-				// Return success for CreatePermission.
-				return TransactionResult{
-					Msg: stun.MustBuild(stun.NewType(stun.MethodCreatePermission, stun.ClassSuccessResponse)),
-				}, nil
-			},
-			writeTo: func(data []byte, _ net.Addr) (int, error) {
-				writtenData = data
-				// Return the actual number of bytes written (the STUN message size).
-				return len(data), nil
-			},
-		}
-
-		addr := netip.MustParseAddrPort("127.0.0.1:1234")
-
-		conn := UDPConn{
-			allocation: allocation{
-				clientHooks: client.hooks(),
-				serverAddr:  &net.UDPAddr{IP: net.ParseIP("10.0.0.1"), Port: 3478},
-				permMap:     newPermissionMap(),
-				username:    stun.NewUsername("user"),
-				realm:       stun.NewRealm("realm"),
-				integrity:   stun.NewShortTermIntegrity("pass"),
-				_nonce:      stun.NewNonce("nonce"),
-			},
-			bindingMgr: newBindingManager(),
-		}
-
-		payload := []byte("Hello")
-		n, err := conn.WriteTo(payload, addr)
 		assert.NoError(t, err)
-
-		// The SendIndication STUN message (captured in writeTo above) should be larger
-		// than the payload due to headers/attributes.
-		assert.Greater(t, len(writtenData), len(payload),
-			"STUN message should be larger than payload")
-
-		// WriteTo MUST return the real payload length, not the STUN message length.
-		assert.Equal(t, len(payload), n,
-			"WriteTo should return payload length (%d), not STUN message length (%d)",
-			len(payload), len(writtenData))
+		assert.Equal(t, len(buf), n, "WriteTo reports the payload length, not the ChannelData frame length")
 	})
 
 	t.Run("ChannelBind transaction failure retains channel number", func(t *testing.T) {
@@ -589,12 +545,14 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 			bindingMgr: bm,
 		}
 
-		// A failed bind attempt should not remove the binding, so a subsequent WriteTo
-		// should not allocate a different channel number for the same peer.
+		// A failed bind attempt should not remove the binding: the same peer keeps
+		// its channel number, and a write (which fails, unprepared) does not
+		// disturb it.
 		err := conn.bind(bound)
 		assert.ErrorIs(t, err, errFake)
 
-		_, _ = conn.WriteTo([]byte("hi"), addr)
+		_, err = conn.WriteTo([]byte("hi"), addr)
+		assert.ErrorIs(t, err, ErrNotPrepared)
 
 		b2, ok := bm.findByAddr(addr)
 		assert.True(t, ok)


### PR DESCRIPTION
One-PR implementation of **Slice 4 — Prepared-only writes: delete the Send-indication path** from the M1 plan.

- **Plan:** `docs/adr/2026-08-15-modernize-kept-api-plan.md` — slice heading "Slice 4 — Prepared-only writes: delete the Send-indication path"
- **Plan commit:** `4d779e51dbdc04d5a77bf53aac23b405d588cee7`
- **ADR:** `docs/adr/2026-08-15-prepared-only-writes.md`
- **Parent:** #19
- Closes #23

## What this delivers

- `Allocation.WriteTo` is prepared-only: canonicalize the peer; if no prepared, confirmed binding exists on this allocation return the new exported `ErrNotPrepared` (root and `internal/client`) with zero bytes and zero network output; if the binding is prepared but not usable (expired, failed, permission-refresh failure) return the recorded cause as before; otherwise send ChannelData.
- Deleted, not guarded: the Send-indication build, on-write permission creation, and the write-path `maybeBind`. `stun.MethodSend`/`proto.SendIndication` no longer appear in any non-test file of the root package or `internal/client` (`internal/proto` keeps its helper under the no-trimming rule), so the ChannelData-only invariant is structural. The `*net.TCPAddr` branch of `addr2PeerAddress` named by the plan was already gone (Slice 2 replaced it with `peerAddress(netip.AddrPort)`).
- Retained as audited: `maybeBind` on the `checkBindingsTimer` refresh path, `refreshPermsTimer` over the permission map, Data-indication inbound handling, `PreparePeer` semantics. Permissions and bindings are now created only by `PreparePeer`; refresh membership is unchanged.
- Single owner: the prepared-binding check in `WriteTo`; no second emitter exists.

## Evidence

- New `TestWriteToPreparedOnly` (`internal/client/prepare_test.go`): four-state table — unprepared → `ErrNotPrepared`, 0 writes, 0 permission/bind transactions; prepared-and-ready → one ChannelData datagram; prepared-then-terminal → `ErrPermissionRefreshFailed`, 0 writes; closed → `net.ErrClosed`, 0 writes. Written first; red on the unprepared row (Send indication + on-write permission + bind observed) before the change.
- Preservation anchors unchanged: `TestPreparePeer` "readiness success then ChannelData writes" and "permission refresh failure fails writes, never Send indication".
- Root `TestClientNonceExpiration` / `TestClientE2E` adapted to `PreparePeer` before the first write and confirmed green against the upstream fixture **before** deleting the path (ChannelData-path preservation gate). Retired: `TestClientE2E`'s `disableChannelBind` variant + `channelBindFilterConn`, `TestUDPConn` "WriteTo() returns real payload length" (indication assertions). `TestUDPConn` "WriteTo()" marks its binding prepared.
- Guard mutation (one, applied and reverted): replacing the prepared check with binding creation fails only the unprepared row.
- Negative grep clean; `task check` (gofmt, vet, tests, lint) green; `go mod tidy` clean.

Contract closure: not triggered (one reachable emitter after deletion; unprepared negative space collapses to one error return), per the slice contract.
