### PR TITLE
T3.S1: Preserve typed TURN errors through ChannelBind policy

### DIFF
--- a/docs/adr/2026-08-17-architecture-deepening-program.md
+++ b/docs/adr/2026-08-17-architecture-deepening-program.md
@@ -1,6 +1,6 @@
 # TURN Architecture Deepening Program — 2026-08-17
 
-**Status:** Accepted; Tracks 1 and 2 implemented by PRs #49 and #51; two independently audited slices remain on the frontier
+**Status:** Accepted; Tracks 1, 2, and T3.S1 implemented by PRs #49, #51, and #53; T3.S2 remains on the frontier
 
 ## What this is
 
@@ -22,11 +22,11 @@ This program packages the post-M1 architecture review and delegated grilling of 
 |---|---|---|---|---|---|---|
 | 1 | Transaction registry deepening | [plan](2026-08-17-transaction-registry-plan.md) | #41 | None | 1 | COMPLETE via PR #49 |
 | 2 | Allocation lifecycle deepening | [plan](2026-08-17-allocation-lifecycle-plan.md) | #42 | None | 1 | COMPLETE via PR #51 |
-| 3 | TURN consistency and bounded state | [plan](2026-08-17-turn-consistency-plan.md) | pending | None | 2 | FRONTIER after publication; T3.S1 S and T3.S2 S-M |
+| 3 | TURN consistency and bounded state | [plan](2026-08-17-turn-consistency-plan.md) | #43 | None | 2 | T3.S1 COMPLETE via PR #53; T3.S2 FRONTIER |
 
 There are no genuine slice-level blocking edges. Track 1's registry supplies the abort-current capability consumed by the completed T2.S1 without changing its Allocation-side contract. Likely text conflicts between independently implemented tracks require rebasing, not artificial blockers.
 
-Current parallel-safe frontier after PR #51: T3.S1 and T3.S2. T1.S1 and T2.S1 are complete; T3.S1 and T3.S2 touch nearby `udp_conn.go` regions but have separate owners. Ordinary rebase handles text conflicts, and the remaining frontier slices may run in parallel in separate fresh contexts.
+Current frontier after PR #53: T3.S2. T1.S1, T2.S1, and T3.S1 are complete; T3.S2 remains independently dispatchable with no blockers.
 
 ## Rules that bind every track
 

--- a/docs/adr/2026-08-17-turn-consistency-plan.md
+++ b/docs/adr/2026-08-17-turn-consistency-plan.md
@@ -1,12 +1,12 @@
 # TURN Consistency and Bounded-State Implementation Plan
 
 **Date:** 2026-08-17
-**Status:** Accepted; not implemented
+**Status:** Accepted; T3.S1 implemented by PR #53; T3.S2 remains on the frontier
 **Track:** 3 of 3 in the 2026-08-17 architecture deepening program
 **Depends on:** Nothing; both slices are independent of Tracks 1 and 2 and of each other
 **Related:** [Program index](2026-08-17-architecture-deepening-program.md), [Modernize the kept API plan](2026-08-15-modernize-kept-api-plan.md), [Prepared-only writes ADR](2026-08-15-prepared-only-writes.md)
 **Normative scope:** Current outcome, boundaries, invariants, acceptance evidence, blockers, and stop conditions
-**Audit history:** Independently audited against `e251b6b` on 2026-08-17; both slices passed after typed-error recovery/exhaustion and concurrent final-channel capacity contracts were closed; no implementation or overlapping open issue/PR exists
+**Audit history:** Independently audited against `e251b6b` on 2026-08-17; both slices passed after typed-error recovery/exhaustion and concurrent final-channel capacity contracts were closed; T3.S1 implemented by PR #53
 
 ## Goal
 
@@ -40,7 +40,7 @@ Delete `binding.mgr` and the dead test-only `create`, delete, and size methods i
 
 | Slice | Status/disposition | Delivers | Blocked by | Removes temporary seam |
 |---|---|---|---|---|
-| T3.S1 | New | ChannelBind preserves typed TURN errors while existing 438/400 policy stays local | None | n/a |
+| T3.S1 | Complete via PR #53 | ChannelBind preserves typed TURN errors while existing 438/400 policy stays local | None | n/a |
 | T3.S2 | New | Channel-number allocation is bounded and binding manager mutation surface contracts | None | Removes dead binding manager test-only mutation methods in this slice |
 
 T3.S1 and T3.S2 are parallel-safe in behavior and have no genuine blocking edge. They touch nearby `udp_conn.go` regions, so the second branch may need an ordinary rebase after the first merges; a likely text conflict is not an architectural dependency.
@@ -50,6 +50,8 @@ T3.S1 and T3.S2 are parallel-safe in behavior and have no genuine blocking edge.
 ### Slice T3.S1 — Preserve typed TURN errors through ChannelBind policy
 
 **What it delivers:** One PR changing ChannelBind error classification so the classifier-created error for every well-formed non-438 response contributes a `*stun.TurnError`. Code 400 also preserves `errCannotBindChannel` and `errChannelBindBadRequest`; a fresh/unknown binding exposes that error through its failure/terminal chain, while the existing previously-ready recovery intentionally consumes it and returns nil. Code 438 still updates nonce and returns `errTryAgain`, including after retry exhaustion; success and malformed-response behavior remain unchanged. Setter order and emitted bytes do not change.
+
+**Implementation:** PR #53 is the slice's one intended product PR.
 
 **Existing-work disposition:** New slice.
 
@@ -113,9 +115,9 @@ T3.S1 and T3.S2 are parallel-safe in behavior and have no genuine blocking edge.
 
 ## Acceptance Criteria
 
-- [ ] The classifier-created error for every well-formed non-438 ChannelBind response carries a typed `*stun.TurnError`; fresh/unknown failures expose it, while previously-ready 400 recovery intentionally consumes it and returns nil. The finite supported response/code/state domain, owners, universal guarantee, and evidence are declared in T3.S1.
-- [ ] ChannelBind 400 retains existing ready-binding recovery and fresh-binding Allocation seal behavior, and 438 retains nonce retry behavior.
-- [ ] ChannelBind request setters, bytes, and retry counts remain unchanged.
+- [x] The classifier-created error for every well-formed non-438 ChannelBind response carries a typed `*stun.TurnError`; fresh/unknown failures expose it, while previously-ready 400 recovery intentionally consumes it and returns nil. The finite supported response/code/state domain, owners, universal guarantee, and evidence are declared in T3.S1.
+- [x] ChannelBind 400 retains existing ready-binding recovery and fresh-binding Allocation seal behavior, and 438 retains nonce retry behavior.
+- [x] ChannelBind request setters, bytes, and retry counts remain unchanged.
 - [ ] Every live binding in one Allocation has a unique channel number in `[0x4000,0x7fff]`, and both maps remain a bijection; the finite supported peer/range domain, owner, universal/canonical-subset guarantee, and evidence are declared in T3.S2.
 - [ ] An existing peer remains resolvable at capacity; after successful permission, the next distinct peer fails with `ErrChannelBindFailed`, does not overwrite state, and starts no ChannelBind request; permission rejection/cancellation/closure retain their earlier outcomes.
 - [ ] `binding.mgr` and test-only create/delete/size mutation paths are absent; tests retain live behavior coverage through production-shaped seams.

--- a/internal/client/prepare_test.go
+++ b/internal/client/prepare_test.go
@@ -341,6 +341,33 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 		assert.False(t, harness.conn.isClosed())
 	})
 
