### PR TITLE
docs: package architecture deepening program

### DIFF
--- a/docs/adr/2026-08-17-allocation-lifecycle-plan.md
+++ b/docs/adr/2026-08-17-allocation-lifecycle-plan.md
@@ -1,0 +1,114 @@
+# Allocation Lifecycle Ownership Implementation Plan
+
+**Date:** 2026-08-17
+**Status:** Accepted; not implemented
+**Track:** 2 of 3 in the 2026-08-17 architecture deepening program
+**Depends on:** Nothing — safe to start independently
+**Related:** [Program index](2026-08-17-architecture-deepening-program.md), [Transaction registry plan](2026-08-17-transaction-registry-plan.md), [Modernize the kept API plan](2026-08-15-modernize-kept-api-plan.md), [Prepared-only writes ADR](2026-08-15-prepared-only-writes.md), [RFC 8656](https://www.rfc-editor.org/rfc/rfc8656.html)
+**Normative scope:** Current outcome, boundaries, invariants, acceptance evidence, blockers, and stop conditions
+**Audit history:** Independently audited against `e251b6b` on 2026-08-17; T2.S1 passed after its abort-capability and finite lifecycle contracts were closed; the proposed adaptive-refresh successor was closed without code because it is unreachable in the conforming exact-wire domain; no implementation or overlapping open issue/PR exists
+
+## Goal
+
+Make `UDPConn` the single implementation owner of one Allocation's nonce, grant, maintenance outcomes, terminal cause, release, and worker join. Remove the shallow embedded `allocation` half and its upward callbacks while retaining the already-deep `startClose`/`Close` lifecycle and the supported fixed refresh schedule.
+
+## Current Shape (verified 2026-08-17 at `e251b6b`)
+
+`UDPConn` embeds an `allocation` value (`internal/client/udp_conn.go:43-64`). Construction nests three client hooks inside that value, then installs upward callbacks from the embedded half back to `UDPConn` for permission-refresh and Allocation-refresh failure (`internal/client/udp_conn.go:66-100`; `internal/client/client.go:13-22`; `internal/client/allocation.go:44-70`). The embedded type owns nonce, lifetime, Refresh requests, permission refresh, and two timers, while `UDPConn` owns binding state, close state, terminal cause, worker registration, and joins. Understanding one Allocation lifecycle therefore requires following state and callback direction across three files.
+
+The healthy terminal owner already exists on `UDPConn`: `Close` distinguishes first caller, repeated caller, and prior self-seal, stops and joins timers/workers, and returns the release or terminal result (`internal/client/udp_conn.go:434-471`). `startClose`/`startCloseLocked` are worker-safe, guard exactly one seal and lifetime-zero emission, abort pending transactions before release, record one terminal cause, and never self-join (`internal/client/udp_conn.go:474-520`). Existing tests exercise refresh-failure disposition, concurrent caller closes, refresh-failure seal versus close, release-emission error joining, permission-refresh failure, and ChannelBind-400 recovery/seal (`internal/client/refresh_failure_test.go:107-299`; `internal/client/prepare_test.go:287-304`; `internal/client/udp_conn_test.go:416-495`).
+
+The Allocation refresh timer is created once at half the initial grant (`internal/client/udp_conn.go:102-106`) and `PeriodicTimer` retains that interval (`internal/client/periodic_timer.go:14-60`). Deeper audit rejected the proposed adaptive-refresh slice for the supported production domain: Allocate sends no LIFETIME attribute (`client.go:198-207,233-246`), so RFC 8656 Section 7.2 gives the 600-second default; later Refresh requests ask for the current 600-second grant (`internal/client/allocation.go:83-93,160-170`), and RFC Section 8.2 continues that grant. A 3,600→600 path exists only through nonconforming/example-level stand-ins unless this client changes Allocate bytes. Exact-wire preservation and the owned one-consumer contract take precedence, so fixed half-life scheduling is intentional in this program.
+
+## Decision
+
+`UDPConn` remains the one Allocation lifecycle module and directly owns every field and method now held by the embedded `allocation`. Delete the `allocation` type and `clientHooks` wrapper. Keep implementation split across appropriately named files if useful, but methods use one receiver and no upward lifecycle callback. Allocation-refresh failure directly calls `startClose`; permission-refresh failure directly terminalizes prepared bindings. Root-to-internal construction still supplies socket-write, transaction, deallocation-notification, and abort-current adapters; tests supply local stand-ins. These package-crossing production/mock adapters do not mutate lifecycle state.
+
+The abort-current adapter is required at every `UDPConn` construction site. Production assembly creates that dependency before sending Allocate and uses a construction representation that cannot omit it; `NewUDPConn` never substitutes a default no-op and defensively rejects programmer-invalid test/internal construction before starting timers or workers. A nonnil function cannot prove that its body is effective, so prompt-close and abort-before-release tests exercise the real production adapter. Production rejection after successful server Allocate is structurally unreachable because root assembly establishes the required capability before the request; if implementation makes rejection reachable instead, that path must release the server Allocation before returning. Before Track 1 lands the adapter delegates to the existing transaction map; after Track 1 it delegates to the registry. `startCloseLocked` invokes it before `OnDeallocated` and before the lifetime-zero fire-and-forget Refresh, so the release transaction starts outside the aborted live set.
+
+Preserve terminal semantics exactly: workers may seal but never join themselves; the caller is the join point; exactly one seal emits lifetime zero; one terminal cause wins; a release-emission failure joins a self-seal cause; repeated caller close returns `net.ErrClosed`. Permission-refresh exhaustion terminalizes prepared bindings but does not seal the Allocation. ChannelBind 400 on a previously confirmed binding preserves that binding and does not seal; 400 on a fresh binding seals. Invalid relayed addresses remain construct-then-close so the server Allocation is released before rejection (`client.go:326-355`). `Client.Close` remains separate.
+
+Keep Allocation, permission, and binding timer cadence unchanged. Ordinary Refresh success still records the parsed lifetime; 438 still updates nonce and retries up to the existing limit; permanent failure still seals. The stored lifetime does not create an adaptive schedule in this program because conforming supported traffic cannot vary it. If future work adds a requested Allocate lifetime, changes the exact wire contract, or explicitly supports nonconforming grant changes, adaptive scheduling requires a new grilling/handoff with a reachable representation contract.
+
+**Rejected alternative (do not do this):** Extract a standalone Allocation lifecycle/seal object. It would have one production caller, require callbacks into `UDPConn` for bindings/workers/close, and split the existing healthy owner.
+
+**Rejected alternative (do not do this):** Add adaptive Allocation refresh for a hypothetical 3,600→600 grant now. That transition is unreachable through the conforming shipped client, and making it reachable would require an Allocate LIFETIME/wire change or an explicit nonconforming-server robustness decision.
+
+**Rejected alternative (do not do this):** Improve `PeriodicTimer` generically or rewrite permission/binding scheduling. The accepted win is lifecycle locality, not generic goroutine plumbing.
+
+**Rejected alternative (do not do this):** Reject an invalid relayed address before constructing `UDPConn`. The accepted path must emit lifetime zero to avoid leaving a server Allocation until expiry.
+
+**Non-goals:** No public `Allocation` API change; no Client terminality change; no adaptive timer; no requested Allocate lifetime; no nonconforming-server grant support; no prepared-peer module; no Permission/binding identity change; no Send indication; no transaction/retransmission change; no socket ownership or wire-byte change.
+
+## Slice Graph
+
+| Slice | Status/disposition | Delivers | Blocked by | Removes temporary seam |
+|---|---|---|---|---|
+| T2.S1 | New | `UDPConn` becomes the sole Allocation lifecycle implementation; callbacks and embedded half delete | None | Removes the embedded `allocation`/`clientHooks` seam in this slice |
+
+## Implementation Slices
+
+### Slice T2.S1 — Consolidate Allocation lifecycle ownership in `UDPConn`
+
+**What it delivers:** One behavior-preserving PR moving nonce, lifetime, permission-refresh, Allocation-refresh, and root adapter fields/methods from embedded `allocation` onto `UDPConn`; deleting `allocation` and `clientHooks`; replacing upward failure callbacks with direct `UDPConn` calls; making the abort-current capability mandatory in production assembly without substituting a no-op; retiring the internal no-abort construction path; and preserving fixed timer cadence, `startClose`/`Close`, public root `Allocation`, and all supported outcomes.
+
+**Existing-work disposition:** New slice. There is no open issue or PR for this work.
+
+**Blocked by:** None. The current abort-current adapter already supplies the capability; Track 1 changes its implementation owner without changing this Allocation-side contract.
+
+**Single owner after merge:** `UDPConn` is the sole mutation owner for nonce, granted lifetime, maintenance disposition, terminal cause, seal, release, and join. The current map or future transaction registry owns transaction mechanics. Root `Client` supplies adapters and receives deallocation notification but does not mutate Allocation state.
+
+**Authority completeness:** No persisted fact. Every constructor and mutation of nonce/lifetime/terminal state is migrated in this slice, every production/test constructor supplies an explicit abort-current adapter, production assembly makes omission structurally unreachable, and no raw lifecycle callback remains. The constructor never manufactures a default no-op; behavior tests, not a nonnil check, prove that the production adapter aborts.
+
+**Transitional-seam budget:** None. Fixed `PeriodicTimer` instances are intentionally retained supported implementation, not duplicate ownership or a temporary seam. The abort-current adapter is a real production/mock package seam and remains after Track 1 with a different implementation.
+
+**Blast radius:** Internal receiver/field movement throughout `internal/client/allocation.go` and `udp_conn.go`; `NewUDPConn` signature/validation and all root/test constructors; refresh, permission, binding, close, and error paths. Public API, emitted bytes, timer cadence, retry disposition, error chains, worker counts, and caller-owned socket behavior are preserved. The internal missing-abort/no-abort test path is intentionally retired; production already supplies abort at `client.go:338-343`. Untraced effects are not accepted: any lifecycle callback from a nested owner or mutation of nonce/lifetime/terminal cause outside `UDPConn` after merge is a stop.
+
+**Artifact classification:** Consolidated lifecycle behavior and seal/join guards are shipped behavior and required safety enforcement. Existing/adapted lifecycle, race, mock-adapter, and construction tests are verification aids. Plans, issues, and tasks are process metadata. No maintained verification aid is introduced.
+
+**Representation contract:** Supported domain = production `UDPConn` construction with explicitly supplied required adapters and a positive initial RFC-default grant; ordinary Refresh success and 438 retry; permanent Refresh failure; permission-refresh success/failure; fresh and previously-ready ChannelBind 400; caller close; worker self-seal; concurrent seal/close; in-flight transaction abort; invalid relayed-address cleanup; and release-emission success/failure. Root `Client` owns canonical server/relayed-address construction and establishes abort capability before Allocate; `pion/stun`/`internal/proto` own response parsing; `UDPConn` owns lifecycle transitions. Guarantee = universal over the finite lifecycle table below. Missing-capability internal construction is a programmer-invalid state rejected before live work; the production representation cannot reach it after server allocation, and no default/no-op is supplied. Terminating evidence = one focused case per row, production adapter prompt-close/ordering evidence, race suite, preflight, and bounded review.
+
+**Contract closure:** Not triggered. Consequences are material, but the supported lifecycle is finite, already concentrated on `startClose`/`Close`, and reasonably covered by the focused preservation table below; multiple callers alone do not satisfy the closure trigger.
+
+| Semantic class | Expected disposition | Enforcement owner | Terminating evidence | Status |
+|---|---|---|---|---|
+| Missing abort-current adapter in internal/test construction | Programmer-invalid construction is rejected before timer/worker start; constructor supplies no default/no-op; production assembly cannot omit it after Allocate | Root assembly representation + `NewUDPConn` defensive guard | Focused invalid-construction test and production assembly audit; replace no-abort harness case | Planned |
+| Ordinary Refresh success or one/more 438 then success | Nonce/lifetime update and current fixed cadence preserved | `UDPConn` Refresh methods | Existing Refresh/nonce tests adapted | Planned |
+| Caller closes healthy Allocation | Seal once, abort, emit lifetime zero, join, return emission result | `startCloseLocked` + `Close` | Existing close tests | Planned |
+| Allocation Refresh permanently fails | Worker-safe self-seal; operations wake; caller later joins and observes cause | `startClose` | Existing refresh-failure table | Planned |
+| Permission Refresh permanently fails | Prepared bindings terminalize; Allocation remains live; no fallback write | `failPreparedBindings` | `prepare_test.go` permission-refresh case | Planned |
+| Permission Refresh succeeds | Permission refreshed time advances; prepared bindings and Allocation remain usable | `UDPConn` permission-refresh path | Existing success case adapted through consolidated receiver | Planned |
+| Fresh ChannelBind receives 400 | Worker-safe self-seal with ChannelBind cause | `startClose` | Existing fresh-binding 400 test | Planned |
+| Previously-ready ChannelBind refresh receives 400 | Saved binding remains usable; Allocation does not seal | `recoverChannelBindBadRequest` | `udp_conn_test.go` ready-binding cases | Planned |
+| Self-seal races caller close | Exactly one seal/release; caller result follows winning state | `closeMutex` + seal guard | Existing seal-vs-close race | Planned |
+| Concurrent caller closes | One observes release result; duplicates return `net.ErrClosed` | `closeMutex` + `callerClosed` | Existing concurrent-close test | Planned |
+| Release emission fails during self-seal | Failure joins terminal cause; caller join observes both | `startCloseLocked` | Existing emission-failure test | Planned |
+| In-flight shared transaction during seal | Abort wakes worker before join; release starts after abort | `startCloseLocked` ordering + adapter | Prompt-close/abort-order tests | Planned |
+| Invalid relayed address after server success | Construct and close, emit release, clear Client pointer, then reject | root `Client.Allocate` + `UDPConn.Close` | Existing invalid-relayed test | Planned |
+
+**Evidence budget:** One missing-adapter programmer-error case plus static production assembly audit proving the adapter exists before Allocate; replacement of the internal no-abort close-latency case with a real-adapter abort-order case; existing prompt-close and waiter-local-cancellation cases; ordinary Refresh/438 success; refresh-failure table; permission-refresh success and failure; fresh and ready-binding 400; concurrent caller close; seal-vs-close race; self-seal emission failure; invalid-relayed release; full race suite. At most one mutation: bypass the one-seal guard and observe the exact-one release race fail. No timing repetitions, fuzz, or platform matrix beyond repository preflight. Termination = table cases, preflight, same-head hosted CI, one review, at most one replacement, and no `stop-for-decision` finding.
+
+**TDD and preservation evidence:** Add the missing-adapter programmer-error case, production assembly audit, and real-adapter abort-before-release ordering assertions first. Explicitly replace the no-abort internal harness case at `close_latency_test.go:76-96`; it is a retired verification path, not supported shipped behavior. Then migrate receivers/fields in small commits while the lifecycle table remains green, including ordinary permission-refresh success. Preserve exact Refresh/CreatePermission/ChannelBind setters through parsed attribute-order and normalized-message comparisons that ignore generated transaction-ID values.
+
+**Dispatch context budget:** This slice contract and table; all of `internal/client/allocation.go`; all receiver uses in `internal/client/udp_conn.go` including construction, permission, Refresh, ChannelBind, and close; `internal/client/client.go`; root `client.go:299-355`; every `NewUDPConn` constructor found by repository search; `allocation_test.go`; `close_latency_test.go`; `internal/client/{client,prepare,udp_conn,refresh_failure}_test.go`; and the relevant M1 one-owner/socket rules. No earlier architecture report is required. This is a medium-large receiver/ownership migration with focused test adaptation and fits one fresh context.
+
+**Slice decision audit:** Strongest further split = ownership-only collapse independent of abort validation, followed by registry-abort adoption. Rejected because the accepted deep lifecycle must not retain optional close cancellation, and both changes cross the same constructor and `startCloseLocked` seam; splitting would leave a knowingly weak intermediate contract. Splitting fields from callback deletion is also rejected because it would retain two lifecycle owners. Strongest adjacent merge = merge with Track 1. Rejected because registry and Allocation are distinct owners and the combined concurrency matrices exceed one fresh context. No blocker exists: the current adapter provides abort-current now, while Track 1 later changes only its implementation. The rejected adaptive successor is closed without code rather than left as a dangling removal obligation.
+
+**Stop conditions:** A lifecycle field cannot move without creating a second mutation owner; missing abort cannot fail before live timers/workers; direct failure handling requires a worker to call `Close` and self-join; abort cannot precede release; current terminal error/result precedence, timer cadence, or request attributes change; or a supported constructor cannot supply the required adapter.
+
+## Acceptance Criteria
+
+- [ ] `UDPConn` is the sole mutation owner for Allocation nonce, granted lifetime, maintenance disposition, terminal cause, seal, release, and join; the supported lifecycle domain, owner, universal guarantee, and finite evidence are declared above.
+- [ ] Embedded `allocation`, `clientHooks`, and upward allocation/permission failure callbacks are absent.
+- [ ] Production assembly structurally supplies abort-current before Allocate, the constructor never substitutes a no-op, programmer-invalid omission is rejected before timer/worker start, real-adapter tests prove effective abort, and seal invokes abort before deallocation notification and lifetime-zero release.
+- [ ] Exactly one seal emits exactly one lifetime-zero Refresh, workers never self-join, caller `Close` remains the join point, and terminal result precedence is unchanged.
+- [ ] Permission-refresh success/failure, fresh/ready ChannelBind-400 disposition, ordinary Refresh/438 behavior, invalid-relayed cleanup, and fixed timer cadence match the finite preservation table.
+- [ ] Public API, caller-owned socket behavior, prepared-only writes, and normalized TURN request attributes/order remain unchanged.
+
+## Validation Gates
+
+Run constructor/abort-order, ordinary Refresh/438, terminal-state, permission-refresh, fresh/ready ChannelBind-400, invalid-relayed-address, and close-race tests first; then `go test ./...`, `go test -race ./...`, and `task preflight` against the exact candidate head/base. Request `ci-certify` only after local certification and verify the resulting same-head `ci-required` status before merge.
+
+## Operating Discipline
+
+Follow the shared review-loop and contract-closure baselines supplied by `$implement-architecture-slice`, composed with the repository-specific CI-label override in the program index: this repository uses `ci-certify`, not the shared default `ci:certify`. Preserve caller-owned socket, one-seal/one-release, worker-safe seal/caller join, prepared-only writes, fixed supported timer cadence, and exact-wire invariants. Diagnose failures before reruns. Stop rather than widening into adaptive scheduling, nonconforming-server behavior, a generic time module, prepared-peer extraction, Client terminality, or authenticated exchange.

--- a/docs/adr/2026-08-17-architecture-deepening-program.md
+++ b/docs/adr/2026-08-17-architecture-deepening-program.md
@@ -1,0 +1,40 @@
+# TURN Architecture Deepening Program — 2026-08-17
+
+**Status:** Accepted; tracks not yet implemented; all four slices independently audited
+
+## What this is
+
+This program packages the post-M1 architecture review and delegated grilling of `the-sarge/turn`. The three current track plans are the normative source of truth for outcomes, boundaries, ownership, evidence, blockers, and stop conditions. GitHub issues and the OmniFocus mirror carry stable identities, current state, and pointers only. This program is separate from the existing TURN fork molding program's profile-gated packet-path Track 3 and does not open that performance track.
+
+## Outcomes that require no implementation
+
+- Do not create a generic authenticated TURN exchange module now. The repetition is real, but Allocate, Refresh, CreatePermission, and ChannelBind have distinct challenge, retry, success, and Allocation-lifecycle policies; a policy-flag/callback interface would be shallow. Only typed ChannelBind error consistency is accepted now; re-audit residual duplication after Tracks 1 and 2.
+- Do not extract prepared-peer orchestration from `UDPConn`. The public `Allocation` module already hides permission sharing, channel binding, prepared-only admission, inbound lookup, refresh, seal, and worker join; a second internal owner would expose a wide interface and split lifecycle ownership. Revisit only if a second production consumer or a smaller evidence-backed seam appears.
+- Preserve Client close as abort-current and idempotent; do not make Client permanently terminal or move Allocation release/join ownership into it without a new behavior decision.
+- Keep root `Allocation`, canonical address handling, `turntest`, terminal `startClose`/`Close`, and `internal/proto` in their accepted shapes. Do not merge `internal/client` into root, absorb wiremux's composite, restore Send indications, trim protocol codecs, or optimize the packet path without the production profiles required by the existing molding program.
+- Dead helpers are removed only inside a slice whose new owner makes them obsolete. Permission test helpers, broad responder consolidation, `errFake` relocation, and other cleanup not named in a slice are deferred rather than turned into a horizontal cleanup PR.
+- Do not add adaptive Allocation refresh in this program. The shipped client omits Allocate LIFETIME, so its conforming path starts with RFC 8656's 600-second default and later requests that same grant. A varying-grant contract would require an explicit wire change or nonconforming-server support decision and was closed without code.
+- No new domain term is required: Allocation, transaction, permission, channel binding, prepared peer, and terminal cause remain the program vocabulary established by the M1 plans and ADRs.
+
+## Tracks, dependencies, and frontier
+
+| # | Track | Plan | Parent issue | Blocked by | Slices | Status |
+|---|---|---|---|---|---|---|
+| 1 | Transaction registry deepening | [plan](2026-08-17-transaction-registry-plan.md) | pending | None | 1 | FRONTIER after publication; recommended starter; M-L |
+| 2 | Allocation lifecycle deepening | [plan](2026-08-17-allocation-lifecycle-plan.md) | pending | None | 1 | FRONTIER after publication; T2.S1 M-L |
+| 3 | TURN consistency and bounded state | [plan](2026-08-17-turn-consistency-plan.md) | pending | None | 2 | FRONTIER after publication; T3.S1 S and T3.S2 S-M |
+
+There are no genuine slice-level blocking edges. The current abort-current adapter is already sufficient for T2.S1, and Track 1 later changes its implementation owner without changing the Allocation-side capability. Likely text conflicts between independently implemented tracks require rebasing, not artificial blockers.
+
+Parallel-safe frontier after plan publication: T1.S1, T2.S1, T3.S1, and T3.S2. T1.S1 and T2.S1 both touch root/internal construction but are behaviorally independent; T3.S1 and T3.S2 touch nearby `udp_conn.go` regions but have separate owners. Ordinary rebase handles text conflicts. Recommended dispatch is T1.S1 first because it fixes a confirmed stranded-registration path and leaves the deepest common dependency in its final shape; the other frontier slices may run in parallel in separate fresh contexts.
+
+## Rules that bind every track
+
+- Plan docs are normative. One audited slice maps to exactly one child issue, one intended PR, one fresh implementation context, and one OmniFocus slice task.
+- Public API and emitted Allocate, Refresh, CreatePermission, ChannelBind, and ChannelData bytes/order remain unchanged. The accepted changes are transaction rollback/duplicate rejection/ownership, mandatory Allocation abort wiring with one lifecycle owner, typed ChannelBind error reachability, and explicit channel-number exhaustion.
+- The caller owns `ClientConfig.Conn`; the fork never closes it, sets deadlines, or interrupts in-flight I/O. Late transaction writes remain accepted and must not re-arm after ownership loss.
+- Writes remain prepared-only ChannelData. Permission identity remains per canonical peer IP; channel binding identity remains per canonical peer transport address. Send indications do not return.
+- Allocation terminal state has one owner on `UDPConn`: worker-safe seal, exactly one lifetime-zero release, one terminal cause, and caller join. Invalid relayed addresses still construct and close an Allocation before rejection so the server resource is released.
+- Shared review-loop and contract-closure baselines govern every slice with one explicit repository override: replace the shared default certification label `ci:certify` with this repository's implemented one-shot label `ci-certify`, as defined by `.github/workflows/ci.yml`; all other review-loop semantics remain unchanged. Each PR uses TDD-shaped focused evidence, at most one guard mutation per named owner, one fresh review plus at most one replacement, exact-head `task preflight`, same-head PR-associated `ci-certify`/`ci-required`, merge, `append-dev-journal`, then OmniFocus completion.
+- Representation and artifact gates in each plan are ceilings as well as floors. Do not broaden supported protocol syntax, external-service behavior, timing matrices, cleanup, or verification aids during review. Diagnose failures before reruns and stop for a decision when a slice's owner, representation, outcome, or one-PR shape must change.
+- The existing TURN fork molding program and its tracking issue remain authoritative for M0/M1/M2 status, versioning, release tags, and the profile-gated packet-path track. This architecture program adds no release tag or consumer adoption event.

--- a/docs/adr/2026-08-17-transaction-registry-plan.md
+++ b/docs/adr/2026-08-17-transaction-registry-plan.md
@@ -1,0 +1,121 @@
+# Transaction Registry Deepening Implementation Plan
+
+**Date:** 2026-08-17
+**Status:** Accepted; not implemented
+**Track:** 1 of 3 in the 2026-08-17 architecture deepening program
+**Depends on:** Nothing — safe to start first
+**Related:** [Program index](2026-08-17-architecture-deepening-program.md), [Modernize the kept API plan](2026-08-15-modernize-kept-api-plan.md), [TURN molding program](2026-08-14-turn-molding-program.md)
+**Normative scope:** Current outcome, boundaries, invariants, acceptance evidence, blockers, and stop conditions
+**Audit history:** Independently audited against `e251b6b` on 2026-08-17; the slice passed after its initial-send, fire-and-forget, Client-close, socket-authority, and evidence contracts were closed; no implementation or overlapping open issue/PR exists
+
+## Goal
+
+Turn the current shallow `Transaction` plus `TransactionMap` pair into one deep transaction registry whose small internal interface owns each TURN transaction from registration through retirement. The registry concentrates registration, initial-send rollback, retry scheduling, one-winner terminal claims, response publication, waiter cancellation, Allocation abort, Client close, and removal. Root `Client` keeps protocol-method policy and caller-owned socket authority; callers stop composing the registry's concurrency protocol.
+
+## Current Shape (verified 2026-08-17 at `e251b6b`)
+
+`Client` exposes both `trMap` and a separate `mutexTrMap` (`client.go:58-72`). `startTransaction` constructs and inserts a transaction, then performs the initial socket write and arms its timer (`client.go:358-385`). A failed initial write returns after insertion without deleting or closing the transaction and without arming a timer (`client.go:376-380`), leaving a stranded registry entry until a later global close.
+
+The rest of the ownership protocol is spread across root callers: ordinary waits (`client.go:388-408`), Allocate-specific cancellation arbitration (`client.go:410-464`), inbound completion (`client.go:546-573`), Client close and Allocation abort (`client.go:173-190`), and retransmission/exhaustion (`client.go:600-648`). Callers rely on an incomplete convention: most terminal claims use map membership while holding `mutexTrMap`, but initial registration at `client.go:376` occurs outside that outer lock, and `CloseAndDeleteAll` removes/closes entries without stopping their timers first. Socket I/O must remain outside the ownership lock; only a successful claimant may publish or close; timer callbacks and completed writes must discover lost ownership and avoid re-arming. Neither current type enforces the full protocol.
+
+The internal module exposes the mechanics instead of the policy: raw message/destination fields, result channels, timer start/stop, retry counters, close, and independent map insert/find/delete/close operations (`internal/client/transaction.go:18-219`). The map has its own lock in addition to `Client.mutexTrMap`, so correctness depends on a caller convention that neither type can enforce. Root tests insert map entries and inspect map size to exercise inbound handling (`client_test.go:77-114`), while the difficult invariants are tested above the seam through cancellation and blocked-write races (`allocate_ctx_test.go:241-548`).
+
+All production transaction calls target the one canonical TURN server held by `Client` (`client.go:214,253,392`; `internal/client/allocation.go:98`; `internal/client/udp_conn.go:583,774`). Destination string comparison in `TransactionMap.CloseAndDeleteAllTo` (`internal/client/transaction.go:197-213`) therefore does not represent an independent multi-destination domain for the one-server, one-live-Allocation Client. `Client.Close` currently aborts transactions present at the time of the call and is idempotent; it does not make the Client permanently terminal (`client.go:173-180`). M1 preserves abort-all and idempotence but does not promise future transaction support explicitly. This plan deliberately preserves the current nonterminal behavior and pins it with a post-Close transaction test, while also preserving M1's caller-owned socket rule (`2026-08-15-modernize-kept-api-plan.md:135-169`).
+
+## Decision
+
+One private transaction registry owns the live transaction set and every transition that changes ownership. A live transaction is identified by the STUN transaction ID produced and parsed by `pion/stun`; duplicate registration of an already-live ID is rejected rather than overwriting the owner. The registry copies outbound bytes at registration and sends only through an injected send-only capability. It never receives `net.PacketConn`, so closing the socket, setting deadlines, changing read behavior, and interrupting in-flight writes are structurally outside its authority.
+
+The registry exposes behavior-shaped operations to root `Client`: begin a waited or fire-and-forget transaction, complete a matching inbound response, wait with the caller-specific cancellation policy, and abort current work. It does not expose raw insert/find/delete, result-channel writes, timer controls, or retry counters. Exact interface spelling is implementation-local; the acceptance contract is the ownership behavior, not a preselected Go type signature.
+
+The registry's mutex is the sole linearization owner for registration and terminal claims. Its finite phases are registered, initial-send-in-flight, waiting, retry-write-in-flight, claimed, and retired. A claimant removes the transaction before publishing a result or closing a waiter. Initial and retransmit socket writes occur outside that lock. After either unlocked write returns, the registry re-checks ownership under the same claim guard before publishing an error, arming, or re-arming. If an initial send succeeds after a response or abort already claimed the entry, that claimant wins and no timer is armed. If an initial send fails, the send error remains the begin caller's result even when abort raced; the registry only rolls back if it still owns the entry. Late responses and completed writes for removed transactions are discarded without blocking.
+
+Allocate's context may cancel its private transaction. `PreparePeer` cancellation remains waiter-local and does not cancel shared CreatePermission or ChannelBind work; Allocation sealing uses the registry's abort-current operation to stop all current Allocation work. The lifetime-zero release starts only after that abort and is a new fire-and-forget transaction outside the aborted set. Abort-current is an atomic snapshot cut: begins linearized before the cut are claimed, while begins linearized after it survive. `Client.Close` uses that operation but does not set a permanent closed flag.
+
+Root `Client` owns the caller's `net.PacketConn` and adapts only its write capability into the registry; scripted, failing, and blocking send functions are local test adapters. The registry forwards its copied raw request bytes unchanged on the initial write and every retry. Retransmission interval, cap, count, order, and accepted late-write behavior remain unchanged.
+
+**Rejected alternative (do not do this):** Move only retransmission into `Transaction` while leaving registration, claims, cancellation, inbound completion, and abort in root callers. That preserves the shallow ownership protocol and adds another callback crossing.
+
+**Rejected alternative (do not do this):** Make `Client.Close` permanently reject future transactions or directly seal a live Allocation. The accepted contract and sole consumer currently assign release/join ownership to `Allocation.Close`; Client terminality is a separate behavior decision.
+
+**Rejected alternative (do not do this):** Keep destination-scoped abort by comparing `net.Addr.String()`. The supported Client has one canonical server and at most one live Allocation; string identity is weaker than the actual ownership domain.
+
+**Non-goals:** No retransmission-policy change, broad clock abstraction, socket ownership change, STUN/TURN byte change, authenticated-method refactor, root/internal package merge, protocol-codec trimming, or public API change.
+
+## Slice Graph
+
+| Slice | Status/disposition | Delivers | Blocked by | Removes temporary seam |
+|---|---|---|---|---|
+| T1.S1 | New | One transaction registry owns begin, rollback, claims, retry, cancellation, abort, close, and retirement | None | Removes `TransactionMap`, `mutexTrMap`, and caller-composed result/timer operations in the same slice |
+
+## Implementation Slices
+
+### Slice T1.S1 — Make the transaction registry the terminal owner
+
+**What it delivers:** One PR that first pins and fixes initial-send rollback as its tracer bullet, then moves registration, duplicate-ID rejection, inbound completion, retransmission/exhaustion, Allocate cancellation arbitration, fire-and-forget retirement, Allocation abort, and Client close into one private registry. Root `Client` delegates these behaviors and no longer owns `mutexTrMap` or calls raw transaction/map/timer/channel methods. Obsolete `TransactionResult.From`, `TransactionResult.Retries`, `Transaction.Retries`, raw `TransactionMap` methods, and the unreachable wait-on-fire-and-forget error are removed when no production or behavior-level test caller remains.
+
+**Existing-work disposition:** New slice. There is no open issue or PR for this work; the stale local architecture-review branches contain no commits beyond current default-branch history and are not an implementation baseline.
+
+**Blocked by:** None.
+
+**Single owner after merge:** The private transaction registry is the only mutation owner for live-set membership, retry state, terminal claim, result publication/closure, and retirement. Root `Client` owns TURN method policy and delegates; the socket owner remains the external caller.
+
+**Authority completeness:** No persisted fact becomes authoritative. For the in-memory live-set authority, the same slice covers construction, duplicate validation, every producer/closer, and final removal. No raw generic mutation path remains.
+
+**Transitional-seam budget:** None. The first tracer-bullet commit may temporarily fix rollback in `startTransaction`, but the intended PR cannot merge until the registry owns the whole protocol and the raw map/caller-lock seam is removed.
+
+**Blast radius:** Concurrency and ordering across all TURN requests; error delivery for initial/retransmit failures, exhaustion, cancellation, abort, and Client close; root/internal package interaction; tests that currently manipulate `trMap`. Duplicate-ID rejection is a new surfaced internal begin failure instead of silent ownership replacement. Client close remains a nonterminal abort-current snapshot. Destination scoping is removed only because the supported production domain is one canonical server and one live Allocation. Initial writes may race response, abort, or Close; terminal claims may race an in-flight retry. Abort now stops each claimed timer immediately, whereas the old bulk close deleted/closed entries and let callbacks later discover absence. Public API and emitted bytes are unchanged. No performance claim is accepted. Security posture is unchanged. Untraced effects are not accepted: if any producer, closer, timer callback, or map mutation exists outside the registry after migration, stop before merge.
+
+**Artifact classification:** Registry behavior and its ownership guards are shipped behavior and required safety enforcement. Race tests, scripted/failing/blocking socket adapters, and the optional single guard mutation are verification aids. This plan, issue pointers, review receipts, and OmniFocus tasks are process or traceability metadata. No verification aid becomes a maintained product deliverable.
+
+**Representation contract:** Supported domain = outbound STUN messages built by this client with `pion/stun` transaction IDs; admitted inbound STUN success/error responses from the canonical server; real-time retry callbacks; Allocate cancellation; Allocation abort; Client close; initial/retransmit send failure; and the fire-and-forget lifetime-zero release. `pion/stun` owns message and transaction-ID parsing; the registry owns the copied raw bytes, live-ID set, and finite phases. The ownership guarantee is universal over the finite state/event matrix below, not over arbitrary STUN syntax or hostile send implementations. Socket authority is structural: the registry receives only a send capability. Byte preservation is universal over each supplied raw `[]byte`: every successful initial/retry call receives an equal copy; method-level turntest flows are examples because builders remain outside this slice. Public-API preservation is finite over the exported root identifier/signature manifest and compiler checks, not an inference from runtime tests. Terminating evidence = the matrix, focused behavior tests, static implementation/export audit, `go test -race ./...`, and one review plus at most one replacement.
+
+**Contract closure:** Triggered because violating one-winner ownership can panic on send/close, strand waiters, leak live entries, or re-arm canceled work, and the invariant is reached independently through response, cancellation, timeout, socket error, Allocation abort, and Client close.
+
+| Semantic class | Expected disposition | Enforcement owner | Terminating evidence | Status |
+|---|---|---|---|---|
+| Initial send succeeds while registry still owns entry | Transition to waiting and arm exactly one timer; waiter or fire-and-forget path returned | Registry begin | Focused begin test plus existing request tests | Planned |
+| Initial send succeeds after matching response claimed | Response wins; no timer is armed; waiter observes response | Registry begin/completion claim | Blocked-initial-write response race | Planned |
+| Initial send succeeds after abort or Client close claimed | Abort wins; no timer is armed; waiter observes closed semantics | Registry begin/abort claim | Blocked-initial-write abort/Close race | Planned |
+| Initial send fails without competing claim | Registration rolled back; original send error returned; no timer/live entry | Registry begin | New failing-send regression | Planned |
+| Initial send fails after abort or Client close claimed | Send error remains begin caller result; no timer/live entry; abort has already woken any registered waiter | Registry begin/abort claim | Blocked-initial-write error race | Planned |
+| Duplicate live transaction ID | Second registration rejected; original owner preserved | Registry begin | Focused duplicate-ID test | Planned |
+| Matching response claims first | Timer retired, entry removed, exactly one response published | Registry completion | Inbound response test through `Client.HandleInbound` | Planned |
+| Allocate cancellation claims first | Timer retired, entry removed/closed, cancellation cause returned | Registry cancel claim | Existing Allocate cancellation table adapted to registry seam | Planned |
+| Response/close claims before cancellation | Waiter consumes the already-owned result; response or close precedence preserved | Registry claim plus wait | Existing response-wins and close-vs-cancel tests | Planned |
+| Retry fires below exhaustion | Socket write occurs unlocked; re-arm only if ownership remains after write | Registry retry | Existing blocked-retransmit test plus ownership re-check assertion | Planned |
+| Response or close claims during retry write | Claim wins; returned write cannot publish or re-arm | Registry completion/abort plus retry guard | Blocked-retransmit response/close cases | Planned |
+| Waited retransmit write fails or budget exhausts | Entry claimed once; typed failure published; no re-arm; exhaustion occurs after seven total identical writes (initial plus six retries) | Registry retry | Focused waited failure/exhaustion cases with byte/count assertions | Planned |
+| Fire-and-forget matching response | Entry retires without publication or blocked sender | Registry completion | Focused release-response retirement case | Planned |
+| Fire-and-forget write failure or exhaustion | Entry retires without publication, re-arm, or leak | Registry retry | Focused release failure/exhaustion retirement case | Planned |
+| Allocation abort or Client close claims live work | All transactions registered before the atomic cut wake with closed semantics and their timers stop | Registry abort-current | Existing close/abort tests under race detector | Planned |
+| Root transaction begins after Client close cut | New request survives and completes through `Client.HandleInbound` because Client close is deliberately nonterminal | Root `Client` delegation plus registry begin | `Client.performTransaction` or `Client.Allocate` after `Client.Close` | Planned |
+| Late response after any retirement | Response is discarded without publication or blocked sender | Registry completion | Focused late-response case | Planned |
+
+**Evidence budget:** One initial-write table covering ordinary success/failure and response/abort/Close races; one duplicate-ID case; one inbound success case through the real Client seam; the existing Allocate cancellation table covering pre-send, both waits, response-wins, and close precedence; one blocked retransmit response/close table; one waited retransmit failure/exhaustion table asserting seven total byte-identical writes; one fire-and-forget response-retirement case; one fire-and-forget failure/exhaustion-retirement case; one root `Client` request after `Client.Close`, completed through `HandleInbound`; one late-response discard case; existing Allocation abort/close coverage; full race suite. Preserve the existing interval constants, exponential progression, and cap mechanically; finite diff inspection of that arithmetic is the gate, with no wall-clock repetition or broad clock abstraction. At most one mutation is permitted if initial and retry completion share one ownership guard: remove that guard and observe both blocked-write classes fail. If the implementation has separate guards, omit mutation rather than expanding the budget. No fuzz, platform matrix beyond repository preflight, or repeated timing run is required. The task terminates after these cases, repository preflight, hosted same-head CI, one review, and at most one replacement review are green with no `stop-for-decision` finding.
+
+**TDD and preservation evidence:** Write the initial-send table and duplicate-ID tests first. Adapt inbound tests to create work through the registry/Client begin path instead of inserting map entries. Preserve existing assertions for cancellation cause, close precedence, late success, and no socket-control authority. Add exact seven-write exhaustion, supplied-byte equality, both fire-and-forget terminal paths, and a root post-Close request completed through `HandleInbound`; existing tests do not establish those claims. Keep retry interval/cap arithmetic mechanically unchanged and audit its diff. Builders and setter order stay outside this slice, while existing turntest flows provide example-level method preservation.
+
+**Dispatch context budget:** This slice contract; the Decision and contract-closure matrix above; `client.go:57-80,133-190,214,253,358-464,546-648`; `internal/client/transaction.go`; `internal/client/allocation.go:18-46,98`; `internal/client/udp_conn.go:474-520,583,774`; `allocate_ctx_test.go:24-548`; `client_test.go:61-114`; `close_latency_test.go:22-140`; `internal/client/transaction_test.go`; and M1's transaction ownership/socket rules at `2026-08-15-modernize-kept-api-plan.md:135-169`. No earlier architecture report or full M1 chronology is required. The bounded surface is two implementation files plus consumers and focused preservation tests; implementation, one review-fix pass, and exact-head verification fit one fresh context.
+
+**Slice decision audit:** Strongest further split = ship the initial-write rollback as a separate PR. Rejected because it is one TDD step in the same begin path and would leave the shallow ownership protocol intact while adding a second review/merge cycle; the full migration remains context-sized and cannot leave two owners at merge. Strongest adjacent merge = combine with Allocation lifecycle consolidation. Rejected because the registry and Allocation are separate mutation owners with different failure/state matrices, the combined context would be too broad, and Allocation can consume the merged registry through a stable internal operation. No blocking edge exists because this slice owns only current transaction behavior.
+
+**Stop conditions:** A supported producer or closer cannot be routed through one registry without changing public behavior; the registry would need to hold its mutex across caller socket I/O; preserving Client-close semantics requires a permanent closed flag; Allocate cancellation would have to cancel shared PreparePeer work; the lifetime-zero release cannot start outside the aborted set; exact retransmission bytes/order/count change; or a second behaviorally distinct counterexample appears at the same one-winner invariant and registry enforcement owner after an accepted fix.
+
+## Acceptance Criteria
+
+- [ ] Every supported transaction terminal event has exactly one registry claim owner, and no result is published or channel closed after another actor owns removal. Supported domain, owner, universal guarantee, and terminating evidence are the representation contract and matrix above.
+- [ ] An initial socket-write failure leaves no live transaction and no armed timer while returning the original error.
+- [ ] Socket writes occur outside the registry ownership lock, and a removed transaction never publishes or re-arms after an in-flight write returns.
+- [ ] Allocate cancellation, response-wins, close precedence, Allocation abort, Client close, and fire-and-forget release preserve their accepted observable outcomes.
+- [ ] The registry receives only a send capability, so it cannot close, deadline, read from, or interrupt the caller-owned socket.
+- [ ] `Client.mutexTrMap`, raw caller mutation of `TransactionMap`, destination-string abort matching, and dead retry/from result surface are absent.
+- [ ] The finite exported root API manifest is unchanged, and the registry forwards an equal copy of every supplied raw request on the initial write and all six retries; method-level turntest flows remain green.
+
+## Validation Gates
+
+Run focused transaction, inbound, cancellation, late-response, blocked-retransmit, and Allocation-close tests first; then `go test ./...`, `go test -race ./...`, and repository `task preflight` against the exact candidate head/base. Request the repository's one-shot `ci-certify` PR label only after local certification and verify the resulting `pull_request`/`labeled` run reports `ci-required` for the same head before merge.
+
+## Operating Discipline
+
+Follow the shared review-loop and contract-closure baselines supplied by `$implement-architecture-slice` for this PR, composed with the repository-specific CI-label override in the program index: this repository uses `ci-certify`, not the shared default `ci:certify`. Preserve the caller-owned socket, prepared-only write, exact-wire, one-winner, and Allocation-before-Client lifecycle invariants. Diagnose any race or hosted-CI failure before rerunning. Stop rather than widening into Client terminality, retransmission policy, authenticated exchange, or Allocation lifecycle implementation.

--- a/docs/adr/2026-08-17-turn-consistency-plan.md
+++ b/docs/adr/2026-08-17-turn-consistency-plan.md
@@ -1,0 +1,130 @@
+# TURN Consistency and Bounded-State Implementation Plan
+
+**Date:** 2026-08-17
+**Status:** Accepted; not implemented
+**Track:** 3 of 3 in the 2026-08-17 architecture deepening program
+**Depends on:** Nothing; both slices are independent of Tracks 1 and 2 and of each other
+**Related:** [Program index](2026-08-17-architecture-deepening-program.md), [Modernize the kept API plan](2026-08-15-modernize-kept-api-plan.md), [Prepared-only writes ADR](2026-08-15-prepared-only-writes.md)
+**Normative scope:** Current outcome, boundaries, invariants, acceptance evidence, blockers, and stop conditions
+**Audit history:** Independently audited against `e251b6b` on 2026-08-17; both slices passed after typed-error recovery/exhaustion and concurrent final-channel capacity contracts were closed; no implementation or overlapping open issue/PR exists
+
+## Goal
+
+Ship the two narrow correctness/consistency outcomes that survived grilling without inventing the rejected authenticated-exchange or prepared-peer modules: preserve typed TURN server errors through ChannelBind's existing policy, and make the finite channel-number space fail explicitly rather than silently overwriting a live binding. Contract the binding manager's dead test-only mutation surface while establishing the capacity owner.
+
+## Current Shape (verified 2026-08-17 at `e251b6b`)
+
+Allocate, Refresh, and CreatePermission convert a well-formed non-438 TURN error response to `*stun.TurnError` (`client.go:192-283`; `internal/client/allocation.go:107-125`; `internal/client/udp_conn.go:588-607`). ChannelBind instead formats most codes into untyped errors; 400 is wrapped with `errChannelBindBadRequest`, other codes only with `errCannotBindChannel`, and 438 updates nonce and returns the retry sentinel (`internal/client/udp_conn.go:756-803`). This violates M1's accepted failure-as-values direction for a supported TURN request, but the four request paths have different challenge, retry, success, and Allocation-lifecycle policies.
+
+Channel numbers are the inclusive range `0x4000` through `0x7fff`, which contains 16,384 values; the source comment says 16,383 (`internal/client/binding.go:13-20`). `bindingManager.assignChannelNumber` wraps to the minimum after the maximum, and `getOrCreate` then overwrites `chanMap[number]` while retaining the old peer in `addrMap` (`internal/client/binding.go:112-164`). On the 16,385th distinct binding, inbound channel lookup can therefore resolve to a different peer than an older prepared binding. No production path deletes bindings during an Allocation, so silent reuse is not a lease/reclamation policy.
+
+The binding manager also exposes helpers used only by internal tests: `create`, `deleteByAddr`, `deleteByNumber`, and `size`; `binding.mgr` is assigned but never read (`internal/client/binding.go:34-45,139-141,184-219`; usage census at this commit). Those helpers encourage tests to validate a generic map rather than the live get-or-create, lookup, iteration, preparation, and write behavior.
+
+## Decision
+
+Keep authenticated request construction and method-specific policy explicit. For ChannelBind only, the classifier-created error for every well-formed non-438 server response carries a `*stun.TurnError` in its error chain. Code 400 additionally remains recognizable as `errChannelBindBadRequest`: a previously confirmed binding intentionally consumes that error and recovers with nil, while a fresh binding exposes the typed error through its binding and Allocation terminal chains. Code 438 remains the nonce-update/retry signal and is never converted to `*stun.TurnError` in this slice, including when the existing retry owner exhausts its attempts. Malformed error responses preserve the existing unexpected-response failure class.
+
+Make `bindingManager` the sole channel-number capacity owner. Existing peers always receive their existing binding. A new distinct peer receives one of the 16,384 channel numbers exactly once. On a live Allocation whose permission phase succeeds, when all numbers are assigned, another distinct peer fails without overwriting either map and without starting a ChannelBind request; `PreparePeer` returns an error satisfying public `ErrChannelBindFailed`. Permission rejection, cancellation, or Allocation closure may terminate earlier with their existing outcomes. A permission may already have been created because the accepted operation order is permission then binding; changing that order or reclaiming bindings is outside this slice.
+
+Delete `binding.mgr` and the dead test-only `create`, delete, and size methods in the capacity slice; adapt tests to the same live get-or-create/lookup/all seam used by production or to public `PreparePeer`/`WriteTo` behavior. Do not delete live state behavior or broad test scenarios. The per-IP Permission and per-transport-address channel binding remain distinct domain facts.
+
+**Rejected alternative (do not do this):** Build a generic authenticated-exchange module now. It would need request setters, success parsers, retry switches, and lifecycle callbacks for four materially different policies; repetition alone does not justify that shallow interface. Re-audit after Tracks 1 and 2, and extract only if a small policy-free core remains.
+
+**Rejected alternative (do not do this):** Extract a prepared-peer orchestration object. `Allocation`/`UDPConn` already provide the deep public module; a second owner would require a wide internal interface spanning preparation, write admission, refresh, inbound lookup, seal, and worker join.
+
+**Rejected alternative (do not do this):** Reclaim or reuse channel numbers. No binding expiry/reclamation lifecycle is accepted, and reuse can violate the server's channel/peer association. Explicit exhaustion is the safe bounded behavior.
+
+**Non-goals:** No authenticated Allocate 438 retry; no setter-order or wire-byte change; no retry-policy change; no public error addition for channel exhaustion; no Permission identity change; no binding reclamation; no Send indication; no prepared-peer module or file-move-only refactor; no deletion of `internal/proto`; no broad test-harness rewrite.
+
+## Slice Graph
+
+| Slice | Status/disposition | Delivers | Blocked by | Removes temporary seam |
+|---|---|---|---|---|
+| T3.S1 | New | ChannelBind preserves typed TURN errors while existing 438/400 policy stays local | None | n/a |
+| T3.S2 | New | Channel-number allocation is bounded and binding manager mutation surface contracts | None | Removes dead binding manager test-only mutation methods in this slice |
+
+T3.S1 and T3.S2 are parallel-safe in behavior and have no genuine blocking edge. They touch nearby `udp_conn.go` regions, so the second branch may need an ordinary rebase after the first merges; a likely text conflict is not an architectural dependency.
+
+## Implementation Slices
+
+### Slice T3.S1 — Preserve typed TURN errors through ChannelBind policy
+
+**What it delivers:** One PR changing ChannelBind error classification so the classifier-created error for every well-formed non-438 response contributes a `*stun.TurnError`. Code 400 also preserves `errCannotBindChannel` and `errChannelBindBadRequest`; a fresh/unknown binding exposes that error through its failure/terminal chain, while the existing previously-ready recovery intentionally consumes it and returns nil. Code 438 still updates nonce and returns `errTryAgain`, including after retry exhaustion; success and malformed-response behavior remain unchanged. Setter order and emitted bytes do not change.
+
+**Existing-work disposition:** New slice.
+
+**Blocked by:** None.
+
+**Single owner after merge:** `handleChannelBindErrorResponse` owns protocol-code classification; `handleBindChannelError` remains the single binding/Allocation disposition owner. No generic exchange owner is introduced.
+
+**Authority completeness:** No persisted or durable fact becomes authoritative. The same slice covers every caller of ChannelBind response classification and the only consumers of the 400 sentinel.
+
+**Transitional-seam budget:** None. Other authenticated request paths remain explicit by accepted decision, not as a temporary adapter.
+
+**Blast radius:** Error chains returned by `PreparePeer`, recorded on failed bindings, and recorded as terminal cause for a fresh ChannelBind 400. `errors.Is` behavior for existing sentinels and 400 recovery/seal is preserved; direct classifier errors and externally visible fresh/unknown failures gain `errors.As(*stun.TurnError)`. Previously-ready 400 still returns nil after recovery. Retry counts, exhausted-438 disposition, nonce update, state transitions, public symbols, and wire bytes remain unchanged. Untraced effects are not accepted.
+
+**Artifact classification:** Typed error propagation and 400 policy guards are shipped behavior and required lifecycle enforcement. Response-table and wire-capture tests are verification aids. Plans/issues/tasks are process metadata.
+
+**Representation contract:** Supported domain = STUN success responses and error responses whose ERROR-CODE is well formed with codes 438, 400, or another code, plus malformed error responses, for messages returned by the transaction layer to ChannelBind; binding disposition additionally distinguishes fresh/unknown from previously-ready state. `pion/stun` owns message and ERROR-CODE parsing; `handleChannelBindErrorResponse` owns classification; `handleBindChannelError` owns lifecycle disposition. Guarantee = universal over this finite response-class/code/state table, not arbitrary STUN syntax. Terminating evidence = one case per table row, direct classifier assertions, existing recovery/seal tests, exact request-byte capture, race suite, preflight, and bounded review.
+
+**Contract closure:** Not triggered. The error table is finite, has one classifier and one disposition owner, and ordinary focused tests cover every behaviorally distinct class.
+
+**Evidence budget:** Direct classifier cases for 438 with nonce, 400, representative non-400/non-438 error, and malformed ERROR-CODE; assert the classifier's 400 error has `errors.As(*stun.TurnError)` and both existing `errors.Is` sentinels, while 438 remains only the retry sentinel. Real flow cases cover success, fresh-binding 400 with terminal-chain `errors.As`, previously-ready 400 returning nil and recovering, representative non-400/non-438 failure with `errors.As`, and three consecutive 438 responses preserving the existing exhausted-retry disposition without a typed error. Assert unchanged retry count/nonce and exact ChannelBind request bytes. Full race and preflight. No mutation required. Termination = listed cases, same-head hosted CI, one review, at most one replacement, and no `stop-for-decision` finding.
+
+**TDD and preservation evidence:** Add failing `errors.As` assertions to representative 400 and server-error tests first. Keep the existing fresh/ready 400 outcomes green. Capture setters/bytes before changing classification to prove response-side work did not alter the request.
+
+**Dispatch context budget:** This slice contract; `internal/client/udp_conn.go:667-803`; existing ChannelBind tests in `udp_conn_test.go` and `prepare_test.go`; Refresh/CreatePermission typed-error implementations as references only; and M1 failure-as-values/ChannelBind-400 rules. The change is one classifier plus focused tests and fits a small fresh context.
+
+**Slice decision audit:** Strongest further split = typed generic errors and 400 dual-classification in separate PRs. Rejected because 400 is one row of the same finite classifier and splitting would temporarily make one well-formed code inconsistent. Strongest merge = combine with T3.S2. Rejected because response error identity and channel-number capacity have different owners, representations, and evidence; both are independently green. No blocker is required.
+
+**Stop conditions:** A typed error cannot coexist with existing 400 `errors.Is` behavior; adding it changes the prepared-binding recovery or fresh-binding seal outcome; request bytes/setter order change; or uniform typed behavior would require adding authenticated Allocate 438 retry or a generic exchange interface.
+
+### Slice T3.S2 — Bound channel-number allocation and contract the binding manager
+
+**What it delivers:** One PR correcting the range count to 16,384; changing new-binding allocation to return explicit exhaustion instead of wrapping/overwriting; propagating exhaustion after a successful permission phase from `PreparePeer` as `ErrChannelBindFailed` without starting ChannelBind; preserving existing-peer lookup even at capacity; deleting unread `binding.mgr` and test-only `create`, `deleteByAddr`, `deleteByNumber`, and `size`; and re-anchoring their useful assertions on live get-or-create, bidirectional lookup, `all`, PreparePeer, and prepared-only WriteTo behavior.
+
+**Existing-work disposition:** New slice.
+
+**Blocked by:** None.
+
+**Single owner after merge:** `bindingManager` is the only owner of the channel-number set, capacity check, and address↔number bijection. `PreparePeer` owns operation ordering and surfaces the manager's exhaustion as `ErrChannelBindFailed`.
+
+**Authority completeness:** No persisted fact. The same slice covers the sole constructor for new bindings, capacity validation, both lookup consumers, and every production call site. Generic deletion/reclamation paths are removed rather than left as alternate mutation authority.
+
+**Transitional-seam budget:** None. There is no wraparound compatibility mode, duplicate map representation, or temporary allocator. Permission-before-binding order remains accepted behavior, not a transitional seam.
+
+**Blast radius:** Only the 16,385th distinct peer and later distinct peers change from corrupting map identity to explicit failure; existing peers, ordinary preparation, refresh, inbound ChannelData lookup, and prepared writes remain unchanged. Allocation memory remains bounded to 16,384 bindings. A permission transaction may precede local exhaustion because operation order is preserved. Public API stays the same; no new wire type or dependency. Untraced effects are not accepted.
+
+**Artifact classification:** Capacity enforcement and address↔channel bijection are shipped behavior and required safety enforcement. Boundary, map-integrity, PreparePeer, inbound lookup, and WriteTo tests are verification aids. Plans/issues/tasks are process metadata.
+
+**Representation contract:** Supported domain = canonical peer `netip.AddrPort` values accepted by `Allocation.PreparePeer`; one live Allocation whose permission phase succeeds; channel numbers in the closed integer interval `[0x4000,0x7fff]`; repeated same-peer and distinct-peer requests; inbound lookup by assigned number. Root canonicalization owns peer representation; permission handling owns admission to the binding phase; `bindingManager` owns the bijection and capacity. Guarantee = universal over the finite 16,384-number range and all manager construction paths once permission succeeds, with a canonical-subset guarantee over already-canonical peer addresses. Permission rejection, caller cancellation, and Allocation closure preserve their earlier existing outcomes and are outside the capacity guarantee. Terminating evidence = arithmetic boundary tests, full-range uniqueness/bijection test, existing-peer-at-capacity case, next-distinct exhaustion case with successful permission, production-path no-ChannelBind assertion, focused prepared/inbound preservation, race suite, preflight, and bounded review.
+
+**Contract closure:** Not triggered. The finite range has one constructor and the complete boundary behavior is reasonably covered directly; no multi-owner semantic family remains after dead mutation paths are deleted.
+
+**Evidence budget:** Arithmetic assertion that the inclusive range size is 16,384; allocate 16,384 distinct canonical peers and assert unique numbers plus forward/reverse lookup; repeat an existing peer at capacity and get the same binding; after successful permission, request the 16,385th distinct peer and assert map sizes/bijection unchanged and `ErrChannelBindFailed`; preload 16,383 entries and race two distinct peers for the final slot, asserting exactly one success, one exhaustion, and a 16,384-entry bijection; one PreparePeer harness case with successful permission proving no ChannelBind request after exhaustion; preservation cases for permission rejection/cancellation/closure before binding; existing prepared-only WriteTo and inbound channel lookup cases; full race and preflight. At most one mutation: remove the capacity guard and observe the 16,385th integrity test fail. No reclamation, timing repetitions, fuzzing, or extra platform cells. Termination = listed cases, same-head hosted CI, one review, at most one replacement, and no `stop-for-decision` finding.
+
+**TDD and preservation evidence:** Write the full-range boundary and existing-peer-at-capacity tests first; the next-distinct case must expose current overwrite. Add the PreparePeer no-ChannelBind assertion. Then contract the test-only manager methods and adapt tests without deleting live behavior assertions.
+
+**Dispatch context budget:** This slice contract; `internal/client/binding.go`; `internal/client/binding_test.go`; `internal/client/udp_conn.go:176-390,628-665`; prepared-only/inbound tests in `prepare_test.go`, `udp_conn_test.go`, and root `client_test.go`; and the prepared-only ADR. The bounded change is one in-memory manager plus two production callers and focused tests; it fits one fresh context.
+
+**Slice decision audit:** Strongest further split = capacity guard first, dead-surface deletion second. Rejected because deleting alternate mutation methods establishes the same single constructor and keeps the evidence on the production seam; both changes fit a small context. Strongest merge = combine with T3.S1. Rejected because the two invariants have separate owners and no correctness dependency. No blocking edge is required; likely textual overlap is handled by rebase rather than false serialization.
+
+**Stop conditions:** A supported production path deletes/reclaims bindings; preserving existing peers requires number reuse; capacity cannot be checked atomically with construction; exhaustion would require changing permission-before-binding order or adding public API; or the full-range test cannot distinguish overwrite from legitimate reuse.
+
+## Acceptance Criteria
+
+- [ ] The classifier-created error for every well-formed non-438 ChannelBind response carries a typed `*stun.TurnError`; fresh/unknown failures expose it, while previously-ready 400 recovery intentionally consumes it and returns nil. The finite supported response/code/state domain, owners, universal guarantee, and evidence are declared in T3.S1.
+- [ ] ChannelBind 400 retains existing ready-binding recovery and fresh-binding Allocation seal behavior, and 438 retains nonce retry behavior.
+- [ ] ChannelBind request setters, bytes, and retry counts remain unchanged.
+- [ ] Every live binding in one Allocation has a unique channel number in `[0x4000,0x7fff]`, and both maps remain a bijection; the finite supported peer/range domain, owner, universal/canonical-subset guarantee, and evidence are declared in T3.S2.
+- [ ] An existing peer remains resolvable at capacity; after successful permission, the next distinct peer fails with `ErrChannelBindFailed`, does not overwrite state, and starts no ChannelBind request; permission rejection/cancellation/closure retain their earlier outcomes.
+- [ ] `binding.mgr` and test-only create/delete/size mutation paths are absent; tests retain live behavior coverage through production-shaped seams.
+- [ ] Prepared-only ChannelData, permission-per-IP identity, binding-per-transport-address identity, public API, and caller-owned socket rules remain unchanged.
+
+## Validation Gates
+
+For T3.S1 run the ChannelBind response table, fresh/ready 400 lifecycle tests, request-byte capture, full race, and repository preflight. For T3.S2 run range/bijection/exhaustion tests, PreparePeer no-ChannelBind exhaustion, prepared WriteTo/inbound preservation, full race, and preflight. For each PR request `ci-certify` only after exact-head local certification and verify the resulting same-head `ci-required` status before merge.
+
+## Operating Discipline
+
+Follow the shared review-loop and contract-closure baselines supplied by `$implement-architecture-slice` for every slice/PR, composed with the repository-specific CI-label override in the program index: this repository uses `ci-certify`, not the shared default `ci:certify`. Keep authenticated method policy local, preserve the prepared-only structural invariant and the distinct Permission/channel-binding identities, and diagnose failures before reruns. Stop rather than extracting a generic exchange, prepared-peer module, channel lease/reclamation policy, or broader cleanup batch.


### PR DESCRIPTION
## Outcome

Publishes the audited 2026-08-17 architecture deepening program as four normative plan documents. No implementation is included or dispatched.

## Accepted program

- T1.S1: deepen transaction registry ownership
- T2.S1: consolidate Allocation lifecycle ownership in UDPConn
- T3.S1: preserve typed TURN errors through ChannelBind policy
- T3.S2: bound channel-number allocation and contract the binding manager

Adaptive refresh, a generic authenticated exchange, prepared-peer extraction, Client terminality changes, package merging, and protocol trimming were grilled and closed or deferred without code.

## Validation

- Independent slice audits: PASS
- Fresh whole-package audit: PASS
- `task preflight BASE_REF=origin/main`: PASS at `4b134e7935dfa7896396cb08ffdfce19ba7ad5c3`

After this docs-only PR merges, child issues and the OmniFocus mirror will point to the verified immutable plan commit on `main`.