### PR TITLE
T3.S2: Bound channel-number allocation and contract binding manager

### DIFF
--- a/docs/adr/2026-08-17-architecture-deepening-program.md
+++ b/docs/adr/2026-08-17-architecture-deepening-program.md
@@ -1,6 +1,6 @@
 # TURN Architecture Deepening Program — 2026-08-17
 
-**Status:** Accepted; Tracks 1, 2, and T3.S1 implemented by PRs #49, #51, and #53; T3.S2 remains on the frontier
+**Status:** Accepted; all tracks implemented by PRs #49, #51, #53, and #55
 
 ## What this is
 
@@ -22,11 +22,11 @@ This program packages the post-M1 architecture review and delegated grilling of 
 |---|---|---|---|---|---|---|
 | 1 | Transaction registry deepening | [plan](2026-08-17-transaction-registry-plan.md) | #41 | None | 1 | COMPLETE via PR #49 |
 | 2 | Allocation lifecycle deepening | [plan](2026-08-17-allocation-lifecycle-plan.md) | #42 | None | 1 | COMPLETE via PR #51 |
-| 3 | TURN consistency and bounded state | [plan](2026-08-17-turn-consistency-plan.md) | #43 | None | 2 | T3.S1 COMPLETE via PR #53; T3.S2 FRONTIER |
+| 3 | TURN consistency and bounded state | [plan](2026-08-17-turn-consistency-plan.md) | #43 | None | 2 | COMPLETE via PRs #53 and #55 |
 
 There are no genuine slice-level blocking edges. Track 1's registry supplies the abort-current capability consumed by the completed T2.S1 without changing its Allocation-side contract. Likely text conflicts between independently implemented tracks require rebasing, not artificial blockers.
 
-Current frontier after PR #53: T3.S2. T1.S1, T2.S1, and T3.S1 are complete; T3.S2 remains independently dispatchable with no blockers.
+Current frontier after PR #55: none. T1.S1, T2.S1, T3.S1, and T3.S2 are complete.
 
 ## Rules that bind every track
 

--- a/docs/adr/2026-08-17-turn-consistency-plan.md
+++ b/docs/adr/2026-08-17-turn-consistency-plan.md
@@ -1,12 +1,12 @@
 # TURN Consistency and Bounded-State Implementation Plan
 
 **Date:** 2026-08-17
-**Status:** Accepted; T3.S1 implemented by PR #53; T3.S2 remains on the frontier
+**Status:** Accepted; both slices implemented by PRs #53 and #55
 **Track:** 3 of 3 in the 2026-08-17 architecture deepening program
 **Depends on:** Nothing; both slices are independent of Tracks 1 and 2 and of each other
 **Related:** [Program index](2026-08-17-architecture-deepening-program.md), [Modernize the kept API plan](2026-08-15-modernize-kept-api-plan.md), [Prepared-only writes ADR](2026-08-15-prepared-only-writes.md)
 **Normative scope:** Current outcome, boundaries, invariants, acceptance evidence, blockers, and stop conditions
-**Audit history:** Independently audited against `e251b6b` on 2026-08-17; both slices passed after typed-error recovery/exhaustion and concurrent final-channel capacity contracts were closed; T3.S1 implemented by PR #53
+**Audit history:** Independently audited against `e251b6b` on 2026-08-17; both slices passed after typed-error recovery/exhaustion and concurrent final-channel capacity contracts were closed; implemented by PRs #53 and #55
 
 ## Goal
 
@@ -41,7 +41,7 @@ Delete `binding.mgr` and the dead test-only `create`, delete, and size methods i
 | Slice | Status/disposition | Delivers | Blocked by | Removes temporary seam |
 |---|---|---|---|---|
 | T3.S1 | Complete via PR #53 | ChannelBind preserves typed TURN errors while existing 438/400 policy stays local | None | n/a |
-| T3.S2 | New | Channel-number allocation is bounded and binding manager mutation surface contracts | None | Removes dead binding manager test-only mutation methods in this slice |
+| T3.S2 | Complete via PR #55 | Channel-number allocation is bounded and binding manager mutation surface contracts | None | Removes dead binding manager test-only mutation methods in this slice |
 
 T3.S1 and T3.S2 are parallel-safe in behavior and have no genuine blocking edge. They touch nearby `udp_conn.go` regions, so the second branch may need an ordinary rebase after the first merges; a likely text conflict is not an architectural dependency.
 