+	t.Run("server bind rejection surfaces typed TURN error", func(t *testing.T) {
+		harness := newPrepareHarness(t, false)
+
+		mock := harness.mock
+		inner := mock.performTransaction
+		mock.performTransaction = func(msg *stun.Message, to net.Addr, dontWait bool) (TransactionResult, error) {
+			if msg.Type.Method == stun.MethodChannelBind {
+				harness.bindCount.Add(1)
+
+				return TransactionResult{Msg: stun.MustBuild(
+					stun.NewType(stun.MethodChannelBind, stun.ClassErrorResponse),
+					stun.ErrorCodeAttribute{Code: stun.CodeForbidden, Reason: []byte("Forbidden")},
+				)}, nil
+			}
+
+			return inner(msg, to, dontWait)
+		}
+
+		err := harness.conn.PreparePeer(context.Background(), harness.peer)
+		var turnErr *stun.TurnError
+		if assert.ErrorAs(t, err, &turnErr) {
+			assert.Equal(t, stun.CodeForbidden, turnErr.ErrorCodeAttr.Code)
+		}
+		assert.ErrorIs(t, err, errCannotBindChannel)
+		assert.False(t, harness.conn.isClosed())
+	})
+
 	t.Run("close joins in-flight bind workers", func(t *testing.T) {
 		harness := newPrepareHarness(t, true)
 

--- a/internal/client/udp_conn.go
+++ b/internal/client/udp_conn.go
@@ -800,16 +800,24 @@ func (c *UDPConn) handleChannelBindErrorResponse(res *stun.Message) error {
 		return fmt.Errorf("%w: unexpected response type %s", errCannotBindChannel, res.Type) // nolint:err113
 	}
 
-	switch code.Code {
-	case stun.CodeStaleNonce:
+	if code.Code == stun.CodeStaleNonce {
 		c.setNonceFromMsg(res)
 
 		return errTryAgain
-	case stun.CodeBadRequest:
-		return fmt.Errorf("%w: %w: received error %d", errCannotBindChannel, errChannelBindBadRequest, code.Code)
-	default:
-		return fmt.Errorf("%w: received error %d", errCannotBindChannel, code.Code) // nolint:err113
 	}
+
+	turnError := &stun.TurnError{
+		StunMessageType: res.Type,
+		ErrorCodeAttr:   code,
+	}
+	if code.Code == stun.CodeBadRequest {
+		return fmt.Errorf(
+			"%w: %w: received error %d: %w",
+			errCannotBindChannel, errChannelBindBadRequest, code.Code, turnError,
+		)
+	}
+
+	return fmt.Errorf("%w: received error %d: %w", errCannotBindChannel, code.Code, turnError) // nolint:err113
 }
 
 func (c *UDPConn) sendChannelData(data []byte, chNum uint16) (int, error) {

--- a/internal/client/udp_conn_test.go
+++ b/internal/client/udp_conn_test.go
@@ -332,6 +332,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 			expectErr            error
 			expectErrContains    string
 			expectBadRequest     bool
+			expectTurnErrorCode  stun.ErrorCode
 			expectBindingDeleted bool
 			expectNonceChanged   bool
 		}{
@@ -361,8 +362,9 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 
 					return TransactionResult{Msg: res}, nil
 				},
-				expectErr:         errCannotBindChannel,
-				expectErrContains: "received error",
+				expectErr:           errCannotBindChannel,
+				expectErrContains:   "received error",
+				expectTurnErrorCode: stun.CodeForbidden,
 			},
 			{
 				name: "ErrorResponse with CodeBadRequest is detectable",
@@ -374,9 +376,10 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 
 					return TransactionResult{Msg: res}, nil
 				},
-				expectErr:         errCannotBindChannel,
-				expectErrContains: "received error",
-				expectBadRequest:  true,
+				expectErr:           errCannotBindChannel,
+				expectErrContains:   "received error",
+				expectBadRequest:    true,
+				expectTurnErrorCode: stun.CodeBadRequest,
 			},
 			{
 				name: "ErrorResponse without error code returns unexpected response type error",
@@ -410,6 +413,11 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 					assert.ErrorContains(t, err, tt.expectErrContains)
 				}
 				assert.Equal(t, tt.expectBadRequest, errors.Is(err, errChannelBindBadRequest))
+				if tt.expectTurnErrorCode != 0 {
+					var turnErr *stun.TurnError
+					require.ErrorAs(t, err, &turnErr)
+					assert.Equal(t, tt.expectTurnErrorCode, turnErr.ErrorCodeAttr.Code)
+				}
 
 				if tt.expectBindingDeleted {
 					assert.Empty(t, bm.chanMap)
@@ -433,6 +441,26 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 				}
 			})
 		}
