### PR TITLE
Make binding readiness own transitions

### DIFF
--- a/docs/adr/2026-08-19-architecture-deepening-program.md
+++ b/docs/adr/2026-08-19-architecture-deepening-program.md
@@ -1,6 +1,6 @@
 # TURN Architecture Deepening Program — 2026-08-19
 
-**Status:** In progress; Tracks 1 and 2 implemented by PRs #72 and #74
+**Status:** Complete; Tracks 1, 2, and 3 implemented by PRs #72, #74, and #76
 
 ## What this is
 
@@ -20,7 +20,7 @@ This program packages the 2026-08-19 architecture review and delegated grill of 
 |---|---|---|---|---|---|---|
 | 1 | Server-bound outbound transport | [plan](2026-08-19-server-bound-transport-plan.md) | #65 | None | 1 | Complete via PR #72 |
 | 2 | Inbound Allocation delivery | [plan](2026-08-19-inbound-allocation-delivery-plan.md) | #66 | None | 1 | Complete via PR #74 |
-| 3 | Channel-binding readiness | [plan](2026-08-19-channel-binding-readiness-plan.md) | #67 | None | 1 | FRONTIER |
+| 3 | Channel-binding readiness | [plan](2026-08-19-channel-binding-readiness-plan.md) | #67 | None | 1 | Complete via PR #76 |
 
 There are no genuine slice-level blocking edges. The tracks touch nearby root/internal seams but own independent behavior: outbound destination authority, inbound delivery, and binding readiness. Likely text conflicts require an ordinary rebase, not an architectural blocker. Recommended dispatch order is Track 1, Track 2, then Track 3 because it advances from the smallest broad seam contraction to the bounded inbound move and finally the most concurrency-sensitive state deepening; an operator may run the frontier in parallel if separate agents and worktrees can absorb rebases.
 

--- a/docs/adr/2026-08-19-channel-binding-readiness-plan.md
+++ b/docs/adr/2026-08-19-channel-binding-readiness-plan.md
@@ -1,7 +1,7 @@
 # Channel-Binding Readiness Implementation Plan
 
 **Date:** 2026-08-19
-**Status:** Accepted; not yet implemented
+**Status:** Implemented by PR #76
 **Track:** 3 of 3 in the 2026-08-19 architecture deepening program
 **Depends on:** Nothing — parallel-safe with the other tracks
 **Related:** [Program index](2026-08-19-architecture-deepening-program.md), [Prepared-only writes ADR](2026-08-15-prepared-only-writes.md), [TURN consistency plan](2026-08-17-turn-consistency-plan.md), [Allocation lifecycle plan](2026-08-17-allocation-lifecycle-plan.md)
@@ -48,13 +48,15 @@ Every time-dependent readiness decision receives `time.Time` from the immediate 
 
 | Slice | Status/disposition | Delivers | Blocked by | Removes temporary seam |
 |---|---|---|---|---|
-| T3.S1 | New | One binding-local owner decides readiness transitions, preparation, write access, expiry, and terminality | None | Removes raw state/time/error/prepared access from `UDPConn` and tests in the same slice |
+| T3.S1 | Complete via PR #76 | One binding-local owner decides readiness transitions, preparation, write access, expiry, and terminality | None | Removed raw state/time/error/prepared access from `UDPConn` and tests in the same slice |
 
 ## Implementation Slices
 
 ### Slice T3.S1 — Make binding readiness the transition owner
 
 **What it delivers:** One PR introducing outcome-shaped binding-local decisions, migrating PreparePeer, scheduled refresh, ChannelBind completion/error disposition, prepared-only WriteTo, and permission-loss terminalization to them, deleting outward raw readiness mechanics, and replacing private-state-poking tests with a finite readiness table plus preserved Allocation-level behavior and race evidence.
+
+**Implementation:** PR #76 is the slice's one intended product PR.
 
 **Existing-work disposition:** New slice. There are no open issues, PRs, or implementation branches to retain or rebaseline as of 2026-08-19.
 
@@ -76,29 +78,29 @@ Every time-dependent readiness decision receives `time.Time` from the immediate 
 
 | Semantic class | Expected disposition | Enforcement owner | Evidence | Guard mutation when required | Status |
 |---|---|---|---|---|---|
-| Fresh or fresh-unknown, no attempt active | Initial attempt eligible | Binding readiness | Decision table | n/a | Planned |
-| Fresh initial attempt in flight | Preparation waits on the joined attempt; write remains `ErrNotPrepared` | Attempt coordination plus binding readiness | Controlled in-flight access case | n/a | Planned |
-| Confirmed, age at or below refresh interval | No refresh attempt | Binding readiness | Below/at threshold cases | n/a | Planned |
-| Confirmed, age strictly above refresh interval; or ready-uncertain | Refresh attempt eligible with prior-confirmation history | Binding readiness | Above-threshold and uncertain cases | n/a | Planned |
-| Previously confirmed refresh in flight | Preparation and already-prepared writes remain usable while unexpired | Binding readiness | Controlled in-flight refresh access case | n/a | Planned |
-| Ready-uncertain access | Preparation and prepared writes remain usable while refresh is eligible | Binding readiness | Outcome/access table | n/a | Planned |
-| Successful initial or refresh completion before terminality | Record confirmation time and usable readiness | Binding readiness | Completion table and PreparePeer flow | n/a | Planned |
-| Waiter selects cancellation or close before preparation access after confirmation | Do not establish prepared history; another caller may observe readiness | `UDPConn` waiter plus binding readiness | Deterministic cancellation-selected/second-caller case | n/a | Planned |
-| Waiter observes readiness before concurrently ready cancellation | Preparation may succeed; no new cancellation precedence is promised | `UDPConn` waiter plus binding readiness | Existing selection contract and focused success case | n/a | Planned |
-| Fresh transaction uncertainty | Preserve channel identity, become retryable unknown, and publish transient error only to joined attempt | Binding readiness plus attempt coordination | Outcome table and later retry flow | n/a | Planned |
-| Previously confirmed transaction uncertainty | Preserve usable ready history, make refresh eligible, and keep transient result attempt-local | Binding readiness plus attempt coordination | Outcome table and scheduled refresh | n/a | Planned |
-| Fresh 400 selected as failure by `UDPConn` | Terminal binding cause; `UDPConn` seals Allocation | Binding readiness and `UDPConn` seal owner | Existing fresh-400 lifecycle test | n/a | Planned |
-| Previously confirmed 400 selected as preservation by `UDPConn` | Keep mapping usable without advancing confirmation time | Binding readiness | Recovery table and timestamp assertion | n/a | Planned |
-| Exhausted 438, malformed error, or other permanent ChannelBind failure | Terminal binding with the unchanged specific cause and error chain; 438 remains untyped `errTryAgain` | Binding readiness after `UDPConn` classification | One representative per semantic error class | n/a | Planned |
-| Preparation observes confirmed age below lifetime | Mark prepared and return success | Binding readiness | PreparePeer behavior | n/a | Planned |
-| Write before preparation | `ErrNotPrepared`, zero network output | Binding readiness consumed by `UDPConn.WriteTo` | Prepared-only table | n/a | Planned |
-| Preparation or write at age greater than or equal to ten minutes | Terminalize once with `ErrChannelBindingExpired`, zero output | Binding readiness | Below/at/above lifetime cases | Delete terminal guard and observe non-resurrection test fail | Planned |
-| Permission loss linearizes before preparation marks history | No binding terminalization; later otherwise-valid preparation remains allowed | Binding readiness | Controlled loss-wins case | n/a | Planned |
-| Preparation marks history before permission loss | Terminalize with `ErrPermissionRefreshFailed`; Allocation remains live | Binding readiness plus permission refresh owner | Controlled preparation-wins and existing refresh-failure flow | n/a | Planned |
-| Outcome races preparation or write access | Operations linearize on readiness; access before a permanent outcome may observe prior usability, while access after it returns the durable cause with zero output | Binding readiness | Controlled outcome/access order cases | n/a | Planned |
-| Expiry races successful completion | First readiness operation governs; terminal expiry cannot be resurrected by later completion | Binding readiness | Controlled expiry/completion order cases | Covered by terminal-guard mutation | Planned |
-| Allocation closes before or during attempt | `UDPConn` returns closed/terminal cause; aborted transaction creates no new readiness outcome or binding terminality | `UDPConn` lifecycle and attempt coordination | Existing close/abort cases plus readiness assertion | n/a | Planned |
-| Duplicate, stale, or late token resolution | Ignore without changing current readiness or first terminal cause | Binding readiness | Token-generation table | Covered by terminal-guard mutation | Planned |
+| Fresh or fresh-unknown, no attempt active | Initial attempt eligible | Binding readiness | Decision table | n/a | Covered |
+| Fresh initial attempt in flight | Preparation waits on the joined attempt; write remains `ErrNotPrepared` | Attempt coordination plus binding readiness | Controlled in-flight access case | n/a | Covered |
+| Confirmed, age at or below refresh interval | No refresh attempt | Binding readiness | Below/at threshold cases | n/a | Covered |
+| Confirmed, age strictly above refresh interval; or ready-uncertain | Refresh attempt eligible with prior-confirmation history | Binding readiness | Above-threshold and uncertain cases | n/a | Covered |
+| Previously confirmed refresh in flight | Preparation and already-prepared writes remain usable while unexpired | Binding readiness | Controlled in-flight refresh access case | n/a | Covered |
+| Ready-uncertain access | Preparation and prepared writes remain usable while refresh is eligible | Binding readiness | Outcome/access table | n/a | Covered |
+| Successful initial or refresh completion before terminality | Record confirmation time and usable readiness | Binding readiness | Completion table and PreparePeer flow | n/a | Covered |
+| Waiter selects cancellation or close before preparation access after confirmation | Do not establish prepared history; another caller may observe readiness | `UDPConn` waiter plus binding readiness | Deterministic cancellation-selected/second-caller case | n/a | Covered |
+| Waiter observes readiness before concurrently ready cancellation | Preparation may succeed; no new cancellation precedence is promised | `UDPConn` waiter plus binding readiness | Existing selection contract and focused success case | n/a | Covered |
+| Fresh transaction uncertainty | Preserve channel identity, become retryable unknown, and publish transient error only to joined attempt | Binding readiness plus attempt coordination | Outcome table and later retry flow | n/a | Covered |
+| Previously confirmed transaction uncertainty | Preserve usable ready history, make refresh eligible, and keep transient result attempt-local | Binding readiness plus attempt coordination | Outcome table and scheduled refresh | n/a | Covered |
+| Fresh 400 selected as failure by `UDPConn` | Terminal binding cause; `UDPConn` seals Allocation | Binding readiness and `UDPConn` seal owner | Existing fresh-400 lifecycle test | n/a | Covered |
+| Previously confirmed 400 selected as preservation by `UDPConn` | Keep mapping usable without advancing confirmation time | Binding readiness | Recovery table and timestamp assertion | n/a | Covered |
+| Exhausted 438, malformed error, or other permanent ChannelBind failure | Terminal binding with the unchanged specific cause and error chain; 438 remains untyped `errTryAgain` | Binding readiness after `UDPConn` classification | One representative per semantic error class | n/a | Covered |
+| Preparation observes confirmed age below lifetime | Mark prepared and return success | Binding readiness | PreparePeer behavior | n/a | Covered |
+| Write before preparation | `ErrNotPrepared`, zero network output | Binding readiness consumed by `UDPConn.WriteTo` | Prepared-only table | n/a | Covered |
+| Preparation or write at age greater than or equal to ten minutes | Terminalize once with `ErrChannelBindingExpired`, zero output | Binding readiness | Below/at/above lifetime cases | Delete terminal guard and observe non-resurrection test fail | Covered |
+| Permission loss linearizes before preparation marks history | No binding terminalization; later otherwise-valid preparation remains allowed | Binding readiness | Controlled loss-wins case | n/a | Covered |
+| Preparation marks history before permission loss | Terminalize with `ErrPermissionRefreshFailed`; Allocation remains live | Binding readiness plus permission refresh owner | Controlled preparation-wins and existing refresh-failure flow | n/a | Covered |
+| Outcome races preparation or write access | Operations linearize on readiness; access before a permanent outcome may observe prior usability, while access after it returns the durable cause with zero output | Binding readiness | Controlled outcome/access order cases | n/a | Covered |
+| Expiry races successful completion | First readiness operation governs; terminal expiry cannot be resurrected by later completion | Binding readiness | Controlled expiry/completion order cases | Covered by terminal-guard mutation | Covered |
+| Allocation closes before or during attempt | `UDPConn` returns closed/terminal cause; aborted transaction creates no new readiness outcome or binding terminality | `UDPConn` lifecycle and attempt coordination | Existing close/abort cases plus readiness assertion | n/a | Covered |
+| Duplicate, stale, or late token resolution | Ignore without changing current readiness or first terminal cause | Binding readiness | Token-generation table | Covered by terminal-guard mutation | Covered |
 
 **Evidence budget:** The matrix rows are the complete semantic budget. Use explicit values from one nondecreasing `time.Time` timeline for refresh just below/at/above its strict boundary and lifetime just below/at/above its inclusive expiry boundary; one representative error per semantic failure class; controlled fresh/refresh in-flight access; deterministic cancellation-selected then second-caller observation; both permission-loss/preparation orders; both permanent-outcome/access orders; expiry/completion order; Allocation close without readiness mutation; token duplicate/stale/late rejection; existing end-to-end fresh/ready 400, permission-refresh, prepared-only write, request-byte, and close tests; and `go test -race ./...`. Require one discriminating mutation: bypass terminal collapse and demonstrate that the late-resolution/non-resurrection test fails. No fake clock, repeated sleeps, fuzzing, exhaustive scheduler matrix, new platform cells, generic harness, or recursive mutation. Termination = every matrix row covered/rejected as stated, the required mutation, full gates, one fresh review, at most one replacement, and no `stop-for-decision` finding.
 