@@ -85,6 +85,8 @@ T3.S1 and T3.S2 are parallel-safe in behavior and have no genuine blocking edge.
 
 **What it delivers:** One PR correcting the range count to 16,384; changing new-binding allocation to return explicit exhaustion instead of wrapping/overwriting; propagating exhaustion after a successful permission phase from `PreparePeer` as `ErrChannelBindFailed` without starting ChannelBind; preserving existing-peer lookup even at capacity; deleting unread `binding.mgr` and test-only `create`, `deleteByAddr`, `deleteByNumber`, and `size`; and re-anchoring their useful assertions on live get-or-create, bidirectional lookup, `all`, PreparePeer, and prepared-only WriteTo behavior.
 
+**Implementation:** PR #55 is the slice's one intended product PR.
+
 **Existing-work disposition:** New slice.
 
 **Blocked by:** None.
@@ -118,10 +120,10 @@ T3.S1 and T3.S2 are parallel-safe in behavior and have no genuine blocking edge.
 - [x] The classifier-created error for every well-formed non-438 ChannelBind response carries a typed `*stun.TurnError`; fresh/unknown failures expose it, while previously-ready 400 recovery intentionally consumes it and returns nil. The finite supported response/code/state domain, owners, universal guarantee, and evidence are declared in T3.S1.
 - [x] ChannelBind 400 retains existing ready-binding recovery and fresh-binding Allocation seal behavior, and 438 retains nonce retry behavior.
 - [x] ChannelBind request setters, bytes, and retry counts remain unchanged.
-- [ ] Every live binding in one Allocation has a unique channel number in `[0x4000,0x7fff]`, and both maps remain a bijection; the finite supported peer/range domain, owner, universal/canonical-subset guarantee, and evidence are declared in T3.S2.
-- [ ] An existing peer remains resolvable at capacity; after successful permission, the next distinct peer fails with `ErrChannelBindFailed`, does not overwrite state, and starts no ChannelBind request; permission rejection/cancellation/closure retain their earlier outcomes.
-- [ ] `binding.mgr` and test-only create/delete/size mutation paths are absent; tests retain live behavior coverage through production-shaped seams.
-- [ ] Prepared-only ChannelData, permission-per-IP identity, binding-per-transport-address identity, public API, and caller-owned socket rules remain unchanged.
+- [x] Every live binding in one Allocation has a unique channel number in `[0x4000,0x7fff]`, and both maps remain a bijection; the finite supported peer/range domain, owner, universal/canonical-subset guarantee, and evidence are declared in T3.S2.
+- [x] An existing peer remains resolvable at capacity; after successful permission, the next distinct peer fails with `ErrChannelBindFailed`, does not overwrite state, and starts no ChannelBind request; permission rejection/cancellation/closure retain their earlier outcomes.
+- [x] `binding.mgr` and test-only create/delete/size mutation paths are absent; tests retain live behavior coverage through production-shaped seams.
+- [x] Prepared-only ChannelData, permission-per-IP identity, binding-per-transport-address identity, public API, and caller-owned socket rules remain unchanged.
 
 ## Validation Gates
 