+	})
+
+	t.Run("bindChannel exhausts stale nonce retries without a typed TURN error", func(t *testing.T) {
+		bm := newBindingManager()
+		bound := bm.create(netip.MustParseAddrPort("127.0.0.1:1234"))
+		var attempts atomic.Int32
+		conn := makeConn(&mockClient{
+			performTransaction: func(*stun.Message, net.Addr, bool) (TransactionResult, error) {
+				attempts.Add(1)
+
+				return TransactionResult{Msg: staleNonceMsg()}, nil
+			},
+		}, bm)
+
+		err := conn.bindChannel(bound, bindingStateIdle)
+		assert.ErrorIs(t, err, errTryAgain)
+		assert.Equal(t, int32(maxRetryAttempts), attempts.Load())
+		assert.Equal(t, bindingStateFailed, bound.state())
+		var turnErr *stun.TurnError
+		assert.False(t, errors.As(err, &turnErr), "438 retry exhaustion must not become a typed TURN error")
 	})
 
 	t.Run("maybeBind() retries unknown binding after transaction failure", func(t *testing.T) {
@@ -554,6 +582,13 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 
 		_, err := conn.WriteTo([]byte("still closed"), peerAddr)
 		assert.ErrorIs(t, err, net.ErrClosed)
+		var turnErr *stun.TurnError
+		require.ErrorAs(t, err, &turnErr)
+		assert.Equal(t, stun.CodeBadRequest, turnErr.ErrorCodeAttr.Code)
+
+		closeErr := conn.Close()
+		require.ErrorAs(t, closeErr, &turnErr)
+		assert.Equal(t, stun.CodeBadRequest, turnErr.ErrorCodeAttr.Code)
 	})
 
 	t.Run("ChannelBind 400 after unknown binding closes allocation", func(t *testing.T) {
@@ -616,6 +651,11 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		case <-time.After(5 * time.Second):
 			assert.Fail(t, "timed out waiting for deallocation callback")
 		}
+
+		_, err := conn.WriteTo([]byte("still closed"), peerAddr)
+		var turnErr *stun.TurnError
+		require.ErrorAs(t, err, &turnErr)
+		assert.Equal(t, stun.CodeBadRequest, turnErr.ErrorCodeAttr.Code)
 	})
 
 	t.Run("ChannelBind 400 after lost ready refresh keeps saved binding", func(t *testing.T) {

--- a/internal/client/udp_conn_test.go
+++ b/internal/client/udp_conn_test.go
@@ -413,10 +413,12 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 					assert.ErrorContains(t, err, tt.expectErrContains)
 				}
 				assert.Equal(t, tt.expectBadRequest, errors.Is(err, errChannelBindBadRequest))
+				var turnErr *stun.TurnError
 				if tt.expectTurnErrorCode != 0 {
-					var turnErr *stun.TurnError
 					require.ErrorAs(t, err, &turnErr)
 					assert.Equal(t, tt.expectTurnErrorCode, turnErr.ErrorCodeAttr.Code)
+				} else {
+					assert.False(t, errors.As(err, &turnErr), "response class must remain untyped")
 				}
 
 				if tt.expectBindingDeleted {


### PR DESCRIPTION
## Summary

- Preserve typed `*stun.TurnError` identity for well-formed non-438 ChannelBind error responses.
- Keep the established 400 sentinels, fresh-binding Allocation seal, previously-ready recovery, and 438 retry/nonce policy.
- Add finite-table, PreparePeer propagation, terminal-chain, retry-count, and request-preservation evidence.

## Contract

Parent: #43

Plan: [docs/adr/2026-08-17-turn-consistency-plan.md — Slice T3.S1 — Preserve typed TURN errors through ChannelBind policy](https://github.com/the-sarge/turn/blob/0042dbe7adc42ac92b451073d2b41f68fa4c75f0/docs/adr/2026-08-17-turn-consistency-plan.md#slice-t3s1--preserve-typed-turn-errors-through-channelbind-policy)

Plan commit: `0042dbe7adc42ac92b451073d2b41f68fa4c75f0`

Closes #46

## Validation

- `GOTOOLCHAIN=local go test ./internal/client -run "^(TestUDPConn|TestPreparePeer)$" -count=1`
- `GOTOOLCHAIN=local go test ./... -count=1`
- `task verify`