@@ -112,13 +114,13 @@ Every time-dependent readiness decision receives `time.Time` from the immediate 
 
 ## Acceptance Criteria
 
-- [ ] Every binding readiness fact and transition in the supported finite domain has one owner in `binding`; representation owner, universal guarantee, matrix, and terminating evidence are defined in T3.S1.
-- [ ] `UDPConn` retains TURN classification, 400 disposition, attempt coordination, worker accounting, Permission orchestration, and Allocation seal/release/join without reading or writing raw binding state.
-- [ ] Preparation establishes prepared history only when a waiter invokes preparation access and observes confirmed unexpired readiness; cancellation/close selection remains waiter-local without new precedence, and writes remain prepared-only with zero output after expiry or terminal failure.
-- [ ] Attempt coordination alone owns each joined attempt's transient result; readiness alone owns a durable terminal cause; later retry after fresh uncertainty and all existing error chains preserve the declared matrix.
-- [ ] Refresh eligibility, ten-minute expiry, in-flight access, fresh/ready uncertainty, fresh/ready 400 behavior, permission-loss ordering, close behavior, token validity, specific failure causes, and terminal non-resurrection preserve the declared matrix.
-- [ ] The complete mutation seam is begin/resolve attempt, preparation/write access, and tokenless prepared-permission failure; no raw readiness getter/setter, direct terminal mutation, duplicate expiry calculation, second prepared marker, generic state engine, broad clock, prepared-peer module, or attempt-coalescing abstraction remains or is introduced.
-- [ ] New bindings begin with no confirmation time, and channel identity/capacity, exact wire bytes, retry counts, intervals, public API, caller cancellation, and Allocation lifecycle remain unchanged.
+- [x] Every binding readiness fact and transition in the supported finite domain has one owner in `binding`; representation owner, universal guarantee, matrix, and terminating evidence are defined in T3.S1.
+- [x] `UDPConn` retains TURN classification, 400 disposition, attempt coordination, worker accounting, Permission orchestration, and Allocation seal/release/join without reading or writing raw binding state.
+- [x] Preparation establishes prepared history only when a waiter invokes preparation access and observes confirmed unexpired readiness; cancellation/close selection remains waiter-local without new precedence, and writes remain prepared-only with zero output after expiry or terminal failure.
+- [x] Attempt coordination alone owns each joined attempt's transient result; readiness alone owns a durable terminal cause; later retry after fresh uncertainty and all existing error chains preserve the declared matrix.
+- [x] Refresh eligibility, ten-minute expiry, in-flight access, fresh/ready uncertainty, fresh/ready 400 behavior, permission-loss ordering, close behavior, token validity, specific failure causes, and terminal non-resurrection preserve the declared matrix.
+- [x] The complete mutation seam is begin/resolve attempt, preparation/write access, and tokenless prepared-permission failure; no raw readiness getter/setter, direct terminal mutation, duplicate expiry calculation, second prepared marker, generic state engine, broad clock, prepared-peer module, or attempt-coalescing abstraction remains or is introduced.
+- [x] New bindings begin with no confirmation time, and channel identity/capacity, exact wire bytes, retry counts, intervals, public API, caller cancellation, and Allocation lifecycle remain unchanged.
 
 ## Validation Gates
 

--- a/internal/client/binding.go
+++ b/internal/client/binding.go
@@ -6,7 +6,6 @@ package client
 import (
 	"net/netip"
 	"sync"
-	"sync/atomic"
 	"time"
 )
 
@@ -32,81 +31,219 @@ const (
 	bindingStateFailed
 )
 
+type bindingAttemptToken uint64
+
+type bindingAttemptClass uint8
+
+const (
+	bindingAttemptFresh bindingAttemptClass = iota
+	bindingAttemptPreviouslyConfirmed
+)
+
+type bindingAttemptOutcome uint8
+
+const (
+	bindingAttemptConfirmed bindingAttemptOutcome = iota
+	bindingAttemptUncertain
+	bindingAttemptPreserveConfirmation
+	bindingAttemptPermanentFailure
+)
+
 type binding struct {
-	number       uint16         // Read-only
-	st           bindingState   // Thread-safe (atomic op)
-	addr         netip.AddrPort // Read-only
-	muBind       sync.Mutex     // Thread-safe, for ChannelBind ops
-	attemptDone  chan struct{}  // Protected by muBind; non-nil while a bind attempt is in flight
-	prepared     atomic.Bool    // Thread-safe; peer promised ChannelData-only writes
-	_refreshedAt time.Time      // Protected by mutex
-	_bindErr     error          // Protected by mutex; last failed bind attempt or terminal cause
-	_terminal    bool           // Protected by mutex; binding failed permanently
-	mutex        sync.RWMutex   // Thread-safe
+	number         uint16          // Read-only
+	st             bindingState    // Protected by readinessMutex
+	addr           netip.AddrPort  // Read-only
+	muBind         sync.Mutex      // Thread-safe, for ChannelBind ops
+	attempt        *bindingAttempt // Protected by muBind; non-nil while a bind attempt is in flight
+	confirmedAt    time.Time       // Protected by readinessMutex
+	terminalCause  error           // Protected by readinessMutex
+	terminal       bool            // Protected by readinessMutex
+	prepared       bool            // Protected by readinessMutex; peer promised ChannelData-only writes
+	generation     bindingAttemptToken
+	activeToken    bindingAttemptToken
+	activeClass    bindingAttemptClass
+	readinessMutex sync.Mutex
 }
 
