### PR TITLE
client,turntest: batch review follow-ups #30/#33/#36

### DIFF
--- a/internal/client/errors.go
+++ b/internal/client/errors.go
@@ -49,21 +49,3 @@ var (
 	errChannelBindTransactionFailed        = errors.New("channel bind transaction failed")
 	errNilContext                          = errors.New("context must not be nil")
 )
-
-type timeoutError struct {
-	msg string
-}
-
-func newTimeoutError(msg string) error {
-	return &timeoutError{
-		msg: msg,
-	}
-}
-
-func (e *timeoutError) Error() string {
-	return e.msg
-}
-
-func (e *timeoutError) Timeout() bool {
-	return true
-}

--- a/internal/client/prepare_test.go
+++ b/internal/client/prepare_test.go
@@ -20,15 +20,16 @@ import (
 
 // prepareHarness drives a NewUDPConn against a scripted mock TURN server.
 type prepareHarness struct {
-	conn      *UDPConn
-	mock      *mockClient
-	peer      netip.AddrPort
-	permCount atomic.Int32
-	bindCount atomic.Int32
-	bindGate  chan struct{} // If non-nil, ChannelBind transactions block on it
-	permGate  chan struct{} // If non-nil, CreatePermission transactions block on it
-	failPerms atomic.Bool   // If set, CreatePermission transactions return 403
-	writes    struct {
+	conn       *UDPConn
+	mock       *mockClient
+	peer       netip.AddrPort
+	permCount  atomic.Int32
+	bindCount  atomic.Int32
+	bindGate   chan struct{} // If non-nil, ChannelBind transactions block on it
+	permGate   chan struct{} // If non-nil, CreatePermission transactions block on it
+	failPerms  atomic.Bool   // If set, CreatePermission transactions return 403
+	staleNonce atomic.Bool   // If set, CreatePermission transactions return 438
+	writes     struct {
 		sync.Mutex
 		data [][]byte
 	}
@@ -56,6 +57,13 @@ func newPrepareHarness(t *testing.T, gateBinds bool) *prepareHarness {
 					return TransactionResult{Msg: stun.MustBuild(
 						stun.NewType(stun.MethodCreatePermission, stun.ClassErrorResponse),
 						stun.ErrorCodeAttribute{Code: stun.CodeForbidden, Reason: []byte("Forbidden")},
+					)}, nil
+				}
+				if harness.staleNonce.Load() {
+					return TransactionResult{Msg: stun.MustBuild(
+						stun.NewType(stun.MethodCreatePermission, stun.ClassErrorResponse),
+						stun.ErrorCodeAttribute{Code: stun.CodeStaleNonce, Reason: []byte("Stale Nonce")},
+						stun.NewNonce("nonce2"),
 					)}, nil
 				}
 
@@ -351,6 +359,51 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 			assert.Fail(t, "Close did not return after the bind worker finished")
 		}
 	})
+
+	t.Run("attempt in flight during self-seal records the terminal cause", func(t *testing.T) {
+		harness := newPrepareHarness(t, false)
+		harness.permGate = make(chan struct{})
+		harness.staleNonce.Store(true)
+
+		// A permission attempt is mid-transaction when the allocation seals
+		// itself. The stale-nonce reply sends the worker around its retry loop,
+		// where it observes the seal; the result it records for any waiter that
+		// joined the attempt must carry the recorded terminal cause, not bare
+		// net.ErrClosed.
+		perm := harness.conn.permMap.getOrCreate(harness.peer)
+		done := harness.conn.ensurePermissionAttempt(perm, harness.peer)
+		assert.NotNil(t, done)
+		assert.Eventually(t, func() bool {
+			return harness.permCount.Load() == 1
+		}, 5*time.Second, 10*time.Millisecond)
+
+		harness.conn.startClose(errFake)
+		close(harness.permGate)
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			assert.Fail(t, "permission attempt did not finish after the seal")
+		}
+
+		perm.attemptMutex.Lock()
+		err := perm.attemptErr
+		perm.attemptMutex.Unlock()
+		assert.ErrorIs(t, err, net.ErrClosed)
+		assert.ErrorIs(t, err, errFake,
+			"an in-flight attempt finishing after the seal must record the terminal cause")
+	})
+
+	t.Run("re-entry after binding expiry is terminal", func(t *testing.T) {
+		harness := newPrepareHarness(t, false)
+
+		assert.NoError(t, harness.conn.PreparePeer(context.Background(), harness.peer))
+		bound := harness.conn.bindingMgr.getOrCreate(harness.peer)
+		bound.setRefreshedAt(time.Now().Add(-channelBindingLifetime))
+
+		err := harness.conn.PreparePeer(context.Background(), harness.peer)
+		assert.ErrorIs(t, err, ErrChannelBindingExpired,
+			"a preparing caller re-entering an expired binding must observe the expiry")
+	})
 }
 
 // TestWriteToPreparedOnly is the finite state table for the prepared-only
