### PR TITLE
test(client): make channel-capacity uniqueness checks linear

### DIFF
--- a/internal/client/binding_test.go
+++ b/internal/client/binding_test.go
@@ -31,7 +31,8 @@ func TestBindingManagerCapacity(t *testing.T) {
 		require.NotNil(t, bound)
 		assert.GreaterOrEqual(t, bound.number, minChannelNumber)
 		assert.LessOrEqual(t, bound.number, maxChannelNumber)
-		require.NotContains(t, bindingsByNumber, bound.number, "channel number reused for %v", peer)
+		_, reused := bindingsByNumber[bound.number]
+		require.False(t, reused, "channel number %#x reused for %v", bound.number, peer)
 		bindingsByNumber[bound.number] = bound
 
 		byAddr, found := bm.findByAddr(peer)
@@ -112,7 +113,8 @@ func TestBindingManagerConcurrentFinalSlot(t *testing.T) {
 	require.Len(t, bindings, maxChannelBindings)
 	seen := make(map[uint16]netip.AddrPort, maxChannelBindings)
 	for _, bound := range bindings {
-		require.NotContains(t, seen, bound.number, "channel number reused for %v", bound.addr)
+		_, reused := seen[bound.number]
+		require.False(t, reused, "channel number %#x reused for %v", bound.number, bound.addr)
 		seen[bound.number] = bound.addr
 
 		byAddr, found := bm.findByAddr(bound.addr)


### PR DESCRIPTION
Closes #57. Follow-up from the PR #55 review (`20260818T031953-99a16cf38c93fe5931d3da07`, C-004), revalidated against merged `0c55b10`.

## What changed

Two lines in `internal/client/binding_test.go`: the per-insert `require.NotContains(t, <map>, <uint16>)` checks in `TestBindingManagerCapacity` and `TestBindingManagerConcurrentFinalSlot` are now direct map lookups (`_, reused := m[n]; require.False(t, reused, …)`). testify's `Contains` reflectively walks every map key per call, so duplicate detection was quadratic across the 16,384-entry channel range. No product code, allocation policy, public API, or evidence domain changes.

## Acceptance (from #57)

- 16,384-entry range/bijection test still detects channel-number reuse and keeps forward/reverse lookup assertions — unchanged apart from the reuse-check encoding; mutation (b) below fires it.
- Concurrent final-slot test still proves exactly one success, one exhaustion, and a complete bijection — unchanged apart from the reuse-check encoding.
- Removing the central capacity guard still makes the 16,385th-peer integrity regression fail — mutation (a) below.
- Focused ordinary and race tests pass without quadratic duplicate-detection work — timings below.

## Evidence

| Run (both tests, local arm64) | before | after |
| --- | --- | --- |
| `go test` | 14.3 s (7.5 + 6.5) | 0.26 s (0.04 + 0.02) |
| `go test -race` | 92.0 s (46.7 + 44.0) | 1.5 s (0.19 + 0.08) |

Guard mutations (both reverted before commit):

- (a) delete `if len(mgr.addrMap) >= maxChannelBindings { return nil, false }` in `getOrCreate` → `TestBindingManagerCapacity` exhaustion branch (`binding_test.go:56–62`) and all three `TestPreparePeer/capacity exhaustion…` subtests fail.
- (b) wrap `assignChannelNumber` at `maxChannelNumber-1` → `binding_test.go:35` fails with `channel number 0x4000 reused for 192.0.2.1:16384`; the concurrent test fails at its `require.Len` bijection check.

`task verify` green at `e836827` (format, vet, full tests, lint, docs).

## Review contract

Artifact class: verification aid only. Representation domain: `bindingManager` `chanMap`/`addrMap`; owner unchanged; example-level guarantee. Contract closure: not triggered. Review budget: one initial RAS review, at most one replacement.