--- a/internal/client/binding.go
+++ b/internal/client/binding.go
@@ -13,10 +13,11 @@ import (
 // Channel number:
 //
 //	0x4000 through 0x7FFF: These values are the allowed channel
-//	numbers (16,383 possible values).
+//	numbers (16,384 possible values).
 const (
-	minChannelNumber uint16 = 0x4000
-	maxChannelNumber uint16 = 0x7fff
+	minChannelNumber   uint16 = 0x4000
+	maxChannelNumber   uint16 = 0x7fff
+	maxChannelBindings        = int(maxChannelNumber-minChannelNumber) + 1
 )
 
 type bindingState int32
@@ -32,17 +33,16 @@ const (
 )
 
 type binding struct {
-	number       uint16          // Read-only
-	st           bindingState    // Thread-safe (atomic op)
-	addr         netip.AddrPort  // Read-only
-	mgr          *bindingManager // Read-only
-	muBind       sync.Mutex      // Thread-safe, for ChannelBind ops
-	attemptDone  chan struct{}   // Protected by muBind; non-nil while a bind attempt is in flight
-	prepared     atomic.Bool     // Thread-safe; peer promised ChannelData-only writes
-	_refreshedAt time.Time       // Protected by mutex
-	_bindErr     error           // Protected by mutex; last failed bind attempt or terminal cause
-	_terminal    bool            // Protected by mutex; binding failed permanently
-	mutex        sync.RWMutex    // Thread-safe
+	number       uint16         // Read-only
+	st           bindingState   // Thread-safe (atomic op)
+	addr         netip.AddrPort // Read-only
+	muBind       sync.Mutex     // Thread-safe, for ChannelBind ops
+	attemptDone  chan struct{}  // Protected by muBind; non-nil while a bind attempt is in flight
+	prepared     atomic.Bool    // Thread-safe; peer promised ChannelData-only writes
+	_refreshedAt time.Time      // Protected by mutex
+	_bindErr     error          // Protected by mutex; last failed bind attempt or terminal cause
+	_terminal    bool           // Protected by mutex; binding failed permanently
+	mutex        sync.RWMutex   // Thread-safe
 }
 
 func (b *binding) setState(state bindingState) {
@@ -136,31 +136,30 @@ func (mgr *bindingManager) assignChannelNumber() uint16 {
 	return n
 }
 
-func (mgr *bindingManager) create(addr netip.AddrPort) *binding {
-	return mgr.getOrCreate(addr)
-}
-
-// getOrCreate returns the existing binding for addr, or creates one, so that
-// concurrent callers for the same peer share a single channel number.
-func (mgr *bindingManager) getOrCreate(addr netip.AddrPort) *binding {
+// getOrCreate returns the existing binding for addr, or creates one while a
+// channel number remains available. Concurrent callers for the same peer share
+// a single channel number. A false result leaves both maps unchanged.
+func (mgr *bindingManager) getOrCreate(addr netip.AddrPort) (*binding, bool) {
 	mgr.mutex.Lock()
 	defer mgr.mutex.Unlock()
 
 	if b, ok := mgr.addrMap[addr]; ok {
-		return b
+		return b, true
+	}
+	if len(mgr.addrMap) >= maxChannelBindings {
+		return nil, false
 	}
 
 	b := &binding{
 		number:       mgr.assignChannelNumber(),
 		addr:         addr,
-		mgr:          mgr,
 		_refreshedAt: time.Now(),
 	}
 
 	mgr.chanMap[b.number] = b
 	mgr.addrMap[b.addr] = b
 
-	return b
+	return b, true
 }
 
 func (mgr *bindingManager) findByAddr(addr netip.AddrPort) (*binding, bool) {
@@ -179,43 +178,6 @@ func (mgr *bindingManager) findByNumber(number uint16) (*binding, bool) {
 	b, ok := mgr.chanMap[number]
 
 	return b, ok
-}
-
-func (mgr *bindingManager) deleteByAddr(addr netip.AddrPort) bool {
-	mgr.mutex.Lock()
-	defer mgr.mutex.Unlock()
-
-	b, ok := mgr.addrMap[addr]
-	if !ok {
-		return false
-	}
-
-	delete(mgr.addrMap, addr)
-	delete(mgr.chanMap, b.number)
-
-	return true
-}
-
-func (mgr *bindingManager) deleteByNumber(number uint16) bool {
-	mgr.mutex.Lock()
-	defer mgr.mutex.Unlock()
-
-	b, ok := mgr.chanMap[number]
-	if !ok {
-		return false
-	}
-
-	delete(mgr.addrMap, b.addr)
-	delete(mgr.chanMap, number)
-
-	return true
-}
-
-func (mgr *bindingManager) size() int {
-	mgr.mutex.RLock()
-	defer mgr.mutex.RUnlock()
-
-	return len(mgr.chanMap)
 }
 
 func (mgr *bindingManager) all() []*binding {

--- a/internal/client/binding_test.go
+++ b/internal/client/binding_test.go
@@ -6,37 +6,132 @@ package client
 import (
 	"fmt"
 	"net/netip"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
+func TestBindingManagerCapacity(t *testing.T) {
+	const wantCapacity = 16_384
+
+	assert.Equal(t, wantCapacity, int(maxChannelNumber-minChannelNumber)+1)
+
+	bm := newBindingManager()
+	peers := make([]netip.AddrPort, wantCapacity)
+	bindingsByNumber := make(map[uint16]*binding, wantCapacity)
+	peerAddr := netip.MustParseAddr("192.0.2.1")
+	for i := range wantCapacity {
+		peer := netip.AddrPortFrom(peerAddr, uint16(i+1)) //nolint:gosec // Bounded by channel capacity.
+		peers[i] = peer
+
+		bound, ok := bm.getOrCreate(peer)
+		require.True(t, ok)
+		require.NotNil(t, bound)
+		assert.GreaterOrEqual(t, bound.number, minChannelNumber)
+		assert.LessOrEqual(t, bound.number, maxChannelNumber)
+		require.NotContains(t, bindingsByNumber, bound.number, "channel number reused for %v", peer)
+		bindingsByNumber[bound.number] = bound
+
+		byAddr, found := bm.findByAddr(peer)
+		require.True(t, found)
+		assert.Same(t, bound, byAddr)
+		byNumber, found := bm.findByNumber(bound.number)
+		require.True(t, found)
+		assert.Same(t, bound, byNumber)
+	}
+
+	assert.Len(t, bm.all(), wantCapacity)
+	assert.Len(t, bm.addrMap, wantCapacity)
+	assert.Len(t, bindingsByNumber, wantCapacity)
+
+	existing, ok := bm.getOrCreate(peers[0])
+	require.True(t, ok)
+	assert.Same(t, bindingsByNumber[minChannelNumber], existing)
+
+	exhaustedPeer := netip.AddrPortFrom(netip.MustParseAddr("192.0.2.1"), wantCapacity+1)
+	exhausted, ok := bm.getOrCreate(exhaustedPeer)
+	assert.False(t, ok)
+	assert.Nil(t, exhausted)
+	assert.Len(t, bm.all(), wantCapacity)
+	assert.Len(t, bm.addrMap, wantCapacity)
+	assert.Len(t, bindingsByNumber, wantCapacity)
+	_, found := bm.findByAddr(exhaustedPeer)
+	assert.False(t, found)
+}
+
+func TestBindingManagerConcurrentFinalSlot(t *testing.T) {
+	bm := newBindingManager()
+	peerAddr := netip.MustParseAddr("192.0.2.1")
+	for i := range maxChannelBindings - 1 {
+		peer := netip.AddrPortFrom(peerAddr, uint16(i+1)) //nolint:gosec // Bounded by channel capacity.
+		_, ok := bm.getOrCreate(peer)
+		require.True(t, ok)
+	}
+
+	peers := []netip.AddrPort{
+		netip.MustParseAddrPort("192.0.2.2:1"),
+		netip.MustParseAddrPort("192.0.2.2:2"),
+	}
+	type result struct {
+		bound *binding
+		ok    bool
+	}
+	results := make(chan result, len(peers))
+	start := make(chan struct{})
+	var callers sync.WaitGroup
+	for _, peer := range peers {
+		callers.Add(1)
+		go func() {
+			defer callers.Done()
+			<-start
+			bound, ok := bm.getOrCreate(peer)
+			results <- result{bound: bound, ok: ok}
+		}()
+	}
+	close(start)
+	callers.Wait()
+	close(results)
+
+	successes := 0
+	exhaustions := 0
+	for got := range results {
+		if got.ok {
+			successes++
+			require.NotNil(t, got.bound)
+		} else {
+			exhaustions++
+			assert.Nil(t, got.bound)
+		}
+	}
+	assert.Equal(t, 1, successes)
+	assert.Equal(t, 1, exhaustions)
+
+	bindings := bm.all()
+	require.Len(t, bindings, maxChannelBindings)
+	seen := make(map[uint16]netip.AddrPort, maxChannelBindings)
+	for _, bound := range bindings {
+		require.NotContains(t, seen, bound.number, "channel number reused for %v", bound.addr)
+		seen[bound.number] = bound.addr
+
+		byAddr, found := bm.findByAddr(bound.addr)
+		require.True(t, found)
+		assert.Same(t, bound, byAddr)
+		byNumber, found := bm.findByNumber(bound.number)
+		require.True(t, found)
+		assert.Same(t, bound, byNumber)
+	}
+}
+
 func TestBindingManager(t *testing.T) {
-	t.Run("number assignment", func(t *testing.T) {
-		bm := newBindingManager()
-		var chanNum uint16
-		for i := range uint16(10) {
-			chanNum = bm.assignChannelNumber()
-			assert.Equal(t, minChannelNumber+i, chanNum, "should match")
-		}
-
-		bm.next = uint16(0x7ff0)
-		for i := range uint16(16) {
-			chanNum = bm.assignChannelNumber()
-			assert.Equal(t, 0x7ff0+i, chanNum, "should match")
-		}
-
-		// Back to min
-		chanNum = bm.assignChannelNumber()
-		assert.Equal(t, minChannelNumber, chanNum, "should match")
-	})
-
-	t.Run("method test", func(t *testing.T) {
+	t.Run("lookup and iteration", func(t *testing.T) {
 		count := 100
 		bm := newBindingManager()
 		for i := range count {
 			addr := netip.MustParseAddrPort(fmt.Sprintf("127.0.0.1:%d", 10000+i))
-			b0 := bm.create(addr)
+			b0, created := bm.getOrCreate(addr)
+			require.True(t, created)
 			b1, ok := bm.findByAddr(addr)
 			assert.True(t, ok, "should succeed")
 			b2, ok := bm.findByNumber(b0.number)
@@ -53,34 +148,14 @@ func TestBindingManager(t *testing.T) {
 			assert.Equal(t, b, found, "should match")
 		}
 		assert.Equal(t, count, len(all), "should match")
-		assert.Equal(t, count, bm.size(), "should match")
-		assert.Equal(t, count, len(bm.addrMap), "should match")
-
-		for i := range count {
-			addr := netip.MustParseAddrPort(fmt.Sprintf("127.0.0.1:%d", 10000+i))
-			if i%2 == 0 {
-				assert.True(t, bm.deleteByAddr(addr), "should return true")
-			} else {
-				assert.True(t, bm.deleteByNumber(minChannelNumber+uint16(i)), "should return true") // nolint:gosec // G115
-			}
-		}
-
-		assert.Equal(t, 0, bm.size(), "should match")
-		assert.Equal(t, 0, len(bm.addrMap), "should match")
-		assert.Equal(t, 0, len(bm.all()), "should match")
 	})
 
-	t.Run("failure test", func(t *testing.T) {
+	t.Run("missing lookup", func(t *testing.T) {
 		addr := netip.MustParseAddrPort("127.0.0.1:7777")
 		m := newBindingManager()
-		var ok bool
-		_, ok = m.findByAddr(addr)
+		_, ok := m.findByAddr(addr)
 		assert.False(t, ok, "should fail")
 		_, ok = m.findByNumber(uint16(5555))
-		assert.False(t, ok, "should fail")
-		ok = m.deleteByAddr(addr)
-		assert.False(t, ok, "should fail")
-		ok = m.deleteByNumber(uint16(5555))
 		assert.False(t, ok, "should fail")
 	})
 }

--- a/internal/client/prepare_test.go
+++ b/internal/client/prepare_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/pion/stun/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/the-sarge/turn/v5/internal/proto"
 )
 
@@ -145,10 +146,68 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 			"write after successful PreparePeer must be ChannelData, not Send indication")
 	})
 
+	t.Run("capacity exhaustion follows permission and starts no ChannelBind", func(t *testing.T) {
+		harness := newPrepareHarness(t, false)
+		peerAddr := netip.MustParseAddr("192.0.2.1")
+		for i := range maxChannelBindings {
+			peer := netip.AddrPortFrom(peerAddr, uint16(i+1)) //nolint:gosec // Bounded by channel capacity.
+			_, ok := harness.conn.bindingMgr.getOrCreate(peer)
+			require.True(t, ok)
+		}
+
+		bindingsBefore := harness.conn.bindingMgr.all()
+		err := harness.conn.PreparePeer(context.Background(), harness.peer)
+		assert.ErrorIs(t, err, ErrChannelBindFailed)
+		assert.Equal(t, int32(1), harness.permCount.Load(), "permission phase remains first")
+		assert.Equal(t, int32(0), harness.bindCount.Load(), "exhaustion must not start ChannelBind")
+		assert.Len(t, harness.conn.bindingMgr.all(), len(bindingsBefore))
+		_, found := harness.conn.bindingMgr.findByAddr(harness.peer)
+		assert.False(t, found)
+		perm, found := harness.conn.permMap.find(harness.peer)
+		require.True(t, found)
+		assert.Equal(t, permStatePermitted, perm.state())
+
+		harness.failPerms.Store(true)
+		rejectedPeer := netip.MustParseAddrPort("192.0.2.2:1234")
+		err = harness.conn.PreparePeer(context.Background(), rejectedPeer)
+		var turnErr *stun.TurnError
+		require.ErrorAs(t, err, &turnErr)
+		assert.Equal(t, stun.CodeForbidden, turnErr.ErrorCodeAttr.Code)
+		assert.NotErrorIs(t, err, ErrChannelBindFailed, "permission rejection retains its earlier outcome")
+		assert.Equal(t, int32(0), harness.bindCount.Load(), "permission rejection must stop before binding")
+		_, found = harness.conn.bindingMgr.findByAddr(rejectedPeer)
+		assert.False(t, found)
+	})
+
+	t.Run("cancellation and closure retain their pre-binding outcomes", func(t *testing.T) {
+		t.Run("cancellation", func(t *testing.T) {
+			harness := newPrepareHarness(t, false)
+			cause := errors.New("caller canceled before preparation") //nolint:err113 // Test-local cause.
+			ctx, cancel := context.WithCancelCause(context.Background())
+			cancel(cause)
+
+			err := harness.conn.PreparePeer(ctx, harness.peer)
+			assert.ErrorIs(t, err, cause)
+			assert.Equal(t, int32(0), harness.permCount.Load())
+			assert.Equal(t, int32(0), harness.bindCount.Load())
+		})
+
+		t.Run("closure", func(t *testing.T) {
+			harness := newPrepareHarness(t, false)
+			require.NoError(t, harness.conn.Close())
+
+			err := harness.conn.PreparePeer(context.Background(), harness.peer)
+			assert.ErrorIs(t, err, net.ErrClosed)
+			assert.Equal(t, int32(0), harness.permCount.Load())
+			assert.Equal(t, int32(0), harness.bindCount.Load())
+		})
+	})
+
 	t.Run("terminal failure survives an in-flight bind success", func(t *testing.T) {
 		harness := newPrepareHarness(t, true)
 
-		bound := harness.conn.bindingMgr.getOrCreate(harness.peer)
+		bound, ok := harness.conn.bindingMgr.getOrCreate(harness.peer)
+		require.True(t, ok)
 		harness.conn.maybeBind(bound)
 		assert.Eventually(t, func() bool {
 			return harness.bindCount.Load() == 1
@@ -440,7 +499,8 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 		harness := newPrepareHarness(t, false)
 
 		assert.NoError(t, harness.conn.PreparePeer(context.Background(), harness.peer))
-		bound := harness.conn.bindingMgr.getOrCreate(harness.peer)
+		bound, ok := harness.conn.bindingMgr.getOrCreate(harness.peer)
+		require.True(t, ok)
 		bound.setRefreshedAt(time.Now().Add(-channelBindingLifetime))
 
 		err := harness.conn.PreparePeer(context.Background(), harness.peer)
@@ -494,7 +554,8 @@ func TestWriteToPreparedOnly(t *testing.T) {
 			arrange: func(t *testing.T, harness *prepareHarness) {
 				t.Helper()
 				assert.NoError(t, harness.conn.PreparePeer(context.Background(), harness.peer))
-				bound := harness.conn.bindingMgr.getOrCreate(harness.peer)
+				bound, ok := harness.conn.bindingMgr.getOrCreate(harness.peer)
+				require.True(t, ok)
 				bound.setRefreshedAt(time.Now().Add(-channelBindingLifetime))
 			},
 			wantErr:    ErrChannelBindingExpired,

--- a/internal/client/prepare_test.go
+++ b/internal/client/prepare_test.go
@@ -131,6 +131,17 @@ func (harness *prepareHarness) lastWrite() []byte {
 	return harness.writes.data[len(harness.writes.data)-1]
 }
 
+func fillBindingManager(t *testing.T, mgr *bindingManager) {
+	t.Helper()
+
+	peerAddr := netip.MustParseAddr("192.0.2.1")
+	for i := range maxChannelBindings {
+		peer := netip.AddrPortFrom(peerAddr, uint16(i+1)) //nolint:gosec // Bounded by channel capacity.
+		_, ok := mgr.getOrCreate(peer)
+		require.True(t, ok)
+	}
+}
+
 func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 	t.Run("readiness success then ChannelData writes", func(t *testing.T) {
 		harness := newPrepareHarness(t, false)
@@ -148,12 +159,7 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 
 	t.Run("capacity exhaustion follows permission and starts no ChannelBind", func(t *testing.T) {
 		harness := newPrepareHarness(t, false)
-		peerAddr := netip.MustParseAddr("192.0.2.1")
-		for i := range maxChannelBindings {
-			peer := netip.AddrPortFrom(peerAddr, uint16(i+1)) //nolint:gosec // Bounded by channel capacity.
-			_, ok := harness.conn.bindingMgr.getOrCreate(peer)
-			require.True(t, ok)
-		}
+		fillBindingManager(t, harness.conn.bindingMgr)
 
 		bindingsBefore := harness.conn.bindingMgr.all()
 		err := harness.conn.PreparePeer(context.Background(), harness.peer)
@@ -176,6 +182,70 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 		assert.NotErrorIs(t, err, ErrChannelBindFailed, "permission rejection retains its earlier outcome")
 		assert.Equal(t, int32(0), harness.bindCount.Load(), "permission rejection must stop before binding")
 		_, found = harness.conn.bindingMgr.findByAddr(rejectedPeer)
+		assert.False(t, found)
+	})
+
+	t.Run("capacity exhaustion preserves cancellation after permission", func(t *testing.T) {
+		harness := newPrepareHarness(t, false)
+		fillBindingManager(t, harness.conn.bindingMgr)
+
+		harness.conn.bindingMgr.mutex.Lock()
+		managerLocked := true
+		defer func() {
+			if managerLocked {
+				harness.conn.bindingMgr.mutex.Unlock()
+			}
+		}()
+
+		ctx, cancel := context.WithCancelCause(context.Background())
+		cause := errors.New("caller canceled while capacity was contended") //nolint:err113 // Test-local cause.
+		result := make(chan error, 1)
+		go func() { result <- harness.conn.PreparePeer(ctx, harness.peer) }()
+
+		require.Eventually(t, func() bool {
+			perm, found := harness.conn.permMap.find(harness.peer)
+
+			return found && perm.state() == permStatePermitted
+		}, 5*time.Second, 10*time.Millisecond)
+		cancel(cause)
+		harness.conn.bindingMgr.mutex.Unlock()
+		managerLocked = false
+
+		assert.ErrorIs(t, <-result, cause)
+		assert.Equal(t, int32(0), harness.bindCount.Load())
+		assert.Len(t, harness.conn.bindingMgr.all(), maxChannelBindings)
+		_, found := harness.conn.bindingMgr.findByAddr(harness.peer)
+		assert.False(t, found)
+	})
+
+	t.Run("capacity exhaustion preserves closure after permission", func(t *testing.T) {
+		harness := newPrepareHarness(t, false)
+		fillBindingManager(t, harness.conn.bindingMgr)
+
+		harness.conn.bindingMgr.mutex.Lock()
+		managerLocked := true
+		defer func() {
+			if managerLocked {
+				harness.conn.bindingMgr.mutex.Unlock()
+			}
+		}()
+
+		result := make(chan error, 1)
+		go func() { result <- harness.conn.PreparePeer(context.Background(), harness.peer) }()
+
+		require.Eventually(t, func() bool {
+			perm, found := harness.conn.permMap.find(harness.peer)
+
+			return found && perm.state() == permStatePermitted
+		}, 5*time.Second, 10*time.Millisecond)
+		require.NoError(t, harness.conn.Close())
+		harness.conn.bindingMgr.mutex.Unlock()
+		managerLocked = false
+
+		assert.ErrorIs(t, <-result, net.ErrClosed)
+		assert.Equal(t, int32(0), harness.bindCount.Load())
+		assert.Len(t, harness.conn.bindingMgr.all(), maxChannelBindings)
+		_, found := harness.conn.bindingMgr.findByAddr(harness.peer)
 		assert.False(t, found)
 	})
 

--- a/internal/client/udp_conn.go
+++ b/internal/client/udp_conn.go
@@ -207,6 +207,13 @@ func (c *UDPConn) PreparePeer(ctx context.Context, peer netip.AddrPort) error {
 
 	bound, ok := c.bindingMgr.getOrCreate(peer)
 	if !ok {
+		if err := ctx.Err(); err != nil {
+			return context.Cause(ctx)
+		}
+		if c.isClosed() {
+			return c.closedErr()
+		}
+
 		return ErrChannelBindFailed
 	}
 

--- a/internal/client/udp_conn.go
+++ b/internal/client/udp_conn.go
@@ -205,7 +205,12 @@ func (c *UDPConn) PreparePeer(ctx context.Context, peer netip.AddrPort) error {
 		return err
 	}
 
-	return c.awaitBinding(ctx, c.bindingMgr.getOrCreate(peer))
+	bound, ok := c.bindingMgr.getOrCreate(peer)
+	if !ok {
+		return ErrChannelBindFailed
+	}
+
+	return c.awaitBinding(ctx, bound)
 }
 
 // awaitPermission blocks until a permission for peer is installed, the shared

--- a/internal/client/udp_conn_test.go
+++ b/internal/client/udp_conn_test.go
@@ -33,6 +33,15 @@ func (e *timeoutError) Error() string {
 	return e.msg
 }
 
+func requireBinding(t *testing.T, mgr *bindingManager, peer netip.AddrPort) *binding {
+	t.Helper()
+
+	bound, ok := mgr.getOrCreate(peer)
+	require.True(t, ok)
+
+	return bound
+}
+
 func (e *timeoutError) Timeout() bool {
 	return true
 }
@@ -170,7 +179,7 @@ func TestPermissionAndBindingRequestShapes(t *testing.T) {
 	peerA := netip.MustParseAddrPort("192.0.2.1:5000")
 	peerB := netip.MustParseAddrPort("192.0.2.2:6000")
 	bindingMgr := newBindingManager()
-	bound := bindingMgr.create(peerA)
+	bound := requireBinding(t, bindingMgr, peerA)
 
 	mock := &mockClient{
 		performTransaction: func(msg *stun.Message, _ net.Addr, dontWait bool) (TransactionResult, error) {
@@ -295,7 +304,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 				unblock := make(chan struct{})
 
 				bm := newBindingManager()
-				bound := bm.create(netip.MustParseAddrPort("127.0.0.1:1234"))
+				bound := requireBinding(t, bm, netip.MustParseAddrPort("127.0.0.1:1234"))
 				conn := makeConn(&mockClient{
 					performTransaction: func(msg *stun.Message, addr net.Addr, dontWait bool) (TransactionResult, error) {
 						<-unblock
@@ -398,7 +407,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				bm := newBindingManager()
-				bound := bm.create(netip.MustParseAddrPort("127.0.0.1:1234"))
+				bound := requireBinding(t, bm, netip.MustParseAddrPort("127.0.0.1:1234"))
 				conn := makeConn(&mockClient{performTransaction: tt.transactionFn}, bm)
 
 				nonceT0 := conn.nonce()
@@ -447,7 +456,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 
 	t.Run("bindChannel exhausts stale nonce retries without a typed TURN error", func(t *testing.T) {
 		bm := newBindingManager()
-		bound := bm.create(netip.MustParseAddrPort("127.0.0.1:1234"))
+		bound := requireBinding(t, bm, netip.MustParseAddrPort("127.0.0.1:1234"))
 		var attempts atomic.Int32
 		conn := makeConn(&mockClient{
 			performTransaction: func(*stun.Message, net.Addr, bool) (TransactionResult, error) {
@@ -469,7 +478,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		var failed atomic.Bool
 
 		bm := newBindingManager()
-		bound := bm.create(netip.MustParseAddrPort("127.0.0.1:1234"))
+		bound := requireBinding(t, bm, netip.MustParseAddrPort("127.0.0.1:1234"))
 		originalCh := bound.number
 		conn := makeConn(&mockClient{
 			performTransaction: func(msg *stun.Message, addr net.Addr, dontWait bool) (TransactionResult, error) {
@@ -549,7 +558,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		}, func() {})
 		defer func() { _ = conn.Close() }()
 
-		bound := conn.bindingMgr.create(peerAddr)
+		bound := requireBinding(t, conn.bindingMgr, peerAddr)
 		conn.maybeBind(bound)
 
 		assert.Eventually(t, func() bool {
@@ -634,7 +643,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		}, func() {})
 		defer func() { _ = conn.Close() }()
 
-		bound := conn.bindingMgr.create(peerAddr)
+		bound := requireBinding(t, conn.bindingMgr, peerAddr)
 
 		conn.maybeBind(bound)
 		assert.Eventually(t, func() bool {
@@ -697,7 +706,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		}, func() {})
 		defer func() { _ = conn.Close() }()
 
-		bound := conn.bindingMgr.create(peerAddr)
+		bound := requireBinding(t, conn.bindingMgr, peerAddr)
 		staleRefreshedAt := time.Now().Add(-(defaultBindingRefreshInterval + time.Minute))
 		bound.setState(bindingStateReady)
 		bound.setRefreshedAt(staleRefreshedAt)
@@ -717,7 +726,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 
 	t.Run("ChannelBind 400 refresh keeps saved binding", func(t *testing.T) {
 		bm := newBindingManager()
-		bound := bm.create(netip.MustParseAddrPort("127.0.0.1:1234"))
+		bound := requireBinding(t, bm, netip.MustParseAddrPort("127.0.0.1:1234"))
 		staleRefreshedAt := time.Now().Add(-(defaultBindingRefreshInterval + time.Minute))
 		var channelBindAttempts atomic.Int32
 		bound.setState(bindingStateReady)
@@ -760,7 +769,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		}))
 
 		bm := newBindingManager()
-		binding := bm.create(addr)
+		binding := requireBinding(t, bm, addr)
 		binding.setState(bindingStateReady)
 		binding.setRefreshedAt(time.Now())
 		binding.prepared.Store(true)
@@ -785,7 +794,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		assert.True(t, pm.insert(addr, &permission{st: permStatePermitted}))
 
 		bm := newBindingManager()
-		bound := bm.create(addr)
+		bound := requireBinding(t, bm, addr)
 		originalCh := bound.number
 
 		client := &mockClient{


### PR DESCRIPTION
## Summary

- Bound each Allocation to the complete 16,384-value TURN channel-number range and fail distinct-peer exhaustion without map overwrite.
- Preserve existing-peer lookup at capacity and permission-before-binding ordering while preventing ChannelBind after exhaustion.
- Remove the unread binding-manager back-pointer and dead test-only create, delete, and size mutation paths.
- Add full-range bijection, exhaustion, final-slot concurrency, production-path, and preservation evidence.

## Contract

Parent: #43

Plan: [docs/adr/2026-08-17-turn-consistency-plan.md — Slice T3.S2 — Bound channel-number allocation and contract the binding manager](https://github.com/the-sarge/turn/blob/0042dbe7adc42ac92b451073d2b41f68fa4c75f0/docs/adr/2026-08-17-turn-consistency-plan.md#slice-t3s2--bound-channel-number-allocation-and-contract-the-binding-manager)

Plan commit: `0042dbe7adc42ac92b451073d2b41f68fa4c75f0`

Closes #47

## Validation

- `GOTOOLCHAIN=local go test ./internal/client -run "^(TestBindingManager|TestPreparePeer|TestWriteToPreparedOnly|TestPermissionAndBindingRequestShapes|TestUDPConn)$" -count=1`
- `GOTOOLCHAIN=local go test -race ./...`
- `task check`
- Capacity-guard mutation: removing the central guard makes `TestBindingManagerCapacity` fail at the 16,385th peer.
