### PR TITLE
Bind outbound transport to the configured TURN server

### DIFF
--- a/allocate_ctx_test.go
+++ b/allocate_ctx_test.go
@@ -35,8 +35,9 @@ type observerConn struct {
 	gate          chan struct{} // Closed to release blocked writes
 	blocked       chan struct{} // Signaled once a write is blocked on the gate
 
-	mu     sync.Mutex
-	writes [][]byte
+	mu           sync.Mutex
+	writes       [][]byte
+	destinations []string
 }
 
 func newObserverConn() *observerConn {
@@ -46,7 +47,7 @@ func newObserverConn() *observerConn {
 	}
 }
 
-func (o *observerConn) WriteTo(p []byte, _ net.Addr) (int, error) {
+func (o *observerConn) WriteTo(p []byte, to net.Addr) (int, error) {
 	n := o.writeCount.Add(1)
 	if o.blockFrom > 0 && n >= o.blockFrom {
 		o.blocked <- struct{}{}
@@ -54,9 +55,20 @@ func (o *observerConn) WriteTo(p []byte, _ net.Addr) (int, error) {
 	}
 	o.mu.Lock()
 	o.writes = append(o.writes, append([]byte(nil), p...))
+	o.destinations = append(o.destinations, to.String())
 	o.mu.Unlock()
 
 	return len(p), nil
+}
+
+func (o *observerConn) destination(i int) string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if i >= len(o.destinations) {
+		return ""
+	}
+
+	return o.destinations[i]
 }
 
 func (o *observerConn) write(i int) []byte {
@@ -236,6 +248,39 @@ func awaitAuthRequest(t *testing.T, cl *Client, conn *observerConn) []byte {
 	require.NoError(t, cl.HandleInbound(unauthorizedResponse(t, first), testServerNetAddr()))
 
 	return awaitRequestAfter(t, conn, 1, transactionID(t, first))
+}
+
+func TestAllocateTargetsConfiguredServer(t *testing.T) {
+	conn := newObserverConn()
+	cl := newObservedClient(t, conn)
+
+	type outcome struct {
+		allocation *Allocation
+		err        error
+	}
+	resultCh := make(chan outcome, 1)
+	go func() {
+		allocation, err := cl.Allocate(context.Background())
+		resultCh <- outcome{allocation: allocation, err: err}
+	}()
+
+	first := awaitWrite(t, conn, 1)
+	require.NoError(t, cl.HandleInbound(unauthorizedResponse(t, first), testServerNetAddr()))
+	authenticated := awaitRequestAfter(t, conn, 1, transactionID(t, first))
+	require.NoError(t, cl.HandleInbound(allocateSuccessResponse(t, authenticated), testServerNetAddr()))
+
+	select {
+	case result := <-resultCh:
+		require.NoError(t, result.err)
+		require.NotNil(t, result.allocation)
+		t.Cleanup(func() { _ = result.allocation.Close() })
+	case <-time.After(time.Second):
+		require.Fail(t, "Allocate did not return after the success response")
+	}
+
+	want := testServerNetAddr().String()
+	assert.Equal(t, want, conn.destination(0), "anonymous Allocate destination")
+	assert.Equal(t, want, conn.destination(1), "authenticated Allocate destination")
 }
 
 func TestAllocateContext(t *testing.T) {

--- a/allocation_test.go
+++ b/allocation_test.go
@@ -39,14 +39,14 @@ func newAllocHarness(t *testing.T) *allocHarness {
 
 	harness := &allocHarness{}
 	conn := client.NewUDPConn(&client.AllocationConfig{
-		WriteTo: func(data []byte, _ net.Addr) (int, error) {
+		WriteTo: func(data []byte) (int, error) {
 			harness.writes.Lock()
 			harness.writes.data = append(harness.writes.data, append([]byte(nil), data...))
 			harness.writes.Unlock()
 
 			return len(data), nil
 		},
-		PerformTransaction: func(msg *stun.Message, _ net.Addr, _ bool) (client.TransactionResult, error) {
+		PerformTransaction: func(msg *stun.Message, _ bool) (client.TransactionResult, error) {
 			switch msg.Type.Method {
 			case stun.MethodCreatePermission:
 				harness.permCount.Add(1)
@@ -66,7 +66,6 @@ func newAllocHarness(t *testing.T) *allocHarness {
 		},
 		OnDeallocated: func(net.Addr) {},
 		RelayedAddr:   &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 54321},
-		ServerAddr:    &net.UDPAddr{IP: net.ParseIP("10.0.0.1"), Port: 3478},
 		Username:      stun.NewUsername("user"),
 		Realm:         stun.NewRealm("realm"),
 		Integrity:     stun.NewShortTermIntegrity("pass"),
@@ -231,7 +230,8 @@ func TestAllocateRejectsInvalidRelayedAddress(t *testing.T) {
 
 // TestDeletedSurfaceDoesNotResolve pins the negative API contract: the moved
 // PrepareUDPPeer, the deleted deadline/LocalAddr surface, the deleted Listen
-// second idiom, and the removed LoggerFactory seam must not resolve.
+// second idiom, the removed LoggerFactory seam, and internal destination
+// authority must not resolve.
 func TestDeletedSurfaceDoesNotResolve(t *testing.T) {
 	_, ok := reflect.TypeFor[*Client]().MethodByName("PrepareUDPPeer")
 	assert.False(t, ok, "Client.PrepareUDPPeer moved to Allocation.PreparePeer")
@@ -246,4 +246,16 @@ func TestDeletedSurfaceDoesNotResolve(t *testing.T) {
 
 	_, ok = reflect.TypeFor[ClientConfig]().FieldByName("LoggerFactory")
 	assert.False(t, ok, "ClientConfig.LoggerFactory is deleted: the module does not log")
+
+	allocationConfig := reflect.TypeFor[client.AllocationConfig]()
+	_, ok = allocationConfig.FieldByName("ServerAddr")
+	assert.False(t, ok, "AllocationConfig.ServerAddr would restore internal destination authority")
+
+	writeTo, ok := allocationConfig.FieldByName("WriteTo")
+	require.True(t, ok)
+	assert.Equal(t, 1, writeTo.Type.NumIn(), "Allocation raw writes accept bytes only")
+
+	performTransaction, ok := allocationConfig.FieldByName("PerformTransaction")
+	require.True(t, ok)
+	assert.Equal(t, 2, performTransaction.Type.NumIn(), "Allocation transactions accept message and wait policy only")
 }

--- a/client.go
+++ b/client.go
@@ -56,7 +56,7 @@ type ClientConfig struct {
 type Client struct {
 	conn       net.PacketConn // Read-only
 	server     netip.AddrPort // Read-only; canonical, the inbound admission comparand
-	serverAddr net.Addr       // Read-only; server as the transaction destination on conn
+	serverAddr net.Addr       // Read-only; socket-facing form of server
 
 	username     stun.Username               // Read-only
 	password     string                      // Read-only
@@ -155,14 +155,14 @@ func NewClient(config *ClientConfig) (*Client, error) {
 		bindingRefreshInterval:    config.bindingRefreshInterval,
 		bindingCheckInterval:      config.bindingCheckInterval,
 	}
-	turnClient.transactions = client.NewTransactionRegistry(turnClient.writeTo, rto)
+	turnClient.transactions = client.NewTransactionRegistry(turnClient.sendToServer, rto)
 
 	return turnClient, nil
 }
 
-// writeTo sends data to the specified destination using the base socket.
-func (c *Client) writeTo(data []byte, to net.Addr) (int, error) {
-	return c.conn.WriteTo(data, to)
+// sendToServer sends data to the configured server using the base socket.
+func (c *Client) sendToServer(data []byte) (int, error) {
+	return c.conn.WriteTo(data, c.serverAddr)
 }
 
 // Close closes this client: every pending transaction is closed and its
@@ -307,11 +307,10 @@ func (c *Client) Allocate(ctx context.Context) (*Allocation, error) {
 	}
 
 	relayedConn = client.NewUDPConn(&client.AllocationConfig{
-		WriteTo:                   c.writeTo,
+		WriteTo:                   c.sendToServer,
 		PerformTransaction:        c.performTransaction,
 		OnDeallocated:             c.onDeallocated,
 		RelayedAddr:               relayedAddr,
-		ServerAddr:                c.serverAddr,
 		Realm:                     c.realm,
 		Username:                  c.username,
 		Integrity:                 c.integrity,
@@ -336,14 +335,14 @@ func (c *Client) Allocate(ctx context.Context) (*Allocation, error) {
 }
 
 // performTransaction performs STUN transaction.
-func (c *Client) performTransaction(msg *stun.Message, to net.Addr, ignoreResult bool) (client.TransactionResult,
+func (c *Client) performTransaction(msg *stun.Message, ignoreResult bool) (client.TransactionResult,
 	error,
 ) {
 	if ignoreResult {
-		return client.TransactionResult{}, c.transactions.Start(msg, to)
+		return client.TransactionResult{}, c.transactions.Start(msg)
 	}
 
-	return c.transactions.Perform(msg, to)
+	return c.transactions.Perform(msg)
 }
 
 // performAllocateTransaction delegates Allocate's private cancelable wait to
@@ -351,7 +350,7 @@ func (c *Client) performTransaction(msg *stun.Message, to net.Addr, ignoreResult
 func (c *Client) performAllocateTransaction(ctx context.Context, msg *stun.Message) (
 	client.TransactionResult, error,
 ) {
-	return c.transactions.PerformWithContext(ctx, msg, c.serverAddr)
+	return c.transactions.PerformWithContext(ctx, msg)
 }
 
 // onDeallocated is called when de-allocation of relay address has been complete.

--- a/client_test.go
+++ b/client_test.go
@@ -84,7 +84,7 @@ func TestHandleInboundAdmitsOnlyServer(t *testing.T) {
 
 		waited := make(chan client.TransactionResult, 1)
 		go func() {
-			result, _ := c.performTransaction(req, c.serverAddr, false)
+			result, _ := c.performTransaction(req, false)
 			waited <- result
 		}()
 		awaitWrite(t, conn, 1)
@@ -168,7 +168,7 @@ func TestClientCloseIsAnAbortCutNotATerminalState(t *testing.T) {
 	}
 	resultCh := make(chan outcome, 1)
 	go func() {
-		result, err := cl.performTransaction(request, cl.serverAddr, false)
+		result, err := cl.performTransaction(request, false)
 		resultCh <- outcome{result: result, err: err}
 	}()
 	awaitWrite(t, conn, 1)
@@ -191,7 +191,7 @@ func TestClientCloseWinsBlockedInitialSendWithoutRearm(t *testing.T) {
 
 	resultCh := make(chan error, 1)
 	go func() {
-		_, err := cl.performTransaction(request, cl.serverAddr, false)
+		_, err := cl.performTransaction(request, false)
 		resultCh <- err
 	}()
 	select {

--- a/close_latency_test.go
+++ b/close_latency_test.go
@@ -43,20 +43,19 @@ func newSilentServerAllocation(t *testing.T) (*client.UDPConn, <-chan string) {
 	closeOrder := make(chan string, 3)
 
 	config := &client.AllocationConfig{
-		WriteTo: cl.writeTo,
-		PerformTransaction: func(msg *stun.Message, to net.Addr, dontWait bool) (client.TransactionResult, error) {
+		WriteTo: cl.sendToServer,
+		PerformTransaction: func(msg *stun.Message, dontWait bool) (client.TransactionResult, error) {
 			if msg.Type.Method == stun.MethodRefresh && dontWait {
 				closeOrder <- "release"
 			}
 
-			return cl.performTransaction(msg, to, dontWait)
+			return cl.performTransaction(msg, dontWait)
 		},
 		OnDeallocated: func(addr net.Addr) {
 			closeOrder <- "deallocated"
 			cl.onDeallocated(addr)
 		},
 		RelayedAddr: &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 54321},
-		ServerAddr:  cl.serverAddr,
 		Username:    stun.NewUsername("user"),
 		Realm:       stun.NewRealm("realm"),
 		Integrity:   stun.NewShortTermIntegrity("secret"),

--- a/docs/adr/2026-08-19-architecture-deepening-program.md
+++ b/docs/adr/2026-08-19-architecture-deepening-program.md
@@ -1,6 +1,6 @@
 # TURN Architecture Deepening Program — 2026-08-19
 
-**Status:** Accepted; tracks not yet implemented
+**Status:** In progress; Track 1 implemented by PR #72
 
 ## What this is
 
@@ -18,9 +18,9 @@ This program packages the 2026-08-19 architecture review and delegated grill of 
 
 | # | Track | Plan | Parent issue | Blocked by | Slices | Status |
 |---|---|---|---|---|---|---|
-| 1 | Server-bound outbound transport | [plan](2026-08-19-server-bound-transport-plan.md) | pending | None | 1 | FRONTIER after publication |
-| 2 | Inbound Allocation delivery | [plan](2026-08-19-inbound-allocation-delivery-plan.md) | pending | None | 1 | FRONTIER after publication |
-| 3 | Channel-binding readiness | [plan](2026-08-19-channel-binding-readiness-plan.md) | pending | None | 1 | FRONTIER after publication |
+| 1 | Server-bound outbound transport | [plan](2026-08-19-server-bound-transport-plan.md) | #65 | None | 1 | Complete via PR #72 |
+| 2 | Inbound Allocation delivery | [plan](2026-08-19-inbound-allocation-delivery-plan.md) | #66 | None | 1 | FRONTIER |
+| 3 | Channel-binding readiness | [plan](2026-08-19-channel-binding-readiness-plan.md) | #67 | None | 1 | FRONTIER |
 
 There are no genuine slice-level blocking edges. The tracks touch nearby root/internal seams but own independent behavior: outbound destination authority, inbound delivery, and binding readiness. Likely text conflicts require an ordinary rebase, not an architectural blocker. Recommended dispatch order is Track 1, Track 2, then Track 3 because it advances from the smallest broad seam contraction to the bounded inbound move and finally the most concurrency-sensitive state deepening; an operator may run the frontier in parallel if separate agents and worktrees can absorb rebases.
 

--- a/docs/adr/2026-08-19-server-bound-transport-plan.md
+++ b/docs/adr/2026-08-19-server-bound-transport-plan.md
@@ -1,12 +1,12 @@
 # Server-Bound Outbound Transport Implementation Plan
 
 **Date:** 2026-08-19
-**Status:** Accepted; not yet implemented
+**Status:** Implemented by PR #72
 **Track:** 1 of 3 in the 2026-08-19 architecture deepening program
 **Depends on:** Nothing — safe to start first
 **Related:** [Program index](2026-08-19-architecture-deepening-program.md), [Transaction registry plan](2026-08-17-transaction-registry-plan.md), [Allocation lifecycle plan](2026-08-17-allocation-lifecycle-plan.md)
 **Normative scope:** Current outcome, boundaries, invariants, acceptance evidence, blockers, and stop conditions
-**Audit history:** Independently audited against `122019cf5a040bcb7a8ba9002bd3a82e9ad947cf` on 2026-08-19; T1.S1 passed after its exact interface, construction boundary, characterization strategy, source-domain representation, performance ceiling, and evidence budget were closed
+**Audit history:** Independently audited against `122019cf5a040bcb7a8ba9002bd3a82e9ad947cf` on 2026-08-19; T1.S1 passed after its exact interface, construction boundary, characterization strategy, source-domain representation, performance ceiling, and evidence budget were closed; implementation completed by PR #72
 
 ## Goal
 
@@ -44,7 +44,7 @@ The same slice performs only constructor signature changes forced by removing de
 
 | Slice | Status/disposition | Delivers | Blocked by | Removes temporary seam |
 |---|---|---|---|---|
-| T1.S1 | New | Every production outbound send is structurally bound to the configured TURN server | None | Removes destination parameters and storage from the registry and Allocation seam in the same slice |
+| T1.S1 | Complete via PR #72 | Every production outbound send is structurally bound to the configured TURN server | None | Removed destination parameters and storage from the registry and Allocation seam in the same slice |
 
 ## Implementation Slices
 
@@ -52,7 +52,7 @@ The same slice performs only constructor signature changes forced by removing de
 
 **What it delivers:** One PR that binds the registry sender to root `Client.serverAddr`, removes destination fields and parameters from transaction operations, removes `ServerAddr` and arbitrary-destination callbacks from Allocation construction and `UDPConn`, adapts Refresh/CreatePermission/ChannelBind/release to the bound transaction capability, adapts ChannelData to the bound raw-send capability, and preserves every current outbound behavior through the real Client and Allocation seams.
 
-**Existing-work disposition:** New slice. There are no open issues, PRs, or implementation branches to retain or rebaseline as of 2026-08-19.
+**Implementation:** PR #72 is the slice's one intended product PR; unmentioned historical branches were not used as an implementation baseline.
 
 **Blocked by:** None.
 
@@ -82,11 +82,11 @@ The same slice performs only constructor signature changes forced by removing de
 
 ## Acceptance Criteria
 
-- [ ] Every outbound datagram in the supported retained UDP Client domain targets the one canonical server configured at `NewClient`; representation owner, universal domain, and finite evidence are defined in T1.S1.
-- [ ] No transaction entry or internal Allocation operation in the bounded compiled production send graph stores, accepts, or selects a destination; root `Client` alone adapts the server to the caller-owned socket. The compiled source/diff and recorded census own this universal structural guarantee.
-- [ ] Allocate, Refresh, CreatePermission, ChannelBind, lifetime-zero release, retries, and ChannelData preserve exact bytes, ordering, results, and error behavior.
-- [ ] Transaction one-winner concurrency, Client nonterminal close, Allocation abort-before-notification-before-release, invalid-relayed cleanup, and caller socket ownership remain unchanged.
-- [ ] No generic transport, authenticated exchange, builder, clock, or broader constructor module appears in the reviewed production diff; this is a universal structural guarantee over the bounded current source graph owned by the compiled source/diff and recorded census.
+- [x] Every outbound datagram in the supported retained UDP Client domain targets the one canonical server configured at `NewClient`; representation owner, universal domain, and finite evidence are defined in T1.S1.
+- [x] No transaction entry or internal Allocation operation in the bounded compiled production send graph stores, accepts, or selects a destination; root `Client` alone adapts the server to the caller-owned socket. The compiled source/diff and recorded census own this universal structural guarantee.
+- [x] Allocate, Refresh, CreatePermission, ChannelBind, lifetime-zero release, retries, and ChannelData preserve exact bytes, ordering, results, and error behavior.
+- [x] Transaction one-winner concurrency, Client nonterminal close, Allocation abort-before-notification-before-release, invalid-relayed cleanup, and caller socket ownership remain unchanged.
+- [x] No generic transport, authenticated exchange, builder, clock, or broader constructor module appears in the reviewed production diff; this is a universal structural guarantee over the bounded current source graph owned by the compiled source/diff and recorded census.
 
 ## Validation Gates
 

--- a/internal/client/allocation.go
+++ b/internal/client/allocation.go
@@ -15,15 +15,14 @@ import (
 
 // AllocationConfig is a set of configuration params used by NewUDPConn.
 type AllocationConfig struct {
-	// WriteTo sends data to the given destination on the client's base socket.
-	WriteTo func(data []byte, to net.Addr) (int, error)
-	// PerformTransaction runs a STUN transaction against the given destination.
-	PerformTransaction func(msg *stun.Message, to net.Addr, dontWait bool) (TransactionResult, error)
+	// WriteTo sends data to the configured server on the client's base socket.
+	WriteTo func(data []byte) (int, error)
+	// PerformTransaction runs a STUN transaction against the configured server.
+	PerformTransaction func(msg *stun.Message, dontWait bool) (TransactionResult, error)
 	// OnDeallocated is called once de-allocation of the relayed address is complete.
 	OnDeallocated func(relayedAddr net.Addr)
 
 	RelayedAddr               net.Addr
-	ServerAddr                net.Addr
 	Integrity                 stun.MessageIntegrity
 	Nonce                     stun.Nonce
 	Username                  stun.Username
@@ -59,7 +58,7 @@ func (c *UDPConn) refreshAllocation(lifetime time.Duration, dontWait bool) error
 		return fmt.Errorf("%w: %w", errFailedToBuildRefreshRequest, err)
 	}
 
-	trRes, err := c.performTransaction(msg, c.serverAddr, dontWait)
+	trRes, err := c.performTransaction(msg, dontWait)
 	if err != nil {
 		return fmt.Errorf("%w: %w", errFailedToRefreshAllocation, err)
 	}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -10,22 +10,22 @@ import (
 )
 
 type mockClient struct {
-	writeTo            func(data []byte, to net.Addr) (int, error)
-	performTransaction func(msg *stun.Message, to net.Addr, dontWait bool) (TransactionResult, error)
+	writeTo            func(data []byte) (int, error)
+	performTransaction func(msg *stun.Message, dontWait bool) (TransactionResult, error)
 	onDeallocated      func(relayedAddr net.Addr)
 }
 
-func (c *mockClient) WriteTo(data []byte, to net.Addr) (int, error) {
+func (c *mockClient) WriteTo(data []byte) (int, error) {
 	if c.writeTo != nil {
-		return c.writeTo(data, to)
+		return c.writeTo(data)
 	}
 
 	return 0, nil
 }
 
-func (c *mockClient) PerformTransaction(msg *stun.Message, to net.Addr, dontWait bool) (TransactionResult, error) {
+func (c *mockClient) PerformTransaction(msg *stun.Message, dontWait bool) (TransactionResult, error) {
 	if c.performTransaction != nil {
-		return c.performTransaction(msg, to, dontWait)
+		return c.performTransaction(msg, dontWait)
 	}
 
 	return TransactionResult{}, errFake

--- a/internal/client/prepare_test.go
+++ b/internal/client/prepare_test.go
@@ -47,7 +47,7 @@ func newPrepareHarness(t *testing.T, gateBinds bool) *prepareHarness {
 	}
 
 	mock := &mockClient{
-		performTransaction: func(msg *stun.Message, _ net.Addr, _ bool) (TransactionResult, error) {
+		performTransaction: func(msg *stun.Message, _ bool) (TransactionResult, error) {
 			switch msg.Type.Method {
 			case stun.MethodCreatePermission:
 				harness.permCount.Add(1)
@@ -86,7 +86,7 @@ func newPrepareHarness(t *testing.T, gateBinds bool) *prepareHarness {
 				return TransactionResult{}, errFake
 			}
 		},
-		writeTo: func(data []byte, _ net.Addr) (int, error) {
+		writeTo: func(data []byte) (int, error) {
 			harness.writes.Lock()
 			harness.writes.data = append(harness.writes.data, append([]byte(nil), data...))
 			harness.writes.Unlock()
@@ -101,7 +101,6 @@ func newPrepareHarness(t *testing.T, gateBinds bool) *prepareHarness {
 		PerformTransaction: mock.PerformTransaction,
 		OnDeallocated:      mock.OnDeallocated,
 		RelayedAddr:        &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 54321},
-		ServerAddr:         &net.UDPAddr{IP: net.ParseIP("10.0.0.1"), Port: 3478},
 		Username:           stun.NewUsername("user"),
 		Realm:              stun.NewRealm("realm"),
 		Integrity:          stun.NewShortTermIntegrity("pass"),
@@ -455,14 +454,14 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 		// First permission succeeds, but every ChannelBind transaction fails.
 		mock := harness.mock
 		inner := mock.performTransaction
-		mock.performTransaction = func(msg *stun.Message, to net.Addr, dontWait bool) (TransactionResult, error) {
+		mock.performTransaction = func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
 			if msg.Type.Method == stun.MethodChannelBind {
 				harness.bindCount.Add(1)
 
 				return TransactionResult{}, errFake
 			}
 
-			return inner(msg, to, dontWait)
+			return inner(msg, dontWait)
 		}
 
 		err := harness.conn.PreparePeer(context.Background(), harness.peer)
@@ -475,7 +474,7 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 
 		mock := harness.mock
 		inner := mock.performTransaction
-		mock.performTransaction = func(msg *stun.Message, to net.Addr, dontWait bool) (TransactionResult, error) {
+		mock.performTransaction = func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
 			if msg.Type.Method == stun.MethodChannelBind {
 				harness.bindCount.Add(1)
 
@@ -485,7 +484,7 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 				)}, nil
 			}
 
-			return inner(msg, to, dontWait)
+			return inner(msg, dontWait)
 		}
 
 		err := harness.conn.PreparePeer(context.Background(), harness.peer)

--- a/internal/client/refresh_failure_test.go
+++ b/internal/client/refresh_failure_test.go
@@ -42,7 +42,7 @@ func newRefreshFailureHarness(
 
 	harness := &refreshFailureHarness{waitedRefresh: waited, emitErr: emitErr}
 	mock := &mockClient{
-		performTransaction: func(msg *stun.Message, _ net.Addr, dontWait bool) (TransactionResult, error) {
+		performTransaction: func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
 			switch msg.Type.Method {
 			case stun.MethodRefresh:
 				if dontWait {
@@ -68,7 +68,7 @@ func newRefreshFailureHarness(
 				return TransactionResult{}, errFake
 			}
 		},
-		writeTo: func(data []byte, _ net.Addr) (int, error) {
+		writeTo: func(data []byte) (int, error) {
 			return len(data), nil
 		},
 	}
@@ -78,7 +78,6 @@ func newRefreshFailureHarness(
 		PerformTransaction: mock.PerformTransaction,
 		OnDeallocated:      mock.OnDeallocated,
 		RelayedAddr:        &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 54321},
-		ServerAddr:         &net.UDPAddr{IP: net.ParseIP("10.0.0.1"), Port: 3478},
 		Username:           stun.NewUsername("user"),
 		Realm:              stun.NewRealm("realm"),
 		Integrity:          stun.NewShortTermIntegrity("pass"),

--- a/internal/client/transaction.go
+++ b/internal/client/transaction.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	b64 "encoding/base64"
 	"fmt"
-	"net"
 	"sync"
 	"time"
 
@@ -28,7 +27,6 @@ type TransactionResult struct {
 type transactionRegistryEntry struct {
 	id       [stun.TransactionIDSize]byte
 	raw      []byte
-	to       net.Addr
 	interval time.Duration
 	nRtx     int
 	timer    *time.Timer
@@ -37,14 +35,14 @@ type transactionRegistryEntry struct {
 
 // TransactionRegistry owns the live transaction set and its terminal claims.
 type TransactionRegistry struct {
-	send  func([]byte, net.Addr) (int, error)
+	send  func([]byte) (int, error)
 	rto   time.Duration
 	mutex sync.Mutex
 	live  map[[stun.TransactionIDSize]byte]*transactionRegistryEntry
 }
 
 // NewTransactionRegistry creates a registry that can only send on the caller-owned socket.
-func NewTransactionRegistry(send func([]byte, net.Addr) (int, error), rto time.Duration) *TransactionRegistry {
+func NewTransactionRegistry(send func([]byte) (int, error), rto time.Duration) *TransactionRegistry {
 	return &TransactionRegistry{
 		send: send,
 		rto:  rto,
@@ -53,8 +51,8 @@ func NewTransactionRegistry(send func([]byte, net.Addr) (int, error), rto time.D
 }
 
 // Perform registers, initially sends, and waits for one transaction.
-func (r *TransactionRegistry) Perform(msg *stun.Message, to net.Addr) (TransactionResult, error) {
-	entry, err := r.begin(msg, to, false)
+func (r *TransactionRegistry) Perform(msg *stun.Message) (TransactionResult, error) {
+	entry, err := r.begin(msg, false)
 	if err != nil {
 		return TransactionResult{}, err
 	}
@@ -63,8 +61,8 @@ func (r *TransactionRegistry) Perform(msg *stun.Message, to net.Addr) (Transacti
 }
 
 // Start registers and initially sends one fire-and-forget transaction.
-func (r *TransactionRegistry) Start(msg *stun.Message, to net.Addr) error {
-	_, err := r.begin(msg, to, true)
+func (r *TransactionRegistry) Start(msg *stun.Message) error {
+	_, err := r.begin(msg, true)
 
 	return err
 }
@@ -73,13 +71,12 @@ func (r *TransactionRegistry) Start(msg *stun.Message, to net.Addr) error {
 func (r *TransactionRegistry) PerformWithContext(
 	ctx context.Context,
 	msg *stun.Message,
-	to net.Addr,
 ) (TransactionResult, error) {
 	if err := ctx.Err(); err != nil {
 		return TransactionResult{}, context.Cause(ctx)
 	}
 
-	entry, err := r.begin(msg, to, false)
+	entry, err := r.begin(msg, false)
 	if err != nil {
 		return TransactionResult{}, err
 	}
@@ -108,13 +105,11 @@ func (r *TransactionRegistry) PerformWithContext(
 
 func (r *TransactionRegistry) begin(
 	msg *stun.Message,
-	to net.Addr,
 	ignoreResult bool,
 ) (*transactionRegistryEntry, error) {
 	entry := &transactionRegistryEntry{
 		id:       msg.TransactionID,
 		raw:      append([]byte(nil), msg.Raw...),
-		to:       to,
 		interval: r.rto,
 	}
 	if !ignoreResult {
@@ -130,7 +125,7 @@ func (r *TransactionRegistry) begin(
 	r.live[msg.TransactionID] = entry
 	r.mutex.Unlock()
 
-	if _, err := r.send(entry.raw, entry.to); err != nil {
+	if _, err := r.send(entry.raw); err != nil {
 		r.mutex.Lock()
 		if r.live[entry.id] == entry {
 			delete(r.live, entry.id)
@@ -179,7 +174,7 @@ func (r *TransactionRegistry) retry(entry *transactionRegistryEntry) {
 	}
 	r.mutex.Unlock()
 
-	_, err := r.send(entry.raw, entry.to)
+	_, err := r.send(entry.raw)
 
 	r.mutex.Lock()
 	if r.live[entry.id] != entry {

--- a/internal/client/transaction_test.go
+++ b/internal/client/transaction_test.go
@@ -18,7 +18,6 @@ import (
 )
 
 func TestTransactionRegistryInitialSendFailureRollsBack(t *testing.T) {
-	server := &net.UDPAddr{IP: net.ParseIP("192.0.2.1"), Port: 3478}
 	request := stun.MustBuild(stun.TransactionID, stun.BindingRequest)
 	response := stun.MustBuild(
 		stun.NewTransactionIDSetter(request.TransactionID),
@@ -26,7 +25,7 @@ func TestTransactionRegistryInitialSendFailureRollsBack(t *testing.T) {
 	)
 	sendErr := errors.New("initial send failed") //nolint:err113 // test-local failure
 	var sends atomic.Int32
-	registry := NewTransactionRegistry(func([]byte, net.Addr) (int, error) {
+	registry := NewTransactionRegistry(func([]byte) (int, error) {
 		if sends.Add(1) == 1 {
 			return 0, sendErr
 		}
@@ -34,12 +33,12 @@ func TestTransactionRegistryInitialSendFailureRollsBack(t *testing.T) {
 		return len(request.Raw), nil
 	}, time.Hour)
 
-	_, err := registry.Perform(request, server)
+	_, err := registry.Perform(request)
 	require.ErrorIs(t, err, sendErr)
 
 	resultCh := make(chan TransactionResult, 1)
 	go func() {
-		result, _ := registry.Perform(request, server)
+		result, _ := registry.Perform(request)
 		resultCh <- result
 	}()
 	require.Eventually(t, func() bool { return sends.Load() == 2 }, time.Second, time.Millisecond)
@@ -54,14 +53,13 @@ func TestTransactionRegistryInitialSendFailureRollsBack(t *testing.T) {
 }
 
 func TestTransactionRegistryRejectsDuplicateLiveID(t *testing.T) {
-	server := &net.UDPAddr{IP: net.ParseIP("192.0.2.1"), Port: 3478}
 	request := stun.MustBuild(stun.TransactionID, stun.BindingRequest)
 	response := stun.MustBuild(
 		stun.NewTransactionIDSetter(request.TransactionID),
 		stun.NewType(stun.MethodBinding, stun.ClassSuccessResponse),
 	)
 	var sends atomic.Int32
-	registry := NewTransactionRegistry(func(raw []byte, _ net.Addr) (int, error) {
+	registry := NewTransactionRegistry(func(raw []byte) (int, error) {
 		sends.Add(1)
 
 		return len(raw), nil
@@ -69,12 +67,12 @@ func TestTransactionRegistryRejectsDuplicateLiveID(t *testing.T) {
 
 	firstResult := make(chan TransactionResult, 1)
 	go func() {
-		result, _ := registry.Perform(request, server)
+		result, _ := registry.Perform(request)
 		firstResult <- result
 	}()
 	require.Eventually(t, func() bool { return sends.Load() == 1 }, time.Second, time.Millisecond)
 
-	_, err := registry.Perform(request, server)
+	_, err := registry.Perform(request)
 	require.ErrorIs(t, err, errTransactionAlreadyExists)
 	assert.Equal(t, int32(1), sends.Load(), "a duplicate must not reach the socket")
 
@@ -88,11 +86,10 @@ func TestTransactionRegistryRejectsDuplicateLiveID(t *testing.T) {
 }
 
 func TestTransactionRegistryAbortWinsBlockedInitialSend(t *testing.T) {
-	server := &net.UDPAddr{IP: net.ParseIP("192.0.2.1"), Port: 3478}
 	request := stun.MustBuild(stun.TransactionID, stun.BindingRequest)
 	sendStarted := make(chan struct{})
 	releaseSend := make(chan struct{})
-	registry := NewTransactionRegistry(func(raw []byte, _ net.Addr) (int, error) {
+	registry := NewTransactionRegistry(func(raw []byte) (int, error) {
 		close(sendStarted)
 		<-releaseSend
 
@@ -101,7 +98,7 @@ func TestTransactionRegistryAbortWinsBlockedInitialSend(t *testing.T) {
 
 	resultCh := make(chan error, 1)
 	go func() {
-		_, err := registry.Perform(request, server)
+		_, err := registry.Perform(request)
 		resultCh <- err
 	}()
 	<-sendStarted
@@ -117,14 +114,13 @@ func TestTransactionRegistryAbortWinsBlockedInitialSend(t *testing.T) {
 }
 
 func TestTransactionRegistryCancellationClaimsLiveWait(t *testing.T) {
-	server := &net.UDPAddr{IP: net.ParseIP("192.0.2.1"), Port: 3478}
 	request := stun.MustBuild(stun.TransactionID, stun.BindingRequest)
 	response := stun.MustBuild(
 		stun.NewTransactionIDSetter(request.TransactionID),
 		stun.NewType(stun.MethodBinding, stun.ClassSuccessResponse),
 	)
 	sent := make(chan struct{})
-	registry := NewTransactionRegistry(func(raw []byte, _ net.Addr) (int, error) {
+	registry := NewTransactionRegistry(func(raw []byte) (int, error) {
 		close(sent)
 
 		return len(raw), nil
@@ -134,7 +130,7 @@ func TestTransactionRegistryCancellationClaimsLiveWait(t *testing.T) {
 
 	resultCh := make(chan error, 1)
 	go func() {
-		_, err := registry.PerformWithContext(ctx, request, server)
+		_, err := registry.PerformWithContext(ctx, request)
 		resultCh <- err
 	}()
 	<-sent
@@ -151,12 +147,11 @@ func TestTransactionRegistryCancellationClaimsLiveWait(t *testing.T) {
 }
 
 func TestTransactionRegistryExhaustionSendsSevenByteIdenticalRequests(t *testing.T) {
-	server := &net.UDPAddr{IP: net.ParseIP("192.0.2.1"), Port: 3478}
 	request := stun.MustBuild(stun.TransactionID, stun.BindingRequest)
 	expected := append([]byte(nil), request.Raw...)
 	initialSent := make(chan struct{})
 	var writes atomic.Int32
-	registry := NewTransactionRegistry(func(raw []byte, _ net.Addr) (int, error) {
+	registry := NewTransactionRegistry(func(raw []byte) (int, error) {
 		assert.True(t, bytes.Equal(expected, raw), "every retry must preserve the supplied bytes")
 		if writes.Add(1) == 1 {
 			close(initialSent)
@@ -167,7 +162,7 @@ func TestTransactionRegistryExhaustionSendsSevenByteIdenticalRequests(t *testing
 
 	resultCh := make(chan error, 1)
 	go func() {
-		_, err := registry.Perform(request, server)
+		_, err := registry.Perform(request)
 		resultCh <- err
 	}()
 	<-initialSent
@@ -183,7 +178,6 @@ func TestTransactionRegistryExhaustionSendsSevenByteIdenticalRequests(t *testing
 }
 
 func TestTransactionRegistryResponseWinsBlockedInitialSend(t *testing.T) {
-	server := &net.UDPAddr{IP: net.ParseIP("192.0.2.1"), Port: 3478}
 	request := stun.MustBuild(stun.TransactionID, stun.BindingRequest)
 	response := stun.MustBuild(
 		stun.NewTransactionIDSetter(request.TransactionID),
@@ -192,7 +186,7 @@ func TestTransactionRegistryResponseWinsBlockedInitialSend(t *testing.T) {
 	sendStarted := make(chan struct{})
 	releaseSend := make(chan struct{})
 	var sends atomic.Int32
-	registry := NewTransactionRegistry(func(raw []byte, _ net.Addr) (int, error) {
+	registry := NewTransactionRegistry(func(raw []byte) (int, error) {
 		sends.Add(1)
 		close(sendStarted)
 		<-releaseSend
@@ -202,7 +196,7 @@ func TestTransactionRegistryResponseWinsBlockedInitialSend(t *testing.T) {
 
 	resultCh := make(chan TransactionResult, 1)
 	go func() {
-		result, _ := registry.Perform(request, server)
+		result, _ := registry.Perform(request)
 		resultCh <- result
 	}()
 	<-sendStarted
@@ -220,12 +214,11 @@ func TestTransactionRegistryResponseWinsBlockedInitialSend(t *testing.T) {
 }
 
 func TestTransactionRegistryInitialSendErrorSurvivesAbort(t *testing.T) {
-	server := &net.UDPAddr{IP: net.ParseIP("192.0.2.1"), Port: 3478}
 	request := stun.MustBuild(stun.TransactionID, stun.BindingRequest)
 	sendStarted := make(chan struct{})
 	releaseSend := make(chan struct{})
 	sendErr := errors.New("blocked initial send failed") //nolint:err113 // test-local failure
-	registry := NewTransactionRegistry(func([]byte, net.Addr) (int, error) {
+	registry := NewTransactionRegistry(func([]byte) (int, error) {
 		close(sendStarted)
 		<-releaseSend
 
@@ -234,7 +227,7 @@ func TestTransactionRegistryInitialSendErrorSurvivesAbort(t *testing.T) {
 
 	resultCh := make(chan error, 1)
 	go func() {
-		_, err := registry.Perform(request, server)
+		_, err := registry.Perform(request)
 		resultCh <- err
 	}()
 	<-sendStarted
@@ -250,8 +243,6 @@ func TestTransactionRegistryInitialSendErrorSurvivesAbort(t *testing.T) {
 }
 
 func TestTransactionRegistryClaimDuringBlockedRetryPreventsRearm(t *testing.T) {
-	server := &net.UDPAddr{IP: net.ParseIP("192.0.2.1"), Port: 3478}
-
 	for _, tc := range []struct {
 		name   string
 		claim  func(*TransactionRegistry, *stun.Message)
@@ -288,7 +279,7 @@ func TestTransactionRegistryClaimDuringBlockedRetryPreventsRearm(t *testing.T) {
 			retryStarted := make(chan struct{})
 			releaseRetry := make(chan struct{})
 			var sends atomic.Int32
-			registry := NewTransactionRegistry(func(raw []byte, _ net.Addr) (int, error) {
+			registry := NewTransactionRegistry(func(raw []byte) (int, error) {
 				if sends.Add(1) == 2 {
 					close(retryStarted)
 					<-releaseRetry
@@ -303,7 +294,7 @@ func TestTransactionRegistryClaimDuringBlockedRetryPreventsRearm(t *testing.T) {
 			}
 			outcomeCh := make(chan outcome, 1)
 			go func() {
-				result, err := registry.Perform(request, server)
+				result, err := registry.Perform(request)
 				outcomeCh <- outcome{result: result, err: err}
 			}()
 			<-retryStarted
@@ -323,7 +314,6 @@ func TestTransactionRegistryClaimDuringBlockedRetryPreventsRearm(t *testing.T) {
 }
 
 func TestTransactionRegistryWaitedRetryFailureRetires(t *testing.T) {
-	server := &net.UDPAddr{IP: net.ParseIP("192.0.2.1"), Port: 3478}
 	request := stun.MustBuild(stun.TransactionID, stun.BindingRequest)
 	response := stun.MustBuild(
 		stun.NewTransactionIDSetter(request.TransactionID),
@@ -333,7 +323,7 @@ func TestTransactionRegistryWaitedRetryFailureRetires(t *testing.T) {
 	var sends atomic.Int32
 	replacementStarted := make(chan struct{})
 	releaseReplacement := make(chan struct{})
-	registry := NewTransactionRegistry(func(raw []byte, _ net.Addr) (int, error) {
+	registry := NewTransactionRegistry(func(raw []byte) (int, error) {
 		sendNumber := sends.Add(1)
 		if sendNumber == 2 {
 			return 0, retryErr
@@ -346,13 +336,13 @@ func TestTransactionRegistryWaitedRetryFailureRetires(t *testing.T) {
 		return len(raw), nil
 	}, time.Millisecond)
 
-	_, err := registry.Perform(request, server)
+	_, err := registry.Perform(request)
 	require.ErrorIs(t, err, retryErr)
 	assert.Equal(t, int32(2), sends.Load())
 
 	resultCh := make(chan TransactionResult, 1)
 	go func() {
-		result, _ := registry.Perform(request, server)
+		result, _ := registry.Perform(request)
 		resultCh <- result
 	}()
 	<-replacementStarted
@@ -367,8 +357,6 @@ func TestTransactionRegistryWaitedRetryFailureRetires(t *testing.T) {
 }
 
 func TestTransactionRegistryFireAndForgetRetiresOnEveryTerminalPath(t *testing.T) {
-	server := &net.UDPAddr{IP: net.ParseIP("192.0.2.1"), Port: 3478}
-
 	t.Run("response", func(t *testing.T) {
 		request := stun.MustBuild(stun.TransactionID, stun.BindingRequest)
 		response := stun.MustBuild(
@@ -376,16 +364,16 @@ func TestTransactionRegistryFireAndForgetRetiresOnEveryTerminalPath(t *testing.T
 			stun.NewType(stun.MethodBinding, stun.ClassSuccessResponse),
 		)
 		var sends atomic.Int32
-		registry := NewTransactionRegistry(func(raw []byte, _ net.Addr) (int, error) {
+		registry := NewTransactionRegistry(func(raw []byte) (int, error) {
 			sends.Add(1)
 
 			return len(raw), nil
 		}, time.Hour)
 
-		err := registry.Start(request, server)
+		err := registry.Start(request)
 		require.NoError(t, err)
 		registry.Complete(response)
-		err = registry.Start(request, server)
+		err = registry.Start(request)
 		require.NoError(t, err, "the response must retire fire-and-forget ownership")
 		assert.Equal(t, int32(2), sends.Load())
 		registry.AbortCurrent()
@@ -395,7 +383,7 @@ func TestTransactionRegistryFireAndForgetRetiresOnEveryTerminalPath(t *testing.T
 		request := stun.MustBuild(stun.TransactionID, stun.BindingRequest)
 		retryErr := errors.New("retry failed") //nolint:err113 // test-local failure
 		var sends atomic.Int32
-		registry := NewTransactionRegistry(func(raw []byte, _ net.Addr) (int, error) {
+		registry := NewTransactionRegistry(func(raw []byte) (int, error) {
 			if sends.Add(1) == 2 {
 				return 0, retryErr
 			}
@@ -403,10 +391,10 @@ func TestTransactionRegistryFireAndForgetRetiresOnEveryTerminalPath(t *testing.T
 			return len(raw), nil
 		}, time.Millisecond)
 
-		err := registry.Start(request, server)
+		err := registry.Start(request)
 		require.NoError(t, err)
 		require.Eventually(t, func() bool {
-			performErr := registry.Start(request, server)
+			performErr := registry.Start(request)
 
 			return performErr == nil
 		}, time.Second, time.Millisecond, "a failed retry must retire fire-and-forget ownership")
@@ -416,16 +404,16 @@ func TestTransactionRegistryFireAndForgetRetiresOnEveryTerminalPath(t *testing.T
 	t.Run("exhaustion", func(t *testing.T) {
 		request := stun.MustBuild(stun.TransactionID, stun.BindingRequest)
 		var sends atomic.Int32
-		registry := NewTransactionRegistry(func(raw []byte, _ net.Addr) (int, error) {
+		registry := NewTransactionRegistry(func(raw []byte) (int, error) {
 			sends.Add(1)
 
 			return len(raw), nil
 		}, time.Millisecond)
 
-		err := registry.Start(request, server)
+		err := registry.Start(request)
 		require.NoError(t, err)
 		require.Eventually(t, func() bool {
-			performErr := registry.Start(request, server)
+			performErr := registry.Start(request)
 
 			return performErr == nil
 		}, time.Second, time.Millisecond, "exhaustion must retire fire-and-forget ownership")

--- a/internal/client/udp_conn.go
+++ b/internal/client/udp_conn.go
@@ -46,13 +46,12 @@ type inboundData struct {
 type UDPConn struct {
 	// Package-crossing operations are immutable production/mock adapters. They
 	// do not own or mutate Allocation lifecycle state.
-	writeTo            func(data []byte, to net.Addr) (int, error)
-	performTransaction func(msg *stun.Message, to net.Addr, dontWait bool) (TransactionResult, error)
+	writeTo            func(data []byte) (int, error)
+	performTransaction func(msg *stun.Message, dontWait bool) (TransactionResult, error)
 	onDeallocated      func(relayedAddr net.Addr)
 	abortTransactions  func()
 
 	relayedAddr net.Addr // Read-only
-	serverAddr  net.Addr // Read-only
 	permMap     *permissionMap
 	integrity   stun.MessageIntegrity // Read-only
 	username    stun.Username         // Read-only
@@ -94,7 +93,6 @@ func NewUDPConn(config *AllocationConfig, abortTransactions func()) *UDPConn {
 		onDeallocated:          config.OnDeallocated,
 		abortTransactions:      abortTransactions,
 		relayedAddr:            config.RelayedAddr,
-		serverAddr:             config.ServerAddr,
 		permMap:                newPermissionMap(),
 		integrity:              config.Integrity,
 		username:               config.Username,
@@ -601,7 +599,7 @@ func (c *UDPConn) CreatePermissions(addrs ...netip.AddrPort) error {
 		return err
 	}
 
-	trRes, err := c.performTransaction(msg, c.serverAddr, false)
+	trRes, err := c.performTransaction(msg, false)
 	if err != nil {
 		return err
 	}
@@ -792,7 +790,7 @@ func (c *UDPConn) bind(bound *binding) error {
 		return err
 	}
 
-	trRes, err := c.performTransaction(msg, c.serverAddr, false)
+	trRes, err := c.performTransaction(msg, false)
 	if err != nil {
 		return fmt.Errorf("%w: %w", errChannelBindTransactionFailed, err)
 	}
@@ -838,7 +836,7 @@ func (c *UDPConn) sendChannelData(data []byte, chNum uint16) (int, error) {
 		Number: proto.ChannelNumber(chNum),
 	}
 	chData.Encode()
-	_, err := c.writeTo(chData.Raw, c.serverAddr)
+	_, err := c.writeTo(chData.Raw)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/client/udp_conn_test.go
+++ b/internal/client/udp_conn_test.go
@@ -56,7 +56,6 @@ func TestNewUDPConnRejectsMissingAbortBeforeStartingWork(t *testing.T) {
 			PerformTransaction: mock.PerformTransaction,
 			OnDeallocated:      mock.OnDeallocated,
 			RelayedAddr:        &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 54321},
-			ServerAddr:         &net.UDPAddr{IP: net.ParseIP("10.0.0.1"), Port: 3478},
 			Username:           stun.NewUsername("user"),
 			Realm:              stun.NewRealm("realm"),
 			Integrity:          stun.NewShortTermIntegrity("pass"),
@@ -97,7 +96,6 @@ func TestRefreshAllocationPreservesRequestAndRetriesStaleNonce(t *testing.T) {
 	integrity := stun.NewShortTermIntegrity("pass")
 	oldNonce := stun.NewNonce("old-nonce")
 	freshNonce := stun.NewNonce("fresh-nonce")
-	serverAddr := &net.UDPAddr{IP: net.ParseIP("10.0.0.1"), Port: 3478}
 
 	for _, tt := range []struct {
 		name       string
@@ -110,7 +108,7 @@ func TestRefreshAllocationPreservesRequestAndRetriesStaleNonce(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			calls := 0
 			mock := &mockClient{
-				performTransaction: func(msg *stun.Message, _ net.Addr, dontWait bool) (TransactionResult, error) {
+				performTransaction: func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
 					calls++
 					assert.False(t, dontWait)
 					nonce := oldNonce
@@ -148,12 +146,11 @@ func TestRefreshAllocationPreservesRequestAndRetriesStaleNonce(t *testing.T) {
 				},
 			}
 			conn := UDPConn{
-				serverAddr: serverAddr,
-				username:   username,
-				realm:      realm,
-				integrity:  integrity,
-				_nonce:     oldNonce,
-				_lifetime:  lifetime,
+				username:  username,
+				realm:     realm,
+				integrity: integrity,
+				_nonce:    oldNonce,
+				_lifetime: lifetime,
 			}
 			mock.configure(&conn)
 
@@ -175,14 +172,13 @@ func TestPermissionAndBindingRequestShapes(t *testing.T) {
 	realm := stun.NewRealm("realm")
 	integrity := stun.NewShortTermIntegrity("pass")
 	nonce := stun.NewNonce("nonce")
-	serverAddr := &net.UDPAddr{IP: net.ParseIP("10.0.0.1"), Port: 3478}
 	peerA := netip.MustParseAddrPort("192.0.2.1:5000")
 	peerB := netip.MustParseAddrPort("192.0.2.2:6000")
 	bindingMgr := newBindingManager()
 	bound := requireBinding(t, bindingMgr, peerA)
 
 	mock := &mockClient{
-		performTransaction: func(msg *stun.Message, _ net.Addr, dontWait bool) (TransactionResult, error) {
+		performTransaction: func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
 			assert.False(t, dontWait)
 			switch msg.Type.Method {
 			case stun.MethodCreatePermission:
@@ -237,7 +233,6 @@ func TestPermissionAndBindingRequestShapes(t *testing.T) {
 		},
 	}
 	conn := UDPConn{
-		serverAddr: serverAddr,
 		username:   username,
 		realm:      realm,
 		integrity:  integrity,
@@ -306,7 +301,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 				bm := newBindingManager()
 				bound := requireBinding(t, bm, netip.MustParseAddrPort("127.0.0.1:1234"))
 				conn := makeConn(&mockClient{
-					performTransaction: func(msg *stun.Message, addr net.Addr, dontWait bool) (TransactionResult, error) {
+					performTransaction: func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
 						<-unblock
 						if tt.shouldSucceed {
 							return TransactionResult{Msg: new(stun.Message)}, nil
@@ -337,7 +332,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 	t.Run("bind()", func(t *testing.T) {
 		tests := []struct {
 			name                 string
-			transactionFn        func(*stun.Message, net.Addr, bool) (TransactionResult, error)
+			transactionFn        func(*stun.Message, bool) (TransactionResult, error)
 			expectErr            error
 			expectErrContains    string
 			expectBadRequest     bool
@@ -347,7 +342,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		}{
 			{
 				name: "PerformTransaction returns error",
-				transactionFn: func(*stun.Message, net.Addr, bool) (TransactionResult, error) {
+				transactionFn: func(*stun.Message, bool) (TransactionResult, error) {
 					return TransactionResult{}, errFake
 				},
 				expectErr:            errFake,
@@ -355,7 +350,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 			},
 			{
 				name: "ErrorResponse with CodeStaleNonce triggers nonce update",
-				transactionFn: func(*stun.Message, net.Addr, bool) (TransactionResult, error) {
+				transactionFn: func(*stun.Message, bool) (TransactionResult, error) {
 					return TransactionResult{Msg: staleNonceMsg()}, nil
 				},
 				expectErr:          errTryAgain,
@@ -363,7 +358,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 			},
 			{
 				name: "ErrorResponse with error code returns cannot bind channel error",
-				transactionFn: func(*stun.Message, net.Addr, bool) (TransactionResult, error) {
+				transactionFn: func(*stun.Message, bool) (TransactionResult, error) {
 					res := stun.MustBuild(
 						stun.NewType(stun.MethodChannelBind, stun.ClassErrorResponse),
 						stun.ErrorCodeAttribute{Code: stun.CodeForbidden, Reason: []byte("Forbidden")},
@@ -377,7 +372,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 			},
 			{
 				name: "ErrorResponse with CodeBadRequest is detectable",
-				transactionFn: func(*stun.Message, net.Addr, bool) (TransactionResult, error) {
+				transactionFn: func(*stun.Message, bool) (TransactionResult, error) {
 					res := stun.MustBuild(
 						stun.NewType(stun.MethodChannelBind, stun.ClassErrorResponse),
 						stun.ErrorCodeAttribute{Code: stun.CodeBadRequest, Reason: []byte("Bad Request")},
@@ -392,7 +387,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 			},
 			{
 				name: "ErrorResponse without error code returns unexpected response type error",
-				transactionFn: func(*stun.Message, net.Addr, bool) (TransactionResult, error) {
+				transactionFn: func(*stun.Message, bool) (TransactionResult, error) {
 					res := stun.MustBuild(
 						stun.NewType(stun.MethodChannelBind, stun.ClassErrorResponse),
 					)
@@ -459,7 +454,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		bound := requireBinding(t, bm, netip.MustParseAddrPort("127.0.0.1:1234"))
 		var attempts atomic.Int32
 		conn := makeConn(&mockClient{
-			performTransaction: func(*stun.Message, net.Addr, bool) (TransactionResult, error) {
+			performTransaction: func(*stun.Message, bool) (TransactionResult, error) {
 				attempts.Add(1)
 
 				return TransactionResult{Msg: staleNonceMsg()}, nil
@@ -481,7 +476,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		bound := requireBinding(t, bm, netip.MustParseAddrPort("127.0.0.1:1234"))
 		originalCh := bound.number
 		conn := makeConn(&mockClient{
-			performTransaction: func(msg *stun.Message, addr net.Addr, dontWait bool) (TransactionResult, error) {
+			performTransaction: func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
 				if failed.CompareAndSwap(false, true) {
 					return TransactionResult{}, errFake
 				}
@@ -508,15 +503,13 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 	t.Run("ChannelBind 400 closes allocation", func(t *testing.T) {
 		relayedAddr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 54321}
 		peerAddr := netip.MustParseAddrPort("127.0.0.1:50000")
-		serverAddr := &net.UDPAddr{IP: net.ParseIP("10.0.0.1"), Port: 3478}
-
 		deallocatedCh := make(chan net.Addr, 1)
 		refreshLifetimeCh := make(chan time.Duration, 1)
 		refreshDontWaitCh := make(chan bool, 1)
 		refreshErrCh := make(chan error, 1)
 
 		client := &mockClient{
-			performTransaction: func(msg *stun.Message, _ net.Addr, dontWait bool) (TransactionResult, error) {
+			performTransaction: func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
 				switch msg.Type.Method {
 				case stun.MethodChannelBind:
 					return TransactionResult{
@@ -549,7 +542,6 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 			PerformTransaction: client.PerformTransaction,
 			OnDeallocated:      client.OnDeallocated,
 			RelayedAddr:        relayedAddr,
-			ServerAddr:         serverAddr,
 			Username:           stun.NewUsername("user"),
 			Realm:              stun.NewRealm("realm"),
 			Integrity:          stun.NewShortTermIntegrity("pass"),
@@ -605,13 +597,11 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 	t.Run("ChannelBind 400 after unknown binding closes allocation", func(t *testing.T) {
 		relayedAddr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 54321}
 		peerAddr := netip.MustParseAddrPort("127.0.0.1:1234")
-		serverAddr := &net.UDPAddr{IP: net.ParseIP("10.0.0.1"), Port: 3478}
-
 		var channelBindAttempts atomic.Int32
 		deallocatedCh := make(chan net.Addr, 1)
 
 		client := &mockClient{
-			performTransaction: func(msg *stun.Message, addr net.Addr, dontWait bool) (TransactionResult, error) {
+			performTransaction: func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
 				switch msg.Type.Method {
 				case stun.MethodChannelBind:
 					if channelBindAttempts.Add(1) == 1 {
@@ -634,7 +624,6 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 			PerformTransaction: client.PerformTransaction,
 			OnDeallocated:      client.OnDeallocated,
 			RelayedAddr:        relayedAddr,
-			ServerAddr:         serverAddr,
 			Username:           stun.NewUsername("user"),
 			Realm:              stun.NewRealm("realm"),
 			Integrity:          stun.NewShortTermIntegrity("pass"),
@@ -672,12 +661,10 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 	t.Run("ChannelBind 400 after lost ready refresh keeps saved binding", func(t *testing.T) {
 		relayedAddr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 54321}
 		peerAddr := netip.MustParseAddrPort("127.0.0.1:1234")
-		serverAddr := &net.UDPAddr{IP: net.ParseIP("10.0.0.1"), Port: 3478}
-
 		var channelBindAttempts atomic.Int32
 
 		client := &mockClient{
-			performTransaction: func(msg *stun.Message, addr net.Addr, dontWait bool) (TransactionResult, error) {
+			performTransaction: func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
 				switch msg.Type.Method {
 				case stun.MethodChannelBind:
 					if channelBindAttempts.Add(1) == 1 {
@@ -697,7 +684,6 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 			PerformTransaction: client.PerformTransaction,
 			OnDeallocated:      client.OnDeallocated,
 			RelayedAddr:        relayedAddr,
-			ServerAddr:         serverAddr,
 			Username:           stun.NewUsername("user"),
 			Realm:              stun.NewRealm("realm"),
 			Integrity:          stun.NewShortTermIntegrity("pass"),
@@ -732,7 +718,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		bound.setState(bindingStateReady)
 		bound.setRefreshedAt(staleRefreshedAt)
 		conn := makeConn(&mockClient{
-			performTransaction: func(msg *stun.Message, addr net.Addr, dontWait bool) (TransactionResult, error) {
+			performTransaction: func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
 				channelBindAttempts.Add(1)
 
 				return TransactionResult{Msg: badRequestMsg()}, nil
@@ -753,10 +739,10 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 
 	t.Run("WriteTo()", func(t *testing.T) {
 		client := &mockClient{
-			performTransaction: func(*stun.Message, net.Addr, bool) (TransactionResult, error) {
+			performTransaction: func(*stun.Message, bool) (TransactionResult, error) {
 				return TransactionResult{}, errFake
 			},
-			writeTo: func(data []byte, _ net.Addr) (int, error) {
+			writeTo: func(data []byte) (int, error) {
 				return len(data), nil
 			},
 		}
@@ -788,8 +774,6 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 
 	t.Run("ChannelBind transaction failure retains channel number", func(t *testing.T) {
 		addr := netip.MustParseAddrPort("127.0.0.1:9999")
-		serverAddr := &net.UDPAddr{IP: net.ParseIP("10.0.0.1"), Port: 3478}
-
 		pm := newPermissionMap()
 		assert.True(t, pm.insert(addr, &permission{st: permStatePermitted}))
 
@@ -798,16 +782,15 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		originalCh := bound.number
 
 		client := &mockClient{
-			performTransaction: func(*stun.Message, net.Addr, bool) (TransactionResult, error) {
+			performTransaction: func(*stun.Message, bool) (TransactionResult, error) {
 				return TransactionResult{}, errFake
 			},
-			writeTo: func(data []byte, _ net.Addr) (int, error) {
+			writeTo: func(data []byte) (int, error) {
 				return len(data), nil
 			},
 		}
 
 		conn := UDPConn{
-			serverAddr: serverAddr,
 			permMap:    pm,
 			username:   stun.NewUsername("user"),
 			realm:      stun.NewRealm("realm"),
@@ -836,7 +819,7 @@ func TestCreatePermissions(t *testing.T) {
 	t.Run("CreatePermissions success", func(t *testing.T) {
 		called := false
 		client := &mockClient{
-			performTransaction: func(msg *stun.Message, addr net.Addr, _ bool) (TransactionResult, error) {
+			performTransaction: func(msg *stun.Message, _ bool) (TransactionResult, error) {
 				called = true
 				// Simulate a successful response
 				res := stun.New()
@@ -846,11 +829,10 @@ func TestCreatePermissions(t *testing.T) {
 			},
 		}
 		conn := &UDPConn{
-			serverAddr: &net.UDPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 3478},
-			username:   stun.NewUsername("user"),
-			realm:      stun.NewRealm("realm"),
-			integrity:  stun.NewShortTermIntegrity("pass"),
-			_nonce:     stun.NewNonce("nonce"),
+			username:  stun.NewUsername("user"),
+			realm:     stun.NewRealm("realm"),
+			integrity: stun.NewShortTermIntegrity("pass"),
+			_nonce:    stun.NewNonce("nonce"),
 		}
 		client.configure(conn)
 		addr := netip.MustParseAddrPort("5.6.7.8:12345")
@@ -861,7 +843,7 @@ func TestCreatePermissions(t *testing.T) {
 
 	t.Run("CreatePermissions error", func(t *testing.T) {
 		client := &mockClient{
-			performTransaction: func(msg *stun.Message, addr net.Addr, _ bool) (TransactionResult, error) {
+			performTransaction: func(msg *stun.Message, _ bool) (TransactionResult, error) {
 				res := stun.New()
 				res.Type = stun.NewType(stun.MethodCreatePermission, stun.ClassErrorResponse)
 				code := stun.ErrorCodeAttribute{
@@ -874,11 +856,10 @@ func TestCreatePermissions(t *testing.T) {
 			},
 		}
 		conn := &UDPConn{
-			serverAddr: &net.UDPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 3478},
-			username:   stun.NewUsername("user"),
-			realm:      stun.NewRealm("realm"),
-			integrity:  stun.NewShortTermIntegrity("pass"),
-			_nonce:     stun.NewNonce("nonce"),
+			username:  stun.NewUsername("user"),
+			realm:     stun.NewRealm("realm"),
+			integrity: stun.NewShortTermIntegrity("pass"),
+			_nonce:    stun.NewNonce("nonce"),
 		}
 		client.configure(conn)
 		addr := netip.MustParseAddrPort("5.6.7.8:12345")


### PR DESCRIPTION
Closes #68
Parent: #65

Implements `docs/adr/2026-08-19-server-bound-transport-plan.md` at **Slice T1.S1 — Remove destination authority from outbound internals**, recorded plan commit `f722466a1864b1ca89e9e364daa962a7c1c5ba23`.

## Outcome

Root `Client` now captures the configured canonical server in one `sendToServer` adapter. Transaction registry entries and operations, Allocation construction, `UDPConn`, Refresh, CreatePermission, ChannelBind, lifetime-zero release, retries, and ChannelData no longer store, accept, or select an outbound destination.

## Review contract

- Supported representation domain: the finite current non-test UDP Client send graph across anonymous/authenticated Allocate, retry, ordinary/lifetime-zero Refresh, CreatePermission, ChannelBind, and ChannelData.
- Representation owners: `NewClient` and canonical validation own server identity; Pion/proto own bytes; root `Client.sendToServer` owns socket-address adaptation; compiled source and the bounded census own destination-free structure.
- Guarantee: universal over every datagram emitted through that finite current graph, not future transports or destinations.
- Shipped/safety artifacts: bound sends and destination-free structural enforcement. Observer, request-shape, registry race, and lifecycle tests are verification aids; plans/issues/review receipts are traceability metadata. No maintained verification aid is introduced.
- Non-goals: no public API, bytes/setter order, authentication, retry/timing, socket ownership, lifecycle, error-chain, package-layout, builder/factory, generic transport, or performance change.
- Terminating evidence: configured-server Allocate observation; method-class request/ChannelData/lifetime-zero evidence; registry copied-byte/retry/concurrency suite; cancellation, close, invalid-relayed and lifecycle preservation; bounded source census; `go test ./...`; `go test -race ./...`; exact-head `task preflight`; same-head hosted CI; one fresh review and at most one replacement.
- Review budget: one initial RAS review, fix/verify only independently accepted `fix-now` findings, and at most one replacement review.
- Contract closure: not triggered; the material invariant has a finite send graph and one adapter reasonably covered by signatures, census, and focused tests.

## Bounded production census

- Actual socket writes in the supported graph: `client.go` contains the sole `c.conn.WriteTo(data, c.serverAddr)` in `Client.sendToServer`.
- Registry sender and operations are destination-free; entries retain only ID, copied raw bytes, retry timing/state, timer, and waiter.
- Allocation raw send accepts bytes only; Allocation transaction send accepts message plus wait policy only; `AllocationConfig.ServerAddr` and `UDPConn.serverAddr` are absent.
- Remaining `net.Addr` values in the internal bounded source are the relayed address and deallocation notification, not outbound destination authority.

## Validation so far

- Focused root configured-server, inbound-source, cancellation, close, invalid-relayed, and deleted-surface tests
- Full `internal/client` request-shape, registry, ChannelData, lifecycle, and concurrency suite
- `go test ./...`
- `go test -race ./...`