@@ -391,6 +444,17 @@ func TestWriteToPreparedOnly(t *testing.T) {
 				harness.conn.onRefreshTimers(timerIDRefreshPerms)
 			},
 			wantErr:    ErrPermissionRefreshFailed,
+			wantWrites: 0,
+		},
+		{
+			name: "prepared then binding expired",
+			arrange: func(t *testing.T, harness *prepareHarness) {
+				t.Helper()
+				assert.NoError(t, harness.conn.PreparePeer(context.Background(), harness.peer))
+				bound := harness.conn.bindingMgr.getOrCreate(harness.peer)
+				bound.setRefreshedAt(time.Now().Add(-channelBindingLifetime))
+			},
+			wantErr:    ErrChannelBindingExpired,
 			wantWrites: 0,
 		},
 		{

--- a/internal/client/udp_conn.go
+++ b/internal/client/udp_conn.go
@@ -253,7 +253,10 @@ func (c *UDPConn) ensurePermissionAttempt(perm *permission, peer netip.AddrPort)
 		var err error
 		for range maxRetryAttempts {
 			if c.isClosed() {
-				err = net.ErrClosed
+				// Seal precedence: a waiter that joins this attempt gets the
+				// recorded terminal cause, exactly like an operation started
+				// after the seal.
+				err = c.closedErr()
 
 				break
 			}
@@ -667,7 +670,10 @@ func (c *UDPConn) bindChannel(bound *binding, startState bindingState) error {
 	var err error
 	for range maxRetryAttempts {
 		if c.isClosed() {
-			return net.ErrClosed
+			// Seal precedence: the binding result a waiter joins carries the
+			// recorded terminal cause, exactly like an operation started after
+			// the seal.
+			return c.closedErr()
 		}
 		if err = c.bind(bound); !errors.Is(err, errTryAgain) {
 			break

--- a/internal/client/udp_conn_test.go
+++ b/internal/client/udp_conn_test.go
@@ -16,6 +16,26 @@ import (
 	"github.com/the-sarge/turn/v5/internal/proto"
 )
 
+// timeoutError simulates a transaction failure whose Timeout() is true, like
+// an exhausted retransmission budget.
+type timeoutError struct {
+	msg string
+}
+
+func newTimeoutError(msg string) error {
+	return &timeoutError{
+		msg: msg,
+	}
+}
+
+func (e *timeoutError) Error() string {
+	return e.msg
+}
+
+func (e *timeoutError) Timeout() bool {
+	return true
+}
+
 func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 	makeConn := func(client *mockClient, bm *bindingManager) UDPConn {
 		return UDPConn{

--- a/turntest/turntest_test.go
+++ b/turntest/turntest_test.go
@@ -157,3 +157,119 @@ func TestAllocationCount(t *testing.T) {
 		2*time.Second, 10*time.Millisecond,
 		"the closed allocation should be deleted by the lifetime-0 refresh")
 }
+
+// TestSecondAllocateMismatch proves the fixture's 437 arm: a second Allocate
+// on the same five-tuple is answered with 437 (Allocation Mismatch), surfaced
+// by the client as a typed TURN error. The client refuses a repeated Allocate
+// locally, so the second request comes from a second client sharing the same
+// socket.
+func TestSecondAllocateMismatch(t *testing.T) {
+	srv := turntest.Start(t, options())
+
+	conn, err := net.ListenPacket("udp4", "0.0.0.0:0") //nolint:noctx // test socket
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	newClient := func() *turn.Client {
+		client, clientErr := turn.NewClient(&turn.ClientConfig{
+			Conn:     conn,
+			Server:   srv.Addr(),
+			Username: testUsername,
+			Password: testPassword,
+		})
+		require.NoError(t, clientErr)
+		t.Cleanup(client.Close)
+
+		return client
+	}
+	first, second := newClient(), newClient()
+
+	// One pump offers each datagram to both clients: the client that owns the
+	// transaction consumes it, the other's handle error is discarded.
+	go func() {
+		buf := make([]byte, 1500)
+		for {
+			n, from, readErr := conn.ReadFrom(buf)
+			if readErr != nil {
+				return
+			}
+			_ = first.HandleInbound(buf[:n], from)
+			_ = second.HandleInbound(buf[:n], from)
+		}
+	}()
+
+	alloc, err := first.Allocate(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = alloc.Close() })
+	require.Equal(t, 1, srv.AllocationCount())
+
+	_, err = second.Allocate(context.Background())
+	var turnErr *stun.TurnError
+	require.ErrorAs(t, err, &turnErr)
+	assert.Equal(t, stun.CodeAllocMismatch, turnErr.ErrorCodeAttr.Code)
+}
+
+// TestDataIndicationAfterBindingExpiry proves the fixture's Data-indication
+// arm: once the server-side channel binding has expired but the permission is
+// still live, peer traffic reaches the client's ReadFrom as a Data indication.
+func TestDataIndicationAfterBindingExpiry(t *testing.T) {
+	opts := options()
+	opts.ChannelBindTimeout = 200 * time.Millisecond
+	srv := turntest.Start(t, opts)
+	client := startClient(t, srv)
+
+	alloc, err := client.Allocate(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = alloc.Close() })
+
+	peerConn, err := net.ListenPacket("udp4", "127.0.0.1:0") //nolint:noctx // test peer socket
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = peerConn.Close() })
+	peerUDP, ok := peerConn.LocalAddr().(*net.UDPAddr)
+	require.True(t, ok)
+	peer := netip.AddrPortFrom(peerUDP.AddrPort().Addr().Unmap(), peerUDP.AddrPort().Port())
+
+	require.NoError(t, alloc.PreparePeer(context.Background(), peer))
+
+	// Wait out the server-side binding (the sweeper runs every 20ms) while the
+	// default 5-minute permission stays live: after this, the Data-indication
+	// arm is the only path that can deliver peer traffic to the client.
+	time.Sleep(3 * opts.ChannelBindTimeout)
+
+	type inbound struct {
+		payload []byte
+		from    netip.AddrPort
+	}
+	received := make(chan inbound, 1)
+	go func() {
+		buf := make([]byte, 1500)
+		n, from, readErr := alloc.ReadFrom(buf)
+		if readErr != nil {
+			return
+		}
+		received <- inbound{payload: append([]byte(nil), buf[:n]...), from: from}
+	}()
+
+	relayed := alloc.RelayedAddr()
+	relayedUDP := &net.UDPAddr{IP: relayed.Addr().AsSlice(), Port: int(relayed.Port())}
+	payload := []byte("via data indication")
+	deadline := time.After(5 * time.Second)
+	for {
+		_, err = peerConn.WriteTo(payload, relayedUDP)
+		require.NoError(t, err)
+
+		select {
+		case got := <-received:
+			assert.Equal(t, payload, got.payload)
+			assert.Equal(t, peer, got.from,
+				"the Data indication must carry the canonical peer label")
+
+			return
+		case <-time.After(100 * time.Millisecond):
+			// Datagram lost; every retry is after the binding expiry, so no
+			// send can arrive as ChannelData.
+		case <-deadline:
+			require.Fail(t, "peer datagram never reached ReadFrom via Data indication")
+		}
+	}
+}


### PR DESCRIPTION
Batches the three open Track 2 (M1) review follow-ups into one PR, per the operator-approved resolution of #30 (adopt seal precedence).

Closes #30
Closes #33
Closes #36

## What changed

**#30 — seal precedence (the only shipped-behavior change).** The closing permission worker (`ensurePermissionAttempt`) and `bindChannel`'s closing check now route through `closedErr()`, so an operation already in flight when the allocation terminalizes records `net.ErrClosed` wrapped with the recorded terminal cause instead of bare `net.ErrClosed`. `errors.Is(err, net.ErrClosed)` holds on every path before and after; only cause fidelity changes. One gated in-flight regression (stale-nonce knob holds a permission attempt in its retry loop across a self-seal) asserts the worker-recorded result carries the cause — red before the fix, green after. Hygiene rider from the same issue: `timeoutError`/`newTimeoutError` moved from `errors.go` into `udp_conn_test.go`, its only caller's file.

**#33 — test-only.** New `TestWriteToPreparedOnly` row: prepared peer, `refreshedAt` back-dated past `channelBindingLifetime` → `ErrChannelBindingExpired`, zero bytes, zero datagrams; plus the `bindingResult` re-entry case via a second `PreparePeer`. Guard-deletion sanity: removing `WriteTo`'s expiry branch makes the new row fail.

**#36 — test-only.** Two turntest regressions for the enumerated fixture behaviors: a second Allocate on the same five-tuple (second `turn.Client` sharing the socket, dual-fed read pump) → typed `*stun.TurnError` with `stun.CodeAllocMismatch`; and short `ChannelBindTimeout` waited out with the permission live → peer traffic reaches `Allocation.ReadFrom` via the Data-indication arm (mutation sanity: disabling the `permitted` arm fails the test). No growth of the fixture's request subset (fixture ADR).

## Review contract

- **Artifact classes:** #30 code = shipped behavior; everything else = verification aids (turntest is a maintained aid per `docs/adr/2026-08-15-fork-owned-test-fixture.md`).
- **Invariant / owner:** an operation reporting closure after a self-seal carries the recorded terminal cause; single enforcement owner `closedErr()`. No worker path returns a bare `net.ErrClosed` literal after this change.
- **Preserved:** `errors.Is(err, net.ErrClosed)` on all closing paths; caller-Close semantics; no change to emitted message bytes; aborted-transaction errors during close surface as before (only the two enumerated literal sites changed).
- **Non-goals:** wiremux adoption (GridSwarm/wiremux#1180), Track 3, turntest subset growth, the transaction-abort error path (not one of #30's enumerated sites), plan-contract edits.
- **Guarantee level:** example-level regression coverage; contract closure not triggered.
- **Evidence:** `go test -race` on both affected packages, `task verify` (0 lint issues), guard mutations above; `task preflight` + `ci-certify` at the final head before merge. Review budget: one review + at most one replacement.