-func (b *binding) setState(state bindingState) {
-	b.mutex.Lock()
-	defer b.mutex.Unlock()
+// beginAttempt claims one readiness generation when an initial or refresh
+// attempt is eligible. Callers supply the logical decision time; readiness
+// never reads a clock itself.
+func (b *binding) beginAttempt(now time.Time, refreshAfter time.Duration) (
+	bindingAttemptToken,
+	bindingAttemptClass,
+	bool,
+) {
+	b.readinessMutex.Lock()
+	defer b.readinessMutex.Unlock()
 
-	if b._terminal {
-		state = bindingStateFailed
+	if b.terminal || b.activeToken != 0 {
+		return 0, bindingAttemptFresh, false
 	}
-	atomic.StoreInt32((*int32)(&b.st), int32(state))
+
+	state := b.st
+	var class bindingAttemptClass
+	switch {
+	case state == bindingStateIdle || state == bindingStateUnknown:
+		class = bindingAttemptFresh
+		b.st = bindingStateRequest
+	case state == bindingStateReadyUnknown:
+		class = bindingAttemptPreviouslyConfirmed
+		b.st = bindingStateRefresh
+	case state == bindingStateReady && now.Sub(b.confirmedAt) > refreshAfter:
+		class = bindingAttemptPreviouslyConfirmed
+		b.st = bindingStateRefresh
+	default:
+		return 0, bindingAttemptFresh, false
+	}
+
+	b.generation++
+	if b.generation == 0 {
+		b.generation++
+	}
+	b.activeToken = b.generation
+	b.activeClass = class
+
+	return b.activeToken, class, true
 }
 
-// terminalize permanently fails the binding: every later setState collapses to
-// bindingStateFailed so an in-flight bind attempt cannot resurrect it.
-func (b *binding) terminalize(err error) {
-	b.mutex.Lock()
-	defer b.mutex.Unlock()
+// resolveAttempt applies one semantic result to the generation identified by
+// token. Duplicate, stale, late, and post-terminal resolutions are ignored.
+func (b *binding) resolveAttempt(
+	token bindingAttemptToken,
+	outcome bindingAttemptOutcome,
+	cause error,
+	now time.Time,
+) bool {
+	b.readinessMutex.Lock()
+	defer b.readinessMutex.Unlock()
 
-	if b._terminal {
+	if b.terminal || token == 0 || token != b.activeToken {
+		return false
+	}
+
+	if outcome > bindingAttemptPermanentFailure {
+		return false
+	}
+	if !b.applyAttemptOutcomeLocked(outcome, cause, now) {
+		return false
+	}
+	b.activeToken = 0
+
+	return true
+}
+
+func (b *binding) applyAttemptOutcomeLocked(
+	outcome bindingAttemptOutcome,
+	cause error,
+	now time.Time,
+) bool {
+	switch outcome {
+	case bindingAttemptConfirmed:
+		b.confirmedAt = now
+		b.st = bindingStateReady
+	case bindingAttemptUncertain:
+		if b.activeClass == bindingAttemptPreviouslyConfirmed {
+			b.st = bindingStateReadyUnknown
+		} else {
+			b.st = bindingStateUnknown
+		}
+	case bindingAttemptPreserveConfirmation:
+		if b.activeClass != bindingAttemptPreviouslyConfirmed {
+			return false
+		}
+		b.st = bindingStateReady
+	case bindingAttemptPermanentFailure:
+		b.terminal = true
+		b.terminalCause = cause
+		b.st = bindingStateFailed
+	default:
+		return false
+	}
+
+	return true
+}
+
+// preparationAccess observes readiness for one PreparePeer waiter. It marks
+// prepared history only when that waiter observes confirmed, unexpired
+// readiness. The bool reports whether readiness is decisive for the caller.
+func (b *binding) preparationAccess(now time.Time) (bool, error) {
+	b.readinessMutex.Lock()
+	defer b.readinessMutex.Unlock()
+
+	if b.terminal {
+		return true, b.failureCauseLocked()
+	}
+	if !b.usableLocked() {
+		return false, nil
+	}
+	if now.Sub(b.confirmedAt) >= channelBindingLifetime {
+		b.terminalizeLocked(ErrChannelBindingExpired)
+
+		return true, ErrChannelBindingExpired
+	}
+
+	b.prepared = true
+
+	return true, nil
+}
+
+// writeAccess enforces prepared-only, currently usable ChannelData writes.
+// It performs no I/O and terminalizes an expired confirmed binding once.
+func (b *binding) writeAccess(now time.Time) error {
+	b.readinessMutex.Lock()
+	defer b.readinessMutex.Unlock()
+
+	if !b.prepared {
+		return ErrNotPrepared
+	}
+	if b.terminal {
+		return b.failureCauseLocked()
+	}
+	if !b.usableLocked() {
+		return ErrChannelBindFailed
+	}
+	if now.Sub(b.confirmedAt) >= channelBindingLifetime {
+		b.terminalizeLocked(ErrChannelBindingExpired)
+
+		return ErrChannelBindingExpired
+	}
+
+	return nil
+}
+
+// failPrepared applies tokenless Permission-refresh loss. Preparation and
+// permission loss serialize on the same readiness lock.
+func (b *binding) failPrepared(cause error) bool {
+	b.readinessMutex.Lock()
+	defer b.readinessMutex.Unlock()
+
+	if b.terminal || !b.prepared {
+		return false
+	}
+	b.terminalizeLocked(cause)
+
+	return true
+}
+
+func (b *binding) usableLocked() bool {
+	return b.st == bindingStateReady || b.st == bindingStateRefresh || b.st == bindingStateReadyUnknown
+}
+
+func (b *binding) failureCauseLocked() error {
+	if b.terminalCause != nil {
+		return b.terminalCause
+	}
+
+	return ErrChannelBindFailed
+}
+
+func (b *binding) terminalizeLocked(cause error) {
+	if b.terminal {
 		return
 	}
-	b._terminal = true
-	b._bindErr = err
-	atomic.StoreInt32((*int32)(&b.st), int32(bindingStateFailed))
-}
-
-func (b *binding) setBindErr(err error) {
-	b.mutex.Lock()
-	defer b.mutex.Unlock()
-
-	if !b._terminal {
-		b._bindErr = err
-	}
-}
-
-func (b *binding) bindErr() error {
-	b.mutex.RLock()
-	defer b.mutex.RUnlock()
-
-	return b._bindErr
-}
-
-func (b *binding) state() bindingState {
-	return bindingState(atomic.LoadInt32((*int32)(&b.st)))
-}
-
-func (b *binding) setRefreshedAt(at time.Time) {
-	b.mutex.Lock()
-	defer b.mutex.Unlock()
-
-	b._refreshedAt = at
-}
-
-func (b *binding) refreshedAt() time.Time {
-	b.mutex.RLock()
-	defer b.mutex.RUnlock()
-
-	return b._refreshedAt
-}
-
-func (b *binding) ok() bool {
-	state := b.state()
-
-	return state == bindingStateReady || state == bindingStateRefresh || state == bindingStateReadyUnknown
+	b.terminal = true
+	b.terminalCause = cause
+	b.st = bindingStateFailed
 }
 
 // Thread-safe binding map.
@@ -151,9 +288,8 @@ func (mgr *bindingManager) getOrCreate(addr netip.AddrPort) (*binding, bool) {
 	}
 
 	b := &binding{
-		number:       mgr.assignChannelNumber(),
-		addr:         addr,
-		_refreshedAt: time.Now(),
+		number: mgr.assignChannelNumber(),
+		addr:   addr,
 	}
 
 	mgr.chanMap[b.number] = b

--- a/internal/client/binding.go
+++ b/internal/client/binding.go
@@ -176,10 +176,8 @@ func (b *binding) preparationAccess(now time.Time) (bool, error) {
 	if !b.usableLocked() {
 		return false, nil
 	}
-	if now.Sub(b.confirmedAt) >= channelBindingLifetime {
-		b.terminalizeLocked(ErrChannelBindingExpired)
-
-		return true, ErrChannelBindingExpired
+	if err := b.expireLocked(now); err != nil {
+		return true, err
 	}
 
 	b.prepared = true
@@ -202,13 +200,8 @@ func (b *binding) writeAccess(now time.Time) error {
 	if !b.usableLocked() {
 		return ErrChannelBindFailed
 	}
-	if now.Sub(b.confirmedAt) >= channelBindingLifetime {
-		b.terminalizeLocked(ErrChannelBindingExpired)
 
-		return ErrChannelBindingExpired
-	}
-
-	return nil
+	return b.expireLocked(now)
 }
 
 // failPrepared applies tokenless Permission-refresh loss. Preparation and
@@ -227,6 +220,15 @@ func (b *binding) failPrepared(cause error) bool {
 
 func (b *binding) usableLocked() bool {
 	return b.st == bindingStateReady || b.st == bindingStateRefresh || b.st == bindingStateReadyUnknown
+}
+
+func (b *binding) expireLocked(now time.Time) error {
+	if now.Sub(b.confirmedAt) < channelBindingLifetime {
+		return nil
+	}
+	b.terminalizeLocked(ErrChannelBindingExpired)
+
+	return ErrChannelBindingExpired
 }
 
 func (b *binding) failureCauseLocked() error {

--- a/internal/client/binding_test.go
+++ b/internal/client/binding_test.go
@@ -39,6 +39,21 @@ func TestBindingReadinessBeginsAndRetriesFreshAttempt(t *testing.T) {
 		"a stale completion must not overwrite a newer attempt")
 }
 
+func TestBindingReadinessRejectsDuplicateResolution(t *testing.T) {
+	t0 := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+	bound := &binding{}
+	token, _, started := bound.beginAttempt(t0, defaultBindingRefreshInterval)
+	require.True(t, started)
+	require.True(t, bound.resolveAttempt(token, bindingAttemptUncertain, nil, t0))
+
+	assert.False(t, bound.resolveAttempt(token, bindingAttemptConfirmed, nil, t0.Add(time.Minute)),
+		"one live token may resolve at most once")
+	nextToken, class, started := bound.beginAttempt(t0.Add(time.Minute), defaultBindingRefreshInterval)
+	require.True(t, started, "the first uncertainty outcome must remain retryable")
+	assert.NotEqual(t, token, nextToken)
+	assert.Equal(t, bindingAttemptFresh, class)
+}
+
 func TestBindingReadinessRefreshThresholdAndPreservedConfirmation(t *testing.T) {
 	t0 := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
 	bound := &binding{}

--- a/internal/client/binding_test.go
+++ b/internal/client/binding_test.go
@@ -8,10 +8,191 @@ import (
 	"net/netip"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestBindingReadinessBeginsAndRetriesFreshAttempt(t *testing.T) {
+	t0 := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+	bound := &binding{}
+
+	token1, class, started := bound.beginAttempt(t0, defaultBindingRefreshInterval)
+	require.True(t, started)
+	assert.Equal(t, bindingAttemptFresh, class)
+
+	_, _, started = bound.beginAttempt(t0, defaultBindingRefreshInterval)
+	assert.False(t, started, "one readiness generation may be active at a time")
+
+	assert.True(t, bound.resolveAttempt(token1, bindingAttemptUncertain, nil, t0))
+	token2, class, started := bound.beginAttempt(t0, defaultBindingRefreshInterval)
+	require.True(t, started)
+	assert.NotEqual(t, token1, token2)
+	assert.Equal(t, bindingAttemptFresh, class)
+
+	assert.False(t, bound.resolveAttempt(token1, bindingAttemptConfirmed, nil, t0.Add(time.Minute)),
+		"a stale completion must not overwrite a newer attempt")
+}
+
+func TestBindingReadinessRefreshThresholdAndPreservedConfirmation(t *testing.T) {
+	t0 := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+	bound := &binding{}
+	token, _, started := bound.beginAttempt(t0, defaultBindingRefreshInterval)
+	require.True(t, started)
+	require.True(t, bound.resolveAttempt(token, bindingAttemptConfirmed, nil, t0))
+
+	for _, now := range []time.Time{
+		t0.Add(defaultBindingRefreshInterval - time.Nanosecond),
+		t0.Add(defaultBindingRefreshInterval),
+	} {
+		_, _, started = bound.beginAttempt(now, defaultBindingRefreshInterval)
+		assert.False(t, started, "refresh eligibility is strictly after the interval")
+	}
+
+	refreshToken, class, started := bound.beginAttempt(
+		t0.Add(defaultBindingRefreshInterval+time.Nanosecond),
+		defaultBindingRefreshInterval,
+	)
+	require.True(t, started)
+	assert.Equal(t, bindingAttemptPreviouslyConfirmed, class)
+	require.True(t, bound.resolveAttempt(
+		refreshToken,
+		bindingAttemptPreserveConfirmation,
+		nil,
+		t0.Add(defaultBindingRefreshInterval+time.Minute),
+	))
+
+	final, err := bound.preparationAccess(t0.Add(channelBindingLifetime))
+	assert.True(t, final)
+	assert.ErrorIs(t, err, ErrChannelBindingExpired,
+		"preserving a prior confirmation must not advance its age")
+}
+
+func TestBindingReadinessPreparationAndWriteAccess(t *testing.T) {
+	t0 := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+	bound := &binding{}
+
+	assert.ErrorIs(t, bound.writeAccess(t0), ErrNotPrepared)
+	token, _, started := bound.beginAttempt(t0, defaultBindingRefreshInterval)
+	require.True(t, started)
+	require.True(t, bound.resolveAttempt(token, bindingAttemptConfirmed, nil, t0))
+	assert.ErrorIs(t, bound.writeAccess(t0), ErrNotPrepared,
+		"server confirmation alone must not establish prepared history")
+
+	final, err := bound.preparationAccess(t0.Add(channelBindingLifetime - time.Nanosecond))
+	assert.True(t, final)
+	require.NoError(t, err)
+	require.NoError(t, bound.writeAccess(t0.Add(channelBindingLifetime-time.Nanosecond)))
+
+	assert.ErrorIs(t, bound.writeAccess(t0.Add(channelBindingLifetime)), ErrChannelBindingExpired)
+	assert.ErrorIs(t, bound.writeAccess(t0.Add(channelBindingLifetime+time.Second)), ErrChannelBindingExpired,
+		"expiry must retain its first durable cause")
+	assert.False(t, bound.resolveAttempt(token, bindingAttemptConfirmed, nil, t0.Add(time.Hour)),
+		"late completion must not resurrect terminal readiness")
+}
+
+func TestBindingReadinessPreparedPermissionLossOrdering(t *testing.T) {
+	t0 := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+	permissionCause := fmt.Errorf("%w: permission transaction", ErrPermissionRefreshFailed)
+	otherCause := fmt.Errorf("%w: later failure", ErrPermissionRefreshFailed)
+
+	t.Run("loss before preparation does not terminalize", func(t *testing.T) {
+		bound := confirmedBinding(t, t0)
+		assert.False(t, bound.failPrepared(permissionCause))
+		final, err := bound.preparationAccess(t0)
+		assert.True(t, final)
+		assert.NoError(t, err)
+	})
+
+	t.Run("preparation before loss records the first cause", func(t *testing.T) {
+		bound := confirmedBinding(t, t0)
+		final, err := bound.preparationAccess(t0)
+		require.True(t, final)
+		require.NoError(t, err)
+
+		assert.True(t, bound.failPrepared(permissionCause))
+		assert.False(t, bound.failPrepared(otherCause))
+		assert.ErrorIs(t, bound.writeAccess(t0), permissionCause)
+		assert.NotErrorIs(t, bound.writeAccess(t0), otherCause)
+	})
+}
+
+func TestBindingReadinessPreviouslyConfirmedAttemptKeepsAccess(t *testing.T) {
+	t0 := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+	bound := confirmedBinding(t, t0)
+	final, err := bound.preparationAccess(t0)
+	require.True(t, final)
+	require.NoError(t, err)
+
+	token, class, started := bound.beginAttempt(
+		t0.Add(defaultBindingRefreshInterval+time.Nanosecond),
+		defaultBindingRefreshInterval,
+	)
+	require.True(t, started)
+	assert.Equal(t, bindingAttemptPreviouslyConfirmed, class)
+	require.NoError(t, bound.writeAccess(t0.Add(defaultBindingRefreshInterval+time.Second)),
+		"a previously confirmed refresh in flight remains usable")
+
+	require.True(t, bound.resolveAttempt(token, bindingAttemptUncertain, nil, t0.Add(6*time.Minute)))
+	require.NoError(t, bound.writeAccess(t0.Add(6*time.Minute)),
+		"previously confirmed uncertainty preserves usable history")
+	_, class, started = bound.beginAttempt(t0.Add(6*time.Minute), defaultBindingRefreshInterval)
+	require.True(t, started, "uncertain confirmed readiness is immediately refresh eligible")
+	assert.Equal(t, bindingAttemptPreviouslyConfirmed, class)
+}
+
+func TestBindingReadinessPermanentFailureIsDurable(t *testing.T) {
+	t0 := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+	bound := &binding{}
+	token, _, started := bound.beginAttempt(t0, defaultBindingRefreshInterval)
+	require.True(t, started)
+	cause := fmt.Errorf("permanent: %w", ErrChannelBindFailed)
+
+	require.True(t, bound.resolveAttempt(token, bindingAttemptPermanentFailure, cause, t0))
+	final, err := bound.preparationAccess(t0)
+	assert.True(t, final)
+	assert.ErrorIs(t, err, cause)
+	_, _, started = bound.beginAttempt(t0.Add(time.Minute), defaultBindingRefreshInterval)
+	assert.False(t, started)
+	assert.False(t, bound.resolveAttempt(token, bindingAttemptConfirmed, nil, t0.Add(time.Minute)))
+}
+
+func TestBindingReadinessExpiryRejectsInFlightCompletion(t *testing.T) {
+	t0 := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+	bound := confirmedBinding(t, t0)
+	final, err := bound.preparationAccess(t0)
+	require.True(t, final)
+	require.NoError(t, err)
+
+	token, class, started := bound.beginAttempt(
+		t0.Add(defaultBindingRefreshInterval+time.Nanosecond),
+		defaultBindingRefreshInterval,
+	)
+	require.True(t, started)
+	assert.Equal(t, bindingAttemptPreviouslyConfirmed, class)
+	assert.ErrorIs(t, bound.writeAccess(t0.Add(channelBindingLifetime)), ErrChannelBindingExpired)
+	assert.False(t, bound.resolveAttempt(token, bindingAttemptConfirmed, nil, t0.Add(channelBindingLifetime)),
+		"an in-flight success must not resurrect terminal expiry")
+	assert.ErrorIs(t, bound.writeAccess(t0.Add(channelBindingLifetime)), ErrChannelBindingExpired)
+}
+
+func confirmedBinding(t *testing.T, confirmedAt time.Time) *binding {
+	t.Helper()
+
+	bound := &binding{}
+	confirmBindingAt(t, bound, confirmedAt)
+
+	return bound
+}
+
+func confirmBindingAt(t *testing.T, bound *binding, confirmedAt time.Time) {
+	t.Helper()
+
+	token, _, started := bound.beginAttempt(confirmedAt, defaultBindingRefreshInterval)
+	require.True(t, started)
+	require.True(t, bound.resolveAttempt(token, bindingAttemptConfirmed, nil, confirmedAt))
+}
 
 func TestBindingManagerCapacity(t *testing.T) {
 	const wantCapacity = 16_384

--- a/internal/client/binding_test.go
+++ b/internal/client/binding_test.go
@@ -21,6 +21,10 @@ func TestBindingReadinessBeginsAndRetriesFreshAttempt(t *testing.T) {
 	token1, class, started := bound.beginAttempt(t0, defaultBindingRefreshInterval)
 	require.True(t, started)
 	assert.Equal(t, bindingAttemptFresh, class)
+	final, err := bound.preparationAccess(t0)
+	assert.False(t, final)
+	assert.NoError(t, err)
+	assert.ErrorIs(t, bound.writeAccess(t0), ErrNotPrepared)
 
 	_, _, started = bound.beginAttempt(t0, defaultBindingRefreshInterval)
 	assert.False(t, started, "one readiness generation may be active at a time")
@@ -156,6 +160,26 @@ func TestBindingReadinessPermanentFailureIsDurable(t *testing.T) {
 	_, _, started = bound.beginAttempt(t0.Add(time.Minute), defaultBindingRefreshInterval)
 	assert.False(t, started)
 	assert.False(t, bound.resolveAttempt(token, bindingAttemptConfirmed, nil, t0.Add(time.Minute)))
+}
+
+func TestBindingReadinessPermanentOutcomeOrdersWithAccess(t *testing.T) {
+	t0 := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+	bound := confirmedBinding(t, t0)
+	final, err := bound.preparationAccess(t0)
+	require.True(t, final)
+	require.NoError(t, err)
+	token, _, started := bound.beginAttempt(
+		t0.Add(defaultBindingRefreshInterval+time.Nanosecond),
+		defaultBindingRefreshInterval,
+	)
+	require.True(t, started)
+
+	require.NoError(t, bound.writeAccess(t0.Add(defaultBindingRefreshInterval+time.Second)),
+		"access linearized before the permanent outcome may observe prior usability")
+	cause := fmt.Errorf("permanent refresh: %w", ErrChannelBindFailed)
+	require.True(t, bound.resolveAttempt(token, bindingAttemptPermanentFailure, cause, t0.Add(6*time.Minute)))
+	assert.ErrorIs(t, bound.writeAccess(t0.Add(6*time.Minute)), cause,
+		"access linearized after the permanent outcome observes the durable cause")
 }
 
 func TestBindingReadinessExpiryRejectsInFlightCompletion(t *testing.T) {

--- a/internal/client/prepare_test.go
+++ b/internal/client/prepare_test.go
@@ -6,6 +6,7 @@ package client
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"net/netip"
 	"sync"
@@ -277,28 +278,31 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 
 		bound, ok := harness.conn.bindingMgr.getOrCreate(harness.peer)
 		require.True(t, ok)
+		confirmedAt := time.Now().Add(-defaultBindingRefreshInterval - time.Minute)
+		confirmBindingAt(t, bound, confirmedAt)
+		final, err := bound.preparationAccess(confirmedAt)
+		require.True(t, final)
+		require.NoError(t, err)
 		harness.conn.maybeBind(bound)
 		assert.Eventually(t, func() bool {
 			return harness.bindCount.Load() == 1
 		}, 5*time.Second, 10*time.Millisecond)
 
-		// Terminalize while the bind transaction is still in flight, then let
-		// it succeed: the binding must stay failed.
-		bound.prepared.Store(true)
-		bound.terminalize(errFake)
+		// Permission loss terminalizes while refresh is in flight, then the late
+		// success must not resurrect the binding.
+		permissionCause := fmt.Errorf("%w: %w", ErrPermissionRefreshFailed, errFake)
+		require.True(t, bound.failPrepared(permissionCause))
 		close(harness.bindGate)
 
 		assert.Eventually(t, func() bool {
 			bound.muBind.Lock()
 			defer bound.muBind.Unlock()
 
-			return bound.attemptDone == nil
+			return bound.attempt == nil
 		}, 5*time.Second, 10*time.Millisecond)
-		assert.Equal(t, bindingStateFailed, bound.state(),
-			"completed bind attempt must not resurrect a terminalized binding")
 
-		_, err := harness.conn.WriteTo([]byte("data"), harness.peer)
-		assert.ErrorIs(t, err, errFake)
+		_, err = harness.conn.WriteTo([]byte("data"), harness.peer)
+		assert.ErrorIs(t, err, permissionCause)
 	})
 
 	t.Run("same-peer callers coalesce onto one bind", func(t *testing.T) {
@@ -370,6 +374,35 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 			assert.Fail(t, "timed out waiting for surviving waiter")
 		}
 		assert.Equal(t, int32(1), harness.bindCount.Load(), "cancellation must not restart or cancel the shared bind")
+	})
+
+	t.Run("cancellation selected before preparation leaves confirmed peer unprepared", func(t *testing.T) {
+		harness := newPrepareHarness(t, true)
+		ctx, cancel := context.WithCancelCause(context.Background())
+		cause := errors.New("caller selected cancellation") //nolint:err113 // Test-local cause.
+		result := make(chan error, 1)
+		go func() { result <- harness.conn.PreparePeer(ctx, harness.peer) }()
+
+		require.Eventually(t, func() bool {
+			return harness.bindCount.Load() == 1
+		}, 5*time.Second, 10*time.Millisecond)
+		cancel(cause)
+		assert.ErrorIs(t, <-result, cause)
+
+		close(harness.bindGate)
+		bound, ok := harness.conn.bindingMgr.findByAddr(harness.peer)
+		require.True(t, ok)
+		require.Eventually(t, func() bool {
+			bound.muBind.Lock()
+			defer bound.muBind.Unlock()
+
+			return bound.attempt == nil
+		}, 5*time.Second, 10*time.Millisecond)
+
+		_, err := harness.conn.WriteTo([]byte("still unprepared"), harness.peer)
+		assert.ErrorIs(t, err, ErrNotPrepared)
+		assert.NoError(t, harness.conn.PreparePeer(context.Background(), harness.peer))
+		assert.Equal(t, int32(1), harness.bindCount.Load(), "the second waiter observes existing readiness")
 	})
 
 	t.Run("cancellation wakes waiter during in-flight permission transaction", func(t *testing.T) {
@@ -467,6 +500,44 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 		err := harness.conn.PreparePeer(context.Background(), harness.peer)
 		assert.ErrorIs(t, err, errChannelBindTransactionFailed)
 		assert.False(t, harness.conn.isClosed())
+
+		mock.performTransaction = inner
+		assert.NoError(t, harness.conn.PreparePeer(context.Background(), harness.peer),
+			"a fresh transaction failure is attempt-local and a later caller may retry")
+		assert.Equal(t, int32(2), harness.bindCount.Load())
+	})
+
+	t.Run("joined bind failure is attempt-local for every waiter", func(t *testing.T) {
+		harness := newPrepareHarness(t, false)
+		gate := make(chan struct{})
+		mock := harness.mock
+		inner := mock.performTransaction
+		mock.performTransaction = func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
+			if msg.Type.Method == stun.MethodChannelBind {
+				harness.bindCount.Add(1)
+				<-gate
+
+				return TransactionResult{}, errFake
+			}
+
+			return inner(msg, dontWait)
+		}
+
+		results := make(chan error, 2)
+		for range 2 {
+			go func() { results <- harness.conn.PreparePeer(context.Background(), harness.peer) }()
+		}
+		require.Eventually(t, func() bool { return harness.bindCount.Load() == 1 }, 5*time.Second, 10*time.Millisecond)
+		close(gate)
+
+		for range 2 {
+			assert.ErrorIs(t, <-results, errChannelBindTransactionFailed)
+		}
+		assert.Equal(t, int32(1), harness.bindCount.Load())
+
+		mock.performTransaction = inner
+		assert.NoError(t, harness.conn.PreparePeer(context.Background(), harness.peer))
+		assert.Equal(t, int32(2), harness.bindCount.Load())
 	})
 
 	t.Run("server bind rejection surfaces typed TURN error", func(t *testing.T) {
@@ -567,12 +638,15 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 	t.Run("re-entry after binding expiry is terminal", func(t *testing.T) {
 		harness := newPrepareHarness(t, false)
 
-		assert.NoError(t, harness.conn.PreparePeer(context.Background(), harness.peer))
 		bound, ok := harness.conn.bindingMgr.getOrCreate(harness.peer)
 		require.True(t, ok)
-		bound.setRefreshedAt(time.Now().Add(-channelBindingLifetime))
+		confirmedAt := time.Now().Add(-channelBindingLifetime)
+		confirmBindingAt(t, bound, confirmedAt)
+		final, err := bound.preparationAccess(confirmedAt)
+		require.True(t, final)
+		require.NoError(t, err)
 
-		err := harness.conn.PreparePeer(context.Background(), harness.peer)
+		err = harness.conn.PreparePeer(context.Background(), harness.peer)
 		assert.ErrorIs(t, err, ErrChannelBindingExpired,
 			"a preparing caller re-entering an expired binding must observe the expiry")
 	})
@@ -622,10 +696,13 @@ func TestWriteToPreparedOnly(t *testing.T) {
 			name: "prepared then binding expired",
 			arrange: func(t *testing.T, harness *prepareHarness) {
 				t.Helper()
-				assert.NoError(t, harness.conn.PreparePeer(context.Background(), harness.peer))
 				bound, ok := harness.conn.bindingMgr.getOrCreate(harness.peer)
 				require.True(t, ok)
-				bound.setRefreshedAt(time.Now().Add(-channelBindingLifetime))
+				confirmedAt := time.Now().Add(-channelBindingLifetime)
+				confirmBindingAt(t, bound, confirmedAt)
+				final, err := bound.preparationAccess(confirmedAt)
+				require.True(t, final)
+				require.NoError(t, err)
 			},
 			wantErr:    ErrChannelBindingExpired,
 			wantWrites: 0,

--- a/internal/client/prepare_test.go
+++ b/internal/client/prepare_test.go
@@ -600,6 +600,11 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 		case <-time.After(5 * time.Second):
 			assert.Fail(t, "Close did not return after the bind worker finished")
 		}
+		bound, ok := harness.conn.bindingMgr.findByAddr(harness.peer)
+		require.True(t, ok)
+		final, readinessErr := bound.preparationAccess(time.Now())
+		assert.False(t, final, "an attempt completing after Allocation close creates no readiness outcome")
+		assert.NoError(t, readinessErr)
 	})
 
 	t.Run("attempt in flight during self-seal records the terminal cause", func(t *testing.T) {

--- a/internal/client/udp_conn.go
+++ b/internal/client/udp_conn.go
@@ -40,6 +40,15 @@ type inboundData struct {
 	from netip.AddrPort
 }
 
+// bindingAttempt is UDPConn-owned coordination for one ChannelBind generation.
+// Readiness owns only the token and durable result of resolving that generation.
+type bindingAttempt struct {
+	done   chan struct{}
+	token  bindingAttemptToken
+	class  bindingAttemptClass
+	result error
+}
+
 // UDPConn is one live UDP relay allocation. Peer addresses cross its methods
 // as canonical netip.AddrPort values; the root package owns canonicalization
 // and validation, so every peer reaching this type is already canonical.
@@ -300,20 +309,20 @@ func (c *UDPConn) ensurePermissionAttempt(perm *permission, peer netip.AddrPort)
 // binding fails, or ctx is canceled.
 func (c *UDPConn) awaitBinding(ctx context.Context, bound *binding) error { //nolint:cyclop
 	for {
-		if final, err := bindingResult(bound); final {
+		if final, err := bound.preparationAccess(time.Now()); final {
 			return err
 		}
 
 		bound.muBind.Lock()
-		done := bound.attemptDone
-		if done == nil {
-			done = c.startBindAttemptLocked(bound)
+		attempt := bound.attempt
+		if attempt == nil {
+			attempt = c.startBindAttemptLocked(bound, time.Now())
 		}
 		bound.muBind.Unlock()
 
-		if done == nil {
+		if attempt == nil {
 			// No attempt is needed (state already decisive) or none can start (closing).
-			if final, err := bindingResult(bound); final {
+			if final, err := bound.preparationAccess(time.Now()); final {
 				return err
 			}
 			if c.isClosed() {
@@ -324,76 +333,57 @@ func (c *UDPConn) awaitBinding(ctx context.Context, bound *binding) error { //no
 		}
 
 		select {
-		case <-done:
+		case <-attempt.done:
 		case <-ctx.Done():
 			return context.Cause(ctx)
 		case <-c.closeCh:
 			return c.closedErr()
 		}
 
-		if final, err := bindingResult(bound); final {
+		if final, err := bound.preparationAccess(time.Now()); final {
 			return err
 		}
 		// The joined attempt ended without confirming; surface its error rather
 		// than retrying forever on the caller's behalf.
-		if err := bound.bindErr(); err != nil {
-			return err
+		if attempt.result != nil {
+			return attempt.result
 		}
 	}
-}
-
-// bindingResult reports whether the binding reached a decisive state for a
-// preparing caller: (true, nil) once the server has confirmed the channel
-// mapping, (true, err) once the binding failed or its confirmation expired.
-func bindingResult(bound *binding) (bool, error) {
-	if bound.ok() {
-		if time.Since(bound.refreshedAt()) >= channelBindingLifetime {
-			bound.terminalize(ErrChannelBindingExpired)
-
-			return true, ErrChannelBindingExpired
-		}
-		bound.prepared.Store(true)
-
-		return true, nil
-	}
-	if bound.state() == bindingStateFailed {
-		if err := bound.bindErr(); err != nil {
-			return true, err
-		}
-
-		return true, ErrChannelBindFailed
-	}
-
-	return false, nil
 }
 
 // startBindAttemptLocked starts a tracked bind attempt if the binding state
 // calls for one. It requires bound.muBind to be held and returns the channel
 // that closes when the attempt completes, or nil if no attempt was started.
-func (c *UDPConn) startBindAttemptLocked(bound *binding) chan struct{} {
+func (c *UDPConn) startBindAttemptLocked(bound *binding, now time.Time) *bindingAttempt {
 	if !c.addWorker() {
 		return nil
 	}
-	startState, ok := c.startBinding(bound)
-	if !ok {
+	token, class, started := bound.beginAttempt(now, c.bindingRefreshInterval)
+	if !started {
 		c.workerWG.Done()
 
 		return nil
 	}
 
-	done := make(chan struct{})
-	bound.attemptDone = done
+	attempt := &bindingAttempt{
+		done:  make(chan struct{}),
+		token: token,
+		class: class,
+	}
+	bound.attempt = attempt
 	go func() {
 		defer c.workerWG.Done()
-		err := c.bindChannel(bound, startState)
-		bound.setBindErr(err)
+		err := c.bindChannel(bound, token, class)
 		bound.muBind.Lock()
-		bound.attemptDone = nil
+		attempt.result = err
+		if bound.attempt == attempt {
+			bound.attempt = nil
+		}
 		bound.muBind.Unlock()
-		close(done)
+		close(attempt.done)
 	}()
 
-	return done
+	return attempt
 }
 
 // addWorker registers an allocation-owned goroutine with the close join.
@@ -414,10 +404,9 @@ func (c *UDPConn) addWorker() bool {
 // prepared, losing its permission must fail its writes with the recorded
 // cause; there is no other write path to fall back to.
 func (c *UDPConn) failPreparedBindings(err error) {
+	cause := fmt.Errorf("%w: %w", ErrPermissionRefreshFailed, err)
 	for _, bound := range c.bindingMgr.all() {
-		if bound.prepared.Load() {
-			bound.terminalize(fmt.Errorf("%w: %w", ErrPermissionRefreshFailed, err))
-		}
+		bound.failPrepared(cause)
 	}
 }
 
@@ -435,19 +424,12 @@ func (c *UDPConn) WriteTo(payload []byte, addr netip.AddrPort) (int, error) {
 	}
 
 	bound, ok := c.bindingMgr.findByAddr(addr)
-	if !ok || !bound.prepared.Load() {
+	if !ok {
 		return 0, ErrNotPrepared
 	}
 
-	if bound.ok() && time.Since(bound.refreshedAt()) >= channelBindingLifetime {
-		bound.terminalize(ErrChannelBindingExpired)
-	}
-	if !bound.ok() {
-		if bindErr := bound.bindErr(); bindErr != nil {
-			return 0, bindErr
-		}
-
-		return 0, ErrChannelBindFailed
+	if err := bound.writeAccess(time.Now()); err != nil {
+		return 0, err
 	}
 
 	return c.sendChannelData(payload, bound.number)
@@ -685,31 +667,19 @@ func (c *UDPConn) maybeBind(bound *binding) {
 	bound.muBind.Lock()
 	defer bound.muBind.Unlock()
 
-	if bound.attemptDone == nil {
+	if bound.attempt == nil {
 		// Establish binding with the server if the state machine allows it.
-		c.startBindAttemptLocked(bound)
+		c.startBindAttemptLocked(bound, time.Now())
 	}
-}
-
-func (c *UDPConn) startBinding(bound *binding) (bindingState, bool) {
-	startState := bound.state()
-	switch {
-	case startState == bindingStateIdle || startState == bindingStateUnknown:
-		bound.setState(bindingStateRequest)
-	case startState == bindingStateReadyUnknown:
-		bound.setState(bindingStateRefresh)
-	case startState == bindingStateReady && time.Since(bound.refreshedAt()) > c.bindingRefreshInterval:
-		bound.setState(bindingStateRefresh)
-	default:
-		return startState, false
-	}
-
-	return startState, true
 }
 
 // bindChannel performs one ChannelBind attempt. It returns nil when the
 // binding was confirmed or recovered, and the attempt's error otherwise.
-func (c *UDPConn) bindChannel(bound *binding, startState bindingState) error {
+func (c *UDPConn) bindChannel(
+	bound *binding,
+	token bindingAttemptToken,
+	class bindingAttemptClass,
+) error {
 	var err error
 	for range maxRetryAttempts {
 		if c.isClosed() {
@@ -728,63 +698,38 @@ func (c *UDPConn) bindChannel(bound *binding, startState bindingState) error {
 			// transaction must not count as a bind failure.
 			return err
 		}
-		if c.handleBindChannelError(bound, startState, err) {
-			return nil
-		}
 
-		return err
+		return c.resolveBindError(bound, token, class, err)
 	}
 
-	bound.setRefreshedAt(time.Now())
-	bound.setState(bindingStateReady)
+	bound.resolveAttempt(token, bindingAttemptConfirmed, nil, time.Now())
 
 	return nil
 }
 
-// handleBindChannelError reports whether the binding recovered (kept usable).
-func (c *UDPConn) handleBindChannelError(bound *binding, startState bindingState, err error) bool {
-	if c.recoverChannelBindBadRequest(bound, startState, err) {
-		return true
-	}
+func (c *UDPConn) resolveBindError(
+	bound *binding,
+	token bindingAttemptToken,
+	class bindingAttemptClass,
+	err error,
+) error {
+	if errors.Is(err, errChannelBindBadRequest) && class == bindingAttemptPreviouslyConfirmed {
+		bound.resolveAttempt(token, bindingAttemptPreserveConfirmation, nil, time.Now())
 
+		return nil
+	}
 	if errors.Is(err, errChannelBindTransactionFailed) {
-		if bindingStateWasReady(startState) {
-			bound.setState(bindingStateReadyUnknown)
-		} else {
-			bound.setState(bindingStateUnknown)
-		}
+		bound.resolveAttempt(token, bindingAttemptUncertain, nil, time.Now())
 
-		return false
+		return err
 	}
 
-	bound.setState(bindingStateFailed)
-	if errors.Is(err, errChannelBindBadRequest) {
+	applied := bound.resolveAttempt(token, bindingAttemptPermanentFailure, err, time.Now())
+	if applied && errors.Is(err, errChannelBindBadRequest) {
 		c.closeAfterChannelBindBadRequest(err)
 	}
 
-	return false
-}
-
-func (c *UDPConn) recoverChannelBindBadRequest(bound *binding, startState bindingState, err error) bool {
-	if !errors.Is(err, errChannelBindBadRequest) {
-		return false
-	}
-	if !bindingStateWasReady(startState) {
-		return false
-	}
-
-	// If this binding was previously confirmed, a refresh transaction failure or
-	// unexpected 400 does not prove that the saved channel mapping is wrong. The
-	// server may still have the old binding, and switching channels would be
-	// worse because it can trigger "same peer with different channel number" (like what we get from Coturn).
-	// This Keep the saved mapping usable and retry refresh later.
-	bound.setState(bindingStateReady)
-
-	return true
-}
-
-func bindingStateWasReady(state bindingState) bool {
-	return state == bindingStateReady || state == bindingStateReadyUnknown
+	return err
 }
 
 // closeAfterChannelBindBadRequest terminalizes the whole allocation after a

--- a/internal/client/udp_conn.go
+++ b/internal/client/udp_conn.go
@@ -530,9 +530,13 @@ func (c *UDPConn) startCloseLocked(cause error) (bool, error) {
 // wrapped with the recorded terminal cause when the allocation sealed itself.
 func (c *UDPConn) closedErr() error {
 	c.closeMutex.Lock()
-	cause := c.terminalCause
-	c.closeMutex.Unlock()
+	defer c.closeMutex.Unlock()
 
+	return c.closedErrLocked()
+}
+
+func (c *UDPConn) closedErrLocked() error {
+	cause := c.terminalCause
 	if cause != nil {
 		return fmt.Errorf("%w: %w", net.ErrClosed, cause)
 	}
@@ -692,20 +696,33 @@ func (c *UDPConn) bindChannel(
 			break
 		}
 	}
-	if c.isClosed() {
-		if err != nil {
-			return err
-		}
-
-		return c.closedErr()
-	}
 	if err != nil {
 		return c.resolveBindError(bound, token, class, err)
 	}
 
-	bound.resolveAttempt(token, bindingAttemptConfirmed, nil, time.Now())
+	_, completionErr := c.completeBindingAttempt(bound, token, bindingAttemptConfirmed, nil, time.Now())
 
-	return nil
+	return completionErr
+}
+
+// completeBindingAttempt orders readiness publication with Allocation seal.
+// The close lock is never held across TURN I/O; the only nested order is
+// closeMutex then one binding's readiness lock.
+func (c *UDPConn) completeBindingAttempt(
+	bound *binding,
+	token bindingAttemptToken,
+	outcome bindingAttemptOutcome,
+	cause error,
+	now time.Time,
+) (bool, error) {
+	c.closeMutex.Lock()
+	defer c.closeMutex.Unlock()
+
+	if c.isClosed() {
+		return false, c.closedErrLocked()
+	}
+
+	return bound.resolveAttempt(token, outcome, cause, now), nil
 }
 
 func (c *UDPConn) resolveBindError(
@@ -715,22 +732,49 @@ func (c *UDPConn) resolveBindError(
 	err error,
 ) error {
 	if errors.Is(err, errChannelBindBadRequest) && class == bindingAttemptPreviouslyConfirmed {
-		bound.resolveAttempt(token, bindingAttemptPreserveConfirmation, nil, time.Now())
+		_, completionErr := c.completeBindingAttempt(
+			bound,
+			token,
+			bindingAttemptPreserveConfirmation,
+			nil,
+			time.Now(),
+		)
 
-		return nil
+		return completionErr
 	}
 	if errors.Is(err, errChannelBindTransactionFailed) {
-		bound.resolveAttempt(token, bindingAttemptUncertain, nil, time.Now())
+		applied, completionErr := c.completeBindingAttempt(
+			bound,
+			token,
+			bindingAttemptUncertain,
+			nil,
+			time.Now(),
+		)
+		if completionErr != nil {
+			return completionErr
+		}
+		if !applied {
+			return nil
+		}
 
 		return err
 	}
 
-	applied := bound.resolveAttempt(token, bindingAttemptPermanentFailure, err, time.Now())
+	applied, completionErr := c.completeBindingAttempt(
+		bound,
+		token,
+		bindingAttemptPermanentFailure,
+		err,
+		time.Now(),
+	)
+	if completionErr != nil {
+		return completionErr
+	}
 	if applied && errors.Is(err, errChannelBindBadRequest) {
 		c.closeAfterChannelBindBadRequest(err)
 	}
 
-	return err
+	return nil
 }
 
 // closeAfterChannelBindBadRequest terminalizes the whole allocation after a

--- a/internal/client/udp_conn.go
+++ b/internal/client/udp_conn.go
@@ -692,13 +692,14 @@ func (c *UDPConn) bindChannel(
 			break
 		}
 	}
-	if err != nil {
-		if c.isClosed() {
-			// Closing: the binding state no longer matters, and an aborted
-			// transaction must not count as a bind failure.
+	if c.isClosed() {
+		if err != nil {
 			return err
 		}
 
+		return c.closedErr()
+	}
+	if err != nil {
 		return c.resolveBindError(bound, token, class, err)
 	}
 

--- a/internal/client/udp_conn_test.go
+++ b/internal/client/udp_conn_test.go
@@ -115,7 +115,8 @@ func TestUDPConnHandleChannelDataDeliversAssignedUnpreparedBinding(t *testing.T)
 	payload[0] = 'x'
 
 	assert.True(t, handled)
-	assert.False(t, bound.prepared.Load(), "inbound ChannelData must not require a prepared binding")
+	assert.ErrorIs(t, bound.writeAccess(time.Now()), ErrNotPrepared,
+		"inbound ChannelData must not establish prepared write access")
 	buf := make([]byte, len(payload))
 	n, from, err := conn.ReadFrom(buf)
 	require.NoError(t, err)
@@ -393,61 +394,60 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 	}
 
 	t.Run("maybeBind()", func(t *testing.T) {
-		tests := []struct {
-			name          string
-			initialState  bindingState
-			interimState  bindingState
-			finalState    bindingState
-			pastInterval  bool
-			shouldSucceed bool
-		}{
-			{"idle -> request -> ready", bindingStateIdle, bindingStateRequest, bindingStateReady, false, true},
-			{"idle -> request -> failed", bindingStateIdle, bindingStateRequest, bindingStateFailed, false, false},
-			{"unknown -> request -> ready", bindingStateUnknown, bindingStateRequest, bindingStateReady, false, true},
-			{"ready unknown -> refresh -> ready", bindingStateReadyUnknown, bindingStateRefresh, bindingStateReady, false, true},
-			{"ready (stale) -> refresh -> ready", bindingStateReady, bindingStateRefresh, bindingStateReady, true, true},
-			{"ready (stale) -> refresh -> failed", bindingStateReady, bindingStateRefresh, bindingStateFailed, true, false},
+		t.Run("fresh success becomes preparable", func(t *testing.T) {
+			bm := newBindingManager()
+			bound := requireBinding(t, bm, netip.MustParseAddrPort("127.0.0.1:1234"))
+			conn := makeConn(&mockClient{
+				performTransaction: func(*stun.Message, bool) (TransactionResult, error) {
+					return TransactionResult{Msg: new(stun.Message)}, nil
+				},
+			}, bm)
 
-			// Noop cases:
-			{"ready (noop)", bindingStateReady, bindingStateReady, bindingStateReady, false, true},
-			{"request (noop)", bindingStateRequest, bindingStateRequest, bindingStateRequest, false, true},
-			{"refresh (noop)", bindingStateRefresh, bindingStateRefresh, bindingStateRefresh, false, true},
-			{"failed (noop)", bindingStateFailed, bindingStateFailed, bindingStateFailed, false, true},
-		}
+			conn.maybeBind(bound)
+			assert.Eventually(t, func() bool {
+				bound.muBind.Lock()
+				defer bound.muBind.Unlock()
 
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				unblock := make(chan struct{})
+				return bound.attempt == nil
+			}, 5*time.Second, 10*time.Millisecond)
+			final, err := bound.preparationAccess(time.Now())
+			assert.True(t, final)
+			assert.NoError(t, err)
+		})
 
-				bm := newBindingManager()
-				bound := requireBinding(t, bm, netip.MustParseAddrPort("127.0.0.1:1234"))
-				conn := makeConn(&mockClient{
-					performTransaction: func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
-						<-unblock
-						if tt.shouldSucceed {
-							return TransactionResult{Msg: new(stun.Message)}, nil
-						}
+		t.Run("recent confirmation does not refresh", func(t *testing.T) {
+			bm := newBindingManager()
+			bound := requireBinding(t, bm, netip.MustParseAddrPort("127.0.0.1:1234"))
+			confirmBindingAt(t, bound, time.Now())
+			var attempts atomic.Int32
+			conn := makeConn(&mockClient{
+				performTransaction: func(*stun.Message, bool) (TransactionResult, error) {
+					attempts.Add(1)
 
-						return TransactionResult{Msg: staleNonceMsg()}, nil
-					},
-				}, bm)
+					return TransactionResult{Msg: new(stun.Message)}, nil
+				},
+			}, bm)
 
-				bound.setState(tt.initialState)
-				if tt.pastInterval {
-					bound.setRefreshedAt(time.Now().Add(-(defaultBindingRefreshInterval + 1*time.Minute)))
-				}
+			conn.maybeBind(bound)
+			assert.Equal(t, int32(0), attempts.Load())
+		})
 
-				conn.maybeBind(bound)
-				assert.Equal(t, tt.interimState, bound.state())
+		t.Run("stale confirmation refreshes", func(t *testing.T) {
+			bm := newBindingManager()
+			bound := requireBinding(t, bm, netip.MustParseAddrPort("127.0.0.1:1234"))
+			confirmBindingAt(t, bound, time.Now().Add(-defaultBindingRefreshInterval-time.Minute))
+			var attempts atomic.Int32
+			conn := makeConn(&mockClient{
+				performTransaction: func(*stun.Message, bool) (TransactionResult, error) {
+					attempts.Add(1)
 
-				// Release barrier so inner bind() can move forward.
-				close(unblock)
+					return TransactionResult{Msg: new(stun.Message)}, nil
+				},
+			}, bm)
 
-				assert.Eventually(t, func() bool {
-					return bound.state() == tt.finalState
-				}, 5*time.Second, 10*time.Millisecond)
-			})
-		}
+			conn.maybeBind(bound)
+			assert.Eventually(t, func() bool { return attempts.Load() == 1 }, 5*time.Second, 10*time.Millisecond)
+		})
 	})
 
 	t.Run("bind()", func(t *testing.T) {
@@ -582,10 +582,14 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 			},
 		}, bm)
 
-		err := conn.bindChannel(bound, bindingStateIdle)
+		token, class, started := bound.beginAttempt(time.Now(), defaultBindingRefreshInterval)
+		require.True(t, started)
+		err := conn.bindChannel(bound, token, class)
 		assert.ErrorIs(t, err, errTryAgain)
 		assert.Equal(t, int32(maxRetryAttempts), attempts.Load())
-		assert.Equal(t, bindingStateFailed, bound.state())
+		final, readinessErr := bound.preparationAccess(time.Now())
+		assert.True(t, final)
+		assert.ErrorIs(t, readinessErr, errTryAgain)
 		var turnErr *stun.TurnError
 		assert.False(t, errors.As(err, &turnErr), "438 retry exhaustion must not become a typed TURN error")
 	})
@@ -608,12 +612,20 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 
 		conn.maybeBind(bound)
 		assert.Eventually(t, func() bool {
-			return bound.state() == bindingStateUnknown
+			bound.muBind.Lock()
+			defer bound.muBind.Unlock()
+
+			return bound.attempt == nil
 		}, 5*time.Second, 10*time.Millisecond)
+		final, err := bound.preparationAccess(time.Now())
+		assert.False(t, final)
+		assert.NoError(t, err)
 
 		conn.maybeBind(bound)
 		assert.Eventually(t, func() bool {
-			return bound.state() == bindingStateReady
+			final, err = bound.preparationAccess(time.Now())
+
+			return final && err == nil
 		}, 5*time.Second, 10*time.Millisecond)
 
 		b2, ok := bm.findByAddr(bound.addr)
@@ -675,7 +687,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		conn.maybeBind(bound)
 
 		assert.Eventually(t, func() bool {
-			return bound.state() == bindingStateFailed && conn.isClosed()
+			return conn.isClosed()
 		}, 5*time.Second, 10*time.Millisecond)
 
 		select {
@@ -757,12 +769,15 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 
 		conn.maybeBind(bound)
 		assert.Eventually(t, func() bool {
-			return bound.state() == bindingStateUnknown
+			bound.muBind.Lock()
+			defer bound.muBind.Unlock()
+
+			return bound.attempt == nil
 		}, 5*time.Second, 10*time.Millisecond)
 
 		conn.maybeBind(bound)
 		assert.Eventually(t, func() bool {
-			return bound.state() == bindingStateFailed && conn.isClosed()
+			return conn.isClosed()
 		}, 5*time.Second, 10*time.Millisecond)
 		assert.Equal(t, int32(2), channelBindAttempts.Load())
 
@@ -815,19 +830,29 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 
 		bound := requireBinding(t, conn.bindingMgr, peerAddr)
 		staleRefreshedAt := time.Now().Add(-(defaultBindingRefreshInterval + time.Minute))
-		bound.setState(bindingStateReady)
-		bound.setRefreshedAt(staleRefreshedAt)
+		confirmBindingAt(t, bound, staleRefreshedAt)
 
 		conn.maybeBind(bound)
 		assert.Eventually(t, func() bool {
-			return bound.state() == bindingStateReadyUnknown
+			bound.muBind.Lock()
+			defer bound.muBind.Unlock()
+
+			return bound.attempt == nil
 		}, 5*time.Second, 10*time.Millisecond)
+		final, err := bound.preparationAccess(time.Now())
+		require.True(t, final)
+		require.NoError(t, err)
 
 		conn.maybeBind(bound)
 		assert.Eventually(t, func() bool {
-			return channelBindAttempts.Load() == 2 && bound.state() == bindingStateReady
+			bound.muBind.Lock()
+			defer bound.muBind.Unlock()
+
+			return channelBindAttempts.Load() == 2 && bound.attempt == nil
 		}, 5*time.Second, 10*time.Millisecond)
-		assert.True(t, bound.refreshedAt().Equal(staleRefreshedAt))
+		_, err = bound.preparationAccess(staleRefreshedAt.Add(channelBindingLifetime))
+		assert.ErrorIs(t, err, ErrChannelBindingExpired,
+			"recovered 400 must not advance confirmation time")
 		assert.False(t, conn.isClosed())
 	})
 
@@ -836,8 +861,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		bound := requireBinding(t, bm, netip.MustParseAddrPort("127.0.0.1:1234"))
 		staleRefreshedAt := time.Now().Add(-(defaultBindingRefreshInterval + time.Minute))
 		var channelBindAttempts atomic.Int32
-		bound.setState(bindingStateReady)
-		bound.setRefreshedAt(staleRefreshedAt)
+		confirmBindingAt(t, bound, staleRefreshedAt)
 		conn := makeConn(&mockClient{
 			performTransaction: func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
 				channelBindAttempts.Add(1)
@@ -848,13 +872,13 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 
 		conn.maybeBind(bound)
 		assert.Eventually(t, func() bool {
-			return channelBindAttempts.Load() == 1 && bound.state() == bindingStateReady
+			bound.muBind.Lock()
+			defer bound.muBind.Unlock()
+
+			return channelBindAttempts.Load() == 1 && bound.attempt == nil
 		}, 5*time.Second, 10*time.Millisecond)
-		assert.True(t, bound.refreshedAt().Equal(staleRefreshedAt))
-		startState, ok := conn.startBinding(bound)
-		assert.True(t, ok, "recovered binding should remain eligible for refresh")
-		assert.Equal(t, bindingStateReady, startState)
-		assert.Equal(t, bindingStateRefresh, bound.state())
+		conn.maybeBind(bound)
+		assert.Eventually(t, func() bool { return channelBindAttempts.Load() == 2 }, 5*time.Second, 10*time.Millisecond)
 		assert.False(t, conn.isClosed())
 	})
 
@@ -877,9 +901,10 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 
 		bm := newBindingManager()
 		binding := requireBinding(t, bm, addr)
-		binding.setState(bindingStateReady)
-		binding.setRefreshedAt(time.Now())
-		binding.prepared.Store(true)
+		confirmBindingAt(t, binding, time.Now())
+		final, err := binding.preparationAccess(time.Now())
+		require.True(t, final)
+		require.NoError(t, err)
 
 		conn := UDPConn{
 			permMap:    pm,

--- a/internal/client/udp_conn_test.go
+++ b/internal/client/udp_conn_test.go
@@ -5,6 +5,7 @@ package client
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/netip"
@@ -585,7 +586,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		token, class, started := bound.beginAttempt(time.Now(), defaultBindingRefreshInterval)
 		require.True(t, started)
 		err := conn.bindChannel(bound, token, class)
-		assert.ErrorIs(t, err, errTryAgain)
+		assert.NoError(t, err, "the permanent exhausted-retry cause lives only in readiness")
 		assert.Equal(t, int32(maxRetryAttempts), attempts.Load())
 		final, readinessErr := bound.preparationAccess(time.Now())
 		assert.True(t, final)
@@ -958,6 +959,71 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		b2, ok := bm.findByAddr(addr)
 		assert.True(t, ok)
 		assert.Equal(t, originalCh, b2.number)
+	})
+}
+
+func TestUDPConnBindingCompletionOrdersWithClose(t *testing.T) {
+	t0 := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+	bound := &binding{}
+	token, _, started := bound.beginAttempt(t0, defaultBindingRefreshInterval)
+	require.True(t, started)
+	conn := &UDPConn{closeCh: make(chan struct{})}
+	sealCause := errors.New("self-seal won") //nolint:err113 // Test-local cause.
+
+	conn.closeMutex.Lock()
+	result := make(chan struct {
+		applied bool
+		err     error
+	}, 1)
+	go func() {
+		applied, err := conn.completeBindingAttempt(bound, token, bindingAttemptConfirmed, nil, t0)
+		result <- struct {
+			applied bool
+			err     error
+		}{applied: applied, err: err}
+	}()
+	conn.terminalCause = sealCause
+	close(conn.closeCh)
+	conn.closeMutex.Unlock()
+
+	got := <-result
+	assert.False(t, got.applied)
+	assert.ErrorIs(t, got.err, net.ErrClosed)
+	assert.ErrorIs(t, got.err, sealCause)
+	final, err := bound.preparationAccess(t0)
+	assert.False(t, final, "close-winning completion must not create readiness")
+	assert.NoError(t, err)
+}
+
+func TestUDPConnBindingAttemptResultOwnership(t *testing.T) {
+	t0 := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+
+	t.Run("permanent cause lives only in readiness", func(t *testing.T) {
+		bound := &binding{}
+		token, class, started := bound.beginAttempt(t0, defaultBindingRefreshInterval)
+		require.True(t, started)
+		conn := &UDPConn{closeCh: make(chan struct{})}
+		cause := fmt.Errorf("permanent: %w", errCannotBindChannel)
+
+		attemptResult := conn.resolveBindError(bound, token, class, cause)
+		assert.NoError(t, attemptResult, "attempt coordination must not duplicate a durable cause")
+		final, readinessErr := bound.preparationAccess(t0)
+		assert.True(t, final)
+		assert.ErrorIs(t, readinessErr, cause)
+	})
+
+	t.Run("uncertainty remains attempt-local", func(t *testing.T) {
+		bound := &binding{}
+		token, class, started := bound.beginAttempt(t0, defaultBindingRefreshInterval)
+		require.True(t, started)
+		conn := &UDPConn{closeCh: make(chan struct{})}
+		cause := fmt.Errorf("%w: %w", errChannelBindTransactionFailed, errFake)
+
+		attemptResult := conn.resolveBindError(bound, token, class, cause)
+		assert.ErrorIs(t, attemptResult, cause)
+		final, readinessErr := bound.preparationAccess(t0)
+		assert.False(t, final)
+		assert.NoError(t, readinessErr, "transient attempt results must not become durable readiness causes")
 	})
 }
 


### PR DESCRIPTION
Closes #70

Parent: #67

Normative plan: `docs/adr/2026-08-19-channel-binding-readiness-plan.md`
Plan commit: `f722466a1864b1ca89e9e364daa962a7c1c5ba23`
Slice: `Slice T3.S1 — Make binding readiness the transition owner`
Dispatch: `$implement-architecture-slice`

This PR makes binding-local readiness the sole owner of readiness transitions, confirmation/prepared history, durable terminal causes, expiry, and generation-token validity while retaining TURN policy, attempt coordination, workers, Permission orchestration, and Allocation lifecycle on `UDPConn`.

Validation before draft:
- `go test ./...`
- `go test -race ./...`
- `task check`
- Terminal-collapse guard mutation: focused non-resurrection test failed under the mutation and passed after restoration.