### PR TITLE
Route decoded peer data through Allocation

### DIFF
--- a/client.go
+++ b/client.go
@@ -425,7 +425,7 @@ func (c *Client) handleSTUNMessage(data []byte) error { //nolint:cyclop
 			if relayedConn == nil {
 				return nil // Silently discard
 			}
-			relayedConn.HandleInbound(data, source)
+			relayedConn.HandleDataIndication(data, source)
 		default:
 			// Unsupported indication methods are silently discarded.
 		}
@@ -457,12 +457,9 @@ func (c *Client) handleChannelData(data []byte) error {
 		return nil // Silently discard
 	}
 
-	addr, ok := relayedConn.FindAddrByChannelNumber(uint16(chData.Number))
-	if !ok {
+	if !relayedConn.HandleChannelData(chData.Data, uint16(chData.Number)) {
 		return fmt.Errorf("%w: %d", errChannelBindNotFound, int(chData.Number))
 	}
-
-	relayedConn.HandleInbound(chData.Data, addr)
 
 	return nil
 }

--- a/client_test.go
+++ b/client_test.go
@@ -152,6 +152,200 @@ func TestHandleInboundAdmitsOnlyServer(t *testing.T) {
 	})
 }
 
+type inboundDeliveryHarness struct {
+	client     *Client
+	allocation *Allocation
+	conn       *client.UDPConn
+	server     netip.AddrPort
+	peer       netip.AddrPort
+	channel    proto.ChannelNumber
+}
+
+func newInboundDeliveryHarness(t *testing.T) *inboundDeliveryHarness {
+	t.Helper()
+
+	harness := &inboundDeliveryHarness{
+		server: netip.MustParseAddrPort("192.0.2.1:3478"),
+		peer:   netip.MustParseAddrPort("198.51.100.10:5000"),
+	}
+	harness.client = &Client{server: harness.server}
+	harness.conn = client.NewUDPConn(&client.AllocationConfig{
+		WriteTo: func(data []byte) (int, error) {
+			return len(data), nil
+		},
+		PerformTransaction: func(msg *stun.Message, _ bool) (client.TransactionResult, error) {
+			switch msg.Type.Method {
+			case stun.MethodCreatePermission:
+				return client.TransactionResult{Msg: stun.MustBuild(
+					stun.NewType(stun.MethodCreatePermission, stun.ClassSuccessResponse),
+				)}, nil
+			case stun.MethodChannelBind:
+				require.NoError(t, harness.channel.GetFrom(msg))
+
+				return client.TransactionResult{Msg: stun.MustBuild(
+					stun.NewType(stun.MethodChannelBind, stun.ClassSuccessResponse),
+				)}, nil
+			default:
+				return client.TransactionResult{}, nil
+			}
+		},
+		OnDeallocated: func(net.Addr) {
+			harness.client.setRelayedUDPConn(nil)
+		},
+		RelayedAddr: &net.UDPAddr{IP: net.ParseIP("203.0.113.1"), Port: 54321},
+		Username:    stun.NewUsername("user"),
+		Realm:       stun.NewRealm("realm"),
+		Integrity:   stun.NewShortTermIntegrity("pass"),
+		Nonce:       stun.NewNonce("nonce"),
+		Lifetime:    time.Hour,
+	}, func() {})
+	harness.client.setRelayedUDPConn(harness.conn)
+	harness.allocation = newAllocation(harness.conn, netip.MustParseAddrPort("203.0.113.1:54321"))
+	t.Cleanup(func() { _ = harness.conn.Close() })
+
+	return harness
+}
+
+func buildDataIndication(t *testing.T, payload []byte, peer netip.AddrPort) []byte {
+	t.Helper()
+
+	msg, err := stun.Build(
+		stun.TransactionID,
+		stun.NewType(stun.MethodData, stun.ClassIndication),
+		proto.PeerAddress{IP: net.IP(peer.Addr().AsSlice()), Port: int(peer.Port())},
+		proto.Data(payload),
+	)
+	require.NoError(t, err)
+
+	return msg.Raw
+}
+
+func buildChannelData(payload []byte, channel proto.ChannelNumber) []byte {
+	msg := &proto.ChannelData{Data: payload, Number: channel}
+	msg.Encode()
+
+	return msg.Raw
+}
+
+type allocationReadResult struct {
+	n    int
+	from netip.AddrPort
+	err  error
+	data []byte
+}
+
+func readAllocation(t *testing.T, allocation *Allocation, size int) allocationReadResult {
+	t.Helper()
+
+	resultCh := make(chan allocationReadResult, 1)
+	go func() {
+		buf := make([]byte, size)
+		n, from, err := allocation.ReadFrom(buf)
+		resultCh <- allocationReadResult{n: n, from: from, err: err, data: buf[:n]}
+	}()
+
+	select {
+	case result := <-resultCh:
+		return result
+	case <-time.After(time.Second):
+		require.Fail(t, "Allocation.ReadFrom did not observe decoded peer data")
+
+		return allocationReadResult{}
+	}
+}
+
+func TestHandleInboundDeliversDecodedPeerDataThroughAllocation(t *testing.T) {
+	t.Run("Data indication", func(t *testing.T) {
+		harness := newInboundDeliveryHarness(t)
+		payload := []byte("indication payload")
+		raw := buildDataIndication(t, payload, harness.peer)
+
+		require.NoError(t, harness.client.HandleInbound(raw, net.UDPAddrFromAddrPort(harness.server)))
+		for i := range raw {
+			raw[i] = 0
+		}
+
+		result := readAllocation(t, harness.allocation, len(payload))
+		require.NoError(t, result.err)
+		assert.Equal(t, len(payload), result.n)
+		assert.Equal(t, harness.peer, result.from)
+		assert.Equal(t, []byte("indication payload"), result.data)
+	})
+
+	t.Run("ChannelData", func(t *testing.T) {
+		harness := newInboundDeliveryHarness(t)
+		require.NoError(t, harness.allocation.PreparePeer(context.Background(), harness.peer))
+		payload := []byte("channel payload")
+		raw := buildChannelData(payload, harness.channel)
+
+		require.NoError(t, harness.client.HandleInbound(raw, net.UDPAddrFromAddrPort(harness.server)))
+		for i := range raw {
+			raw[i] = 0
+		}
+
+		result := readAllocation(t, harness.allocation, len(payload))
+		require.NoError(t, result.err)
+		assert.Equal(t, len(payload), result.n)
+		assert.Equal(t, harness.peer, result.from)
+		assert.Equal(t, []byte("channel payload"), result.data)
+	})
+}
+
+func TestHandleInboundLiveUnknownChannelReturnsExistingErrorWithoutDelivery(t *testing.T) {
+	harness := newInboundDeliveryHarness(t)
+	unknown := proto.ChannelNumber(proto.MinChannelNumber)
+
+	err := harness.client.HandleInbound(
+		buildChannelData([]byte("unknown"), unknown),
+		net.UDPAddrFromAddrPort(harness.server),
+	)
+
+	assert.ErrorIs(t, err, errChannelBindNotFound)
+	assert.EqualError(t, err, "no binding found for channel: 16384")
+	require.NoError(t, harness.client.HandleInbound(
+		buildDataIndication(t, []byte("marker"), harness.peer),
+		net.UDPAddrFromAddrPort(harness.server),
+	))
+	result := readAllocation(t, harness.allocation, len("marker"))
+	require.NoError(t, result.err)
+	assert.Equal(t, []byte("marker"), result.data, "an unknown channel must not add a queue entry")
+}
+
+func TestHandleInboundSilentlyDiscardsDecodedPeerDataWithoutLiveAllocation(t *testing.T) {
+	server := netip.MustParseAddrPort("192.0.2.1:3478")
+	peer := netip.MustParseAddrPort("198.51.100.10:5000")
+	turnClient := &Client{server: server}
+
+	assert.NoError(t, turnClient.HandleInbound(
+		buildDataIndication(t, []byte("indication"), peer),
+		net.UDPAddrFromAddrPort(server),
+	))
+	assert.NoError(t, turnClient.HandleInbound(
+		buildChannelData([]byte("channel"), proto.ChannelNumber(proto.MinChannelNumber)),
+		net.UDPAddrFromAddrPort(server),
+	))
+}
+
+func TestHandleInboundSilentlyDiscardsDecodedPeerDataThroughStaleSealedAllocation(t *testing.T) {
+	harness := newInboundDeliveryHarness(t)
+	require.NoError(t, harness.allocation.PreparePeer(context.Background(), harness.peer))
+	require.NoError(t, harness.conn.Close())
+	harness.client.setRelayedUDPConn(harness.conn)
+
+	assert.NoError(t, harness.client.HandleInbound(
+		buildDataIndication(t, []byte("indication"), harness.peer),
+		net.UDPAddrFromAddrPort(harness.server),
+	))
+	assert.NoError(t, harness.client.HandleInbound(
+		buildChannelData([]byte("known channel"), harness.channel),
+		net.UDPAddrFromAddrPort(harness.server),
+	))
+	assert.NoError(t, harness.client.HandleInbound(
+		buildChannelData([]byte("unknown channel"), harness.channel+1),
+		net.UDPAddrFromAddrPort(harness.server),
+	))
+}
+
 func TestClientCloseIsAnAbortCutNotATerminalState(t *testing.T) {
 	conn := newObserverConn()
 	cl := newObservedClient(t, conn)

--- a/docs/adr/2026-08-19-architecture-deepening-program.md
+++ b/docs/adr/2026-08-19-architecture-deepening-program.md
@@ -1,6 +1,6 @@
 # TURN Architecture Deepening Program — 2026-08-19
 
-**Status:** In progress; Track 1 implemented by PR #72
+**Status:** In progress; Tracks 1 and 2 implemented by PRs #72 and #74
 
 ## What this is
 
@@ -19,7 +19,7 @@ This program packages the 2026-08-19 architecture review and delegated grill of 
 | # | Track | Plan | Parent issue | Blocked by | Slices | Status |
 |---|---|---|---|---|---|---|
 | 1 | Server-bound outbound transport | [plan](2026-08-19-server-bound-transport-plan.md) | #65 | None | 1 | Complete via PR #72 |
-| 2 | Inbound Allocation delivery | [plan](2026-08-19-inbound-allocation-delivery-plan.md) | #66 | None | 1 | FRONTIER |
+| 2 | Inbound Allocation delivery | [plan](2026-08-19-inbound-allocation-delivery-plan.md) | #66 | None | 1 | Complete via PR #74 |
 | 3 | Channel-binding readiness | [plan](2026-08-19-channel-binding-readiness-plan.md) | #67 | None | 1 | FRONTIER |
 
 There are no genuine slice-level blocking edges. The tracks touch nearby root/internal seams but own independent behavior: outbound destination authority, inbound delivery, and binding readiness. Likely text conflicts require an ordinary rebase, not an architectural blocker. Recommended dispatch order is Track 1, Track 2, then Track 3 because it advances from the smallest broad seam contraction to the bounded inbound move and finally the most concurrency-sensitive state deepening; an operator may run the frontier in parallel if separate agents and worktrees can absorb rebases.

--- a/docs/adr/2026-08-19-inbound-allocation-delivery-plan.md
+++ b/docs/adr/2026-08-19-inbound-allocation-delivery-plan.md
@@ -1,12 +1,12 @@
 # Inbound Allocation Delivery Implementation Plan
 
 **Date:** 2026-08-19
-**Status:** Accepted; not yet implemented
+**Status:** Implemented by PR #74
 **Track:** 2 of 3 in the 2026-08-19 architecture deepening program
 **Depends on:** Nothing — parallel-safe with the other tracks
 **Related:** [Program index](2026-08-19-architecture-deepening-program.md), [Prepared-only writes ADR](2026-08-15-prepared-only-writes.md), [Allocation lifecycle plan](2026-08-17-allocation-lifecycle-plan.md)
 **Normative scope:** Current outcome, boundaries, invariants, acceptance evidence, blockers, and stop conditions
-**Audit history:** Independently audited against `122019cf5a040bcb7a8ba9002bd3a82e9ad947cf` on 2026-08-19; T2.S1 passed after delivery/seal linearization, ChannelData result semantics, no-live ownership, copy scope, queued-before-seal observability, deterministic evidence, and synchronization cost were closed
+**Audit history:** Independently audited against `122019cf5a040bcb7a8ba9002bd3a82e9ad947cf` on 2026-08-19; T2.S1 passed after delivery/seal linearization, ChannelData result semantics, no-live ownership, copy scope, queued-before-seal observability, deterministic evidence, and synchronization cost were closed; implementation completed by PR #74
 
 ## Goal
 
@@ -44,7 +44,7 @@ While live, both operations copy the payload before returning so caller read-buf
 
 | Slice | Status/disposition | Delivers | Blocked by | Removes temporary seam |
 |---|---|---|---|---|
-| T2.S1 | New | Decoded Data indications and ChannelData are delivered through Allocation-owned semantics | None | Removes outward channel lookup plus caller-composed lookup/queue delivery in the same slice |
+| T2.S1 | Complete via PR #74 | Decoded Data indications and ChannelData are delivered through Allocation-owned semantics | None | Removed outward channel lookup plus caller-composed lookup/queue delivery in the same slice |
 
 ## Implementation Slices
 
@@ -52,7 +52,7 @@ While live, both operations copy the payload before returning so caller read-buf
 
 **What it delivers:** One PR replacing the root `FindAddrByChannelNumber` then `HandleInbound` composition with two Allocation-owned delivery operations, consolidating live/sealed disposition, channel lookup, peer association, copy, and queue admission behind `UDPConn`, preserving root errors and wire responsibilities, and pinning the accepted post-seal silent-drop rule.
 
-**Existing-work disposition:** New slice. There are no open issues, PRs, or implementation branches to retain or rebaseline as of 2026-08-19.
+**Implementation:** PR #74 is the slice's one intended product PR; unmentioned historical branches were not used as an implementation baseline.
 
 **Blocked by:** None.
 
@@ -82,12 +82,12 @@ While live, both operations copy the payload before returning so caller read-buf
 
 ## Acceptance Criteria
 
-- [ ] Every admitted, successfully decoded Data indication and ChannelData item in the supported finite domain for which root loaded a nonnil Allocation delegates semantic delivery to `UDPConn`; root owns no-live discard, and all representation owners, the universal domain, and terminating evidence are defined in T2.S1.
-- [ ] Root `Client` no longer composes outward channel lookup with queue delivery, while it retains source admission, wire decoding, canonicalization, transaction completion, and existing unknown-channel error construction.
-- [ ] Live known channels and Data indications preserve peer labels, copy ownership, queue-full drop, short-buffer behavior, and assigned-but-unprepared inbound acceptance; only live unknown ChannelData returns the existing root error.
-- [ ] The delivery guard linearizes decoded delivery with seal: delivery ordered before seal may enqueue, while Data indication and known/unknown ChannelData ordered after seal are silently handled without additional delivery-owned copy, lookup, or queueing.
-- [ ] Seal does not drain, reorder, or close `readCh`; the unchanged `ReadFrom` select makes no guarantee which ready arm wins for pre-seal queued data after seal.
-- [ ] Public API, wire parsing, prepared-only outbound writes, binding identity, and packet-path performance policy remain unchanged.
+- [x] Every admitted, successfully decoded Data indication and ChannelData item in the supported finite domain for which root loaded a nonnil Allocation delegates semantic delivery to `UDPConn`; root owns no-live discard, and all representation owners, the universal domain, and terminating evidence are defined in T2.S1.
+- [x] Root `Client` no longer composes outward channel lookup with queue delivery, while it retains source admission, wire decoding, canonicalization, transaction completion, and existing unknown-channel error construction.
+- [x] Live known channels and Data indications preserve peer labels, copy ownership, queue-full drop, short-buffer behavior, and assigned-but-unprepared inbound acceptance; only live unknown ChannelData returns the existing root error.
+- [x] The delivery guard linearizes decoded delivery with seal: delivery ordered before seal may enqueue, while Data indication and known/unknown ChannelData ordered after seal are silently handled without additional delivery-owned copy, lookup, or queueing.
+- [x] Seal does not drain, reorder, or close `readCh`; the unchanged `ReadFrom` select makes no guarantee which ready arm wins for pre-seal queued data after seal.
+- [x] Public API, wire parsing, prepared-only outbound writes, binding identity, and packet-path performance policy remain unchanged.
 
 ## Validation Gates
 

--- a/internal/client/udp_conn.go
+++ b/internal/client/udp_conn.go
@@ -66,6 +66,7 @@ type UDPConn struct {
 	checkBindingsTimer     *PeriodicTimer
 	readCh                 chan *inboundData
 	closeCh                chan struct{}
+	deliveryMutex          sync.RWMutex   // Linearizes decoded delivery with the closeCh transition
 	closeMutex             sync.Mutex     // Also gates workerWG.Add vs close
 	workerWG               sync.WaitGroup // Joins bind/permission workers on Close
 	bindingRefreshInterval time.Duration  // Read-only
@@ -513,12 +514,16 @@ func (c *UDPConn) startCloseLocked(cause error) (bool, error) {
 	c.refreshPermsTimer.Stop()
 	c.checkBindingsTimer.Stop()
 
+	c.deliveryMutex.Lock()
 	select {
 	case <-c.closeCh:
+		c.deliveryMutex.Unlock()
+
 		return false, nil
 	default:
 		close(c.closeCh)
 	}
+	c.deliveryMutex.Unlock()
 
 	// Wake workers blocked on in-flight transaction waits so Close does not
 	// wait out the retransmission budget against an unresponsive server.
@@ -629,10 +634,10 @@ func (c *UDPConn) CreatePermissions(addrs ...netip.AddrPort) error {
 	return nil
 }
 
-// HandleInbound passes one relayed datagram to the allocation. from is the
-// canonical source peer label, stored as-is and returned by ReadFrom.
-func (c *UDPConn) HandleInbound(data []byte, from netip.AddrPort) {
-	// Copy data
+// enqueueInbound copies one relayed datagram into the bounded read queue. The
+// caller holds deliveryMutex for reading and has already established that the
+// allocation is live.
+func (c *UDPConn) enqueueInbound(data []byte, from netip.AddrPort) {
 	copied := make([]byte, len(data))
 	copy(copied, data)
 
@@ -644,15 +649,34 @@ func (c *UDPConn) HandleInbound(data []byte, from netip.AddrPort) {
 	}
 }
 
-// FindAddrByChannelNumber returns the canonical peer address associated with
-// the channel number on this UDPConn.
-func (c *UDPConn) FindAddrByChannelNumber(chNum uint16) (netip.AddrPort, bool) {
-	b, ok := c.bindingMgr.findByNumber(chNum)
-	if !ok {
-		return netip.AddrPort{}, false
+// HandleDataIndication delivers one decoded Data indication from peer.
+func (c *UDPConn) HandleDataIndication(data []byte, peer netip.AddrPort) {
+	c.deliveryMutex.RLock()
+	defer c.deliveryMutex.RUnlock()
+	if c.isClosed() {
+		return
 	}
 
-	return b.addr, true
+	c.enqueueInbound(data, peer)
+}
+
+// HandleChannelData delivers one decoded ChannelData payload. It reports
+// false only when the live allocation has no binding for channel.
+func (c *UDPConn) HandleChannelData(data []byte, channel uint16) bool {
+	c.deliveryMutex.RLock()
+	defer c.deliveryMutex.RUnlock()
+	if c.isClosed() {
+		return true
+	}
+
+	bound, ok := c.bindingMgr.findByNumber(channel)
+	if !ok {
+		return false
+	}
+
+	c.enqueueInbound(data, bound.addr)
+
+	return true
 }
 
 func (c *UDPConn) maybeBind(bound *binding) {

--- a/internal/client/udp_conn_test.go
+++ b/internal/client/udp_conn_test.go
@@ -5,6 +5,7 @@ package client
 
 import (
 	"errors"
+	"io"
 	"net"
 	"net/netip"
 	"sync/atomic"
@@ -66,6 +67,126 @@ func TestNewUDPConnRejectsMissingAbortBeforeStartingWork(t *testing.T) {
 	if conn != nil {
 		_ = conn.Close()
 	}
+}
+
+func TestUDPConnHandleDataIndicationOwnsQueuedPayload(t *testing.T) {
+	conn := UDPConn{
+		readCh:  make(chan *inboundData, 1),
+		closeCh: make(chan struct{}),
+	}
+	peer := netip.MustParseAddrPort("192.0.2.10:5000")
+	payload := []byte("hello")
+
+	conn.HandleDataIndication(payload, peer)
+	payload[0] = 'j'
+
+	buf := make([]byte, len(payload))
+	n, from, err := conn.ReadFrom(buf)
+	require.NoError(t, err)
+	assert.Equal(t, len(payload), n)
+	assert.Equal(t, peer, from)
+	assert.Equal(t, []byte("hello"), buf)
+}
+
+func TestUDPConnHandleDataIndicationSilentlyDiscardsAfterSeal(t *testing.T) {
+	conn := UDPConn{
+		readCh:  make(chan *inboundData, 1),
+		closeCh: make(chan struct{}),
+	}
+	close(conn.closeCh)
+
+	conn.HandleDataIndication([]byte("late"), netip.MustParseAddrPort("192.0.2.10:5000"))
+
+	assert.Empty(t, conn.readCh)
+}
+
+func TestUDPConnHandleChannelDataDeliversAssignedUnpreparedBinding(t *testing.T) {
+	peer := netip.MustParseAddrPort("192.0.2.20:6000")
+	bindingMgr := newBindingManager()
+	bound := requireBinding(t, bindingMgr, peer)
+	conn := UDPConn{
+		bindingMgr: bindingMgr,
+		readCh:     make(chan *inboundData, 1),
+		closeCh:    make(chan struct{}),
+	}
+	payload := []byte("bound")
+
+	handled := conn.HandleChannelData(payload, bound.number)
+	payload[0] = 'x'
+
+	assert.True(t, handled)
+	assert.False(t, bound.prepared.Load(), "inbound ChannelData must not require a prepared binding")
+	buf := make([]byte, len(payload))
+	n, from, err := conn.ReadFrom(buf)
+	require.NoError(t, err)
+	assert.Equal(t, len(payload), n)
+	assert.Equal(t, peer, from)
+	assert.Equal(t, []byte("bound"), buf)
+}
+
+func newInboundDeliveryConn(t *testing.T) *UDPConn {
+	t.Helper()
+
+	conn := NewUDPConn(&AllocationConfig{
+		WriteTo: func(data []byte) (int, error) {
+			return len(data), nil
+		},
+		PerformTransaction: func(*stun.Message, bool) (TransactionResult, error) {
+			return TransactionResult{}, nil
+		},
+		OnDeallocated: func(net.Addr) {},
+		RelayedAddr:   &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 54321},
+		Username:      stun.NewUsername("user"),
+		Realm:         stun.NewRealm("realm"),
+		Integrity:     stun.NewShortTermIntegrity("pass"),
+		Nonce:         stun.NewNonce("nonce"),
+		Lifetime:      time.Hour,
+	}, func() {})
+	t.Cleanup(func() { _ = conn.Close() })
+
+	return conn
+}
+
+func TestUDPConnDecodedDeliveryQueueAndSealDispositions(t *testing.T) {
+	peer := netip.MustParseAddrPort("192.0.2.30:7000")
+	conn := newInboundDeliveryConn(t)
+	bound := requireBinding(t, conn.bindingMgr, peer)
+
+	conn.HandleDataIndication([]byte("before seal"), peer)
+	require.Len(t, conn.readCh, 1)
+	require.NoError(t, conn.Close())
+	assert.Len(t, conn.readCh, 1, "seal must preserve data queued before its linearization point")
+
+	conn.HandleDataIndication([]byte("late indication"), peer)
+	assert.True(t, conn.HandleChannelData([]byte("late known channel"), bound.number))
+	assert.True(t, conn.HandleChannelData([]byte("late unknown channel"), bound.number+1))
+	assert.Len(t, conn.readCh, 1, "delivery after seal must not queue data")
+}
+
+func TestUDPConnDecodedDeliveryDropsWhenQueueIsFull(t *testing.T) {
+	peer := netip.MustParseAddrPort("192.0.2.40:8000")
+	conn := newInboundDeliveryConn(t)
+	bound := requireBinding(t, conn.bindingMgr, peer)
+	for range cap(conn.readCh) {
+		conn.readCh <- &inboundData{data: []byte("existing"), from: peer}
+	}
+
+	conn.HandleDataIndication([]byte("dropped indication"), peer)
+	assert.True(t, conn.HandleChannelData([]byte("dropped known channel"), bound.number),
+		"a known channel remains handled when its payload is dropped")
+	assert.False(t, conn.HandleChannelData([]byte("unknown channel"), bound.number+1))
+	assert.Len(t, conn.readCh, cap(conn.readCh))
+}
+
+func TestUDPConnDecodedDeliveryPreservesShortBufferError(t *testing.T) {
+	conn := newInboundDeliveryConn(t)
+	conn.HandleDataIndication([]byte("payload"), netip.MustParseAddrPort("192.0.2.50:9000"))
+
+	n, from, err := conn.ReadFrom(make([]byte, 3))
+
+	assert.ErrorIs(t, err, io.ErrShortBuffer)
+	assert.Zero(t, n)
+	assert.Equal(t, netip.AddrPort{}, from)
 }
 
 func assertRequestShape(


### PR DESCRIPTION
Closes #69
Parent: #66

Implements `docs/adr/2026-08-19-inbound-allocation-delivery-plan.md` at **Slice T2.S1 — Route decoded peer data through Allocation**, recorded plan commit `f722466a1864b1ca89e9e364daa962a7c1c5ba23`.

## Outcome

Root `Client` retains source admission, decoding, canonicalization, no-live discard, transaction completion, and the existing live unknown-channel error. `UDPConn` now owns decoded Data-indication and ChannelData delivery, including live/sealed disposition, channel lookup, peer association, copied payload ownership, bounded nonblocking queue admission, and delivery/seal linearization.

## Review contract

- Supported representation domain: admitted datagrams successfully decoded by the existing `pion/stun` or `internal/proto` owners into Data-indication payload plus canonical peer or ChannelData payload plus 16-bit channel, across no-live/live/sealed state, known/unknown assigned channels, and available/full queue state.
- Representation owners: root parsers and canonicalizers own wire and peer representations; root owns no-live discard and existing error construction; the `UDPConn` delivery guard owns live/sealed ordering; `bindingManager` owns channel association; `UDPConn` owns queued copied payloads.
- Guarantee: universal over the finite semantic table above, not malformed wire syntax or arbitrary peer spellings.
- Shipped/safety artifacts: Allocation-owned delivery operations and the delivery/seal guard. Focused root/internal, saturation, copy, lifecycle, and race tests are verification aids; plans, issues, review receipts, and tasks are traceability metadata. No maintained verification aid is introduced.
- Non-goals: no parser, canonicalization, public API, queue-size, drain, close-selection, binding identity, prepared-only write, error-text, wire, protocol-codec, copy-count optimization, or packet-path performance change.
- Terminating evidence: focused root-to-`ReadFrom` delivery; live unknown/no-live/sealed dispositions; assigned-but-unprepared channel delivery; payload copy and queue saturation; both delivery/seal orders; short-buffer and source/parser/transaction preservation; `go test ./...`; `go test -race ./...`; exact-head `task preflight`; same-head hosted CI; one fresh review and at most one replacement.
- Review budget: one initial RAS review, fix/verify only independently accepted `fix-now` findings, and at most one replacement review.
- Contract closure: not triggered; the delivery table is finite, has one owner after this PR, and focused deterministic tests reasonably cover its semantic classes.

## Validation so far

- Focused root and internal decoded-delivery suites
- Existing source-admission, parser, transaction, Allocation read/close, and prepared-only suites
- `go test ./...`
- `go test -race ./...`
- `task verify`
