### PR TITLE
Validate permission refresh interval

### DIFF
--- a/client.go
+++ b/client.go
@@ -45,7 +45,10 @@ type ClientConfig struct {
 	RTO      time.Duration
 	Conn     net.PacketConn // Caller-owned socket; the caller runs the read pump.
 
-	// PermissionTimeout sets the refresh interval of permissions. Defaults to 2 minutes.
+	// PermissionRefreshInterval sets the refresh cadence for permissions. Zero
+	// selects the two-minute default. Explicit values must be positive and
+	// strictly less than five minutes; other values are rejected by NewClient.
+	// Accepted values do not guarantee refresh before expiry under operational delay.
 	PermissionRefreshInterval time.Duration
 
 	bindingRefreshInterval time.Duration
@@ -137,6 +140,9 @@ func NewClient(config *ClientConfig) (*Client, error) {
 	server, ok := canonicalAddrPort(config.Server, canonicalStrict)
 	if !ok {
 		return nil, errInvalidServer
+	}
+	if config.PermissionRefreshInterval < 0 || config.PermissionRefreshInterval >= 5*time.Minute {
+		return nil, errInvalidPermissionRefreshInterval
 	}
 
 	rto := defaultRTO

--- a/client_test.go
+++ b/client_test.go
@@ -53,6 +53,76 @@ func TestNewClientRejectsNonCanonicalServer(t *testing.T) {
 	c.Close()
 }
 
+func TestNewClientValidatesPermissionRefreshInterval(t *testing.T) {
+	conn, err := net.ListenPacket("udp4", "127.0.0.1:0") // nolint: noctx
+	require.NoError(t, err)
+	defer conn.Close() //nolint:errcheck
+
+	server := netip.MustParseAddrPort("192.0.2.1:3478")
+
+	tests := []struct {
+		name     string
+		conn     net.PacketConn
+		server   netip.AddrPort
+		interval time.Duration
+		wantErr  error
+		wantText string
+	}{
+		{
+			name: "negative",
+			conn: conn, server: server, interval: -time.Nanosecond,
+			wantText: "turn: PermissionRefreshInterval must be zero or a positive duration less than 5 minutes",
+		},
+		{name: "zero", conn: conn, server: server},
+		{name: "small positive", conn: conn, server: server, interval: time.Nanosecond},
+		{name: "immediately below five minutes", conn: conn, server: server, interval: 5*time.Minute - 1},
+		{
+			name: "exactly five minutes",
+			conn: conn, server: server, interval: 5 * time.Minute,
+			wantText: "turn: PermissionRefreshInterval must be zero or a positive duration less than 5 minutes",
+		},
+		{
+			name: "above five minutes",
+			conn: conn, server: server, interval: 5*time.Minute + 1,
+			wantText: "turn: PermissionRefreshInterval must be zero or a positive duration less than 5 minutes",
+		},
+		{
+			name:   "nil connection takes precedence over invalid interval",
+			server: server, interval: -time.Nanosecond, wantErr: errNilConn,
+		},
+		{
+			name: "invalid server takes precedence over invalid interval",
+			conn: conn, interval: -time.Nanosecond, wantErr: errInvalidServer,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, newErr := NewClient(&ClientConfig{
+				Conn:                      tt.conn,
+				Server:                    tt.server,
+				PermissionRefreshInterval: tt.interval,
+			})
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, newErr, tt.wantErr)
+				assert.Nil(t, client)
+
+				return
+			}
+			if tt.wantText != "" {
+				assert.EqualError(t, newErr, tt.wantText)
+				assert.Nil(t, client)
+
+				return
+			}
+
+			require.NoError(t, newErr)
+			require.NotNil(t, client)
+			client.Close()
+		})
+	}
+}
+
 // TestHandleInboundAdmitsOnlyServer proves the server-source admission owned by
 // HandleInbound: a datagram whose canonical source is not the configured
 // Server is ignored with a nil error and zero delivery, while a datagram from

--- a/docs/adr/2026-08-19-allocation-construction-timing-validity-plan.md
+++ b/docs/adr/2026-08-19-allocation-construction-timing-validity-plan.md
@@ -1,13 +1,13 @@
 # Allocation Construction Timing Validity Implementation Plan
 
 **Date:** 2026-08-19
-**Status:** Audited; ready for one implementation slice after issue publication
+**Status:** Implemented by PR #81
 **Track:** 4 of 4 in the 2026-08-19 architecture deepening program
 **Depends on:** Track 1 complete via PR #72; no remaining implementation blocker
 **Related:** [Program index](2026-08-19-architecture-deepening-program.md), [Server-bound transport plan](2026-08-19-server-bound-transport-plan.md), [Allocation lifecycle plan](2026-08-17-allocation-lifecycle-plan.md), [RFC 8656 Section 9](https://www.rfc-editor.org/rfc/rfc8656.html#section-9)
-**Parent issue:** pending
+**Parent issue:** #79
 **Normative scope:** Current outcome, boundaries, invariants, acceptance evidence, blockers, and stop conditions
-**Audit history:** Independently audited against `e57b9061efa66b979bc616834b3803cc932ecbdf` on 2026-08-19; T4.S1 passed after its configuration-only guarantee, split artifact classes, constructor-error precedence, immutable consumer receipt, slice debate, evidence budget, and non-goals were closed
+**Audit history:** Independently audited against `e57b9061efa66b979bc616834b3803cc932ecbdf` on 2026-08-19; T4.S1 passed after its configuration-only guarantee, split artifact classes, constructor-error precedence, immutable consumer receipt, slice debate, evidence budget, and non-goals were closed; implementation completed by PR #81
 
 ## Goal
 
@@ -45,7 +45,7 @@ The five-minute limit is the nominal protocol lifetime boundary, not a promise t
 
 | Slice | Status/disposition | Delivers | Blocked by | Removes temporary seam |
 |---|---|---|---|---|
-| T4.S1 | Frontier after issue publication | Public Client construction rejects permission-refresh cadences outside zero or the strict `(0, 5m)` interval | None; Track 1 checkpoint is complete | None introduced |
+| T4.S1 | Complete via PR #81 | Public Client construction rejects permission-refresh cadences outside zero or the strict `(0, 5m)` interval | None; Track 1 checkpoint is complete | None introduced |
 
 ## Implementation Slices
 
@@ -53,7 +53,7 @@ The five-minute limit is the nominal protocol lifetime boundary, not a promise t
 
 **What it delivers:** One PR that adds the public construction guard in `NewClient`, corrects and completes the `ClientConfig.PermissionRefreshInterval` documentation, and adds deterministic table-driven construction evidence for every semantic duration class while preserving all accepted values.
 
-**Implementation:** New slice. No open implementation issue, PR, or implementation branch is an accepted baseline; this issue and its implementation PR are pending publication. The local `codex/timing-validity-handoff` branch contains planning docs only and is not implementation work.
+**Implementation:** PR #81 is the slice's one intended product PR; unmentioned historical branches were not used as an implementation baseline.
 
 **Existing-work disposition:** New work opened by the post-Track-1 evidence gate. Tracks 1–3 remain complete and are not rebaselined. The post-Track-3 attempt-coalescing checkpoint closes without code because the current Permission and binding policies still require distinct deletion, transition, worker, and lifecycle ownership.
 
@@ -85,11 +85,11 @@ The five-minute limit is the nominal protocol lifetime boundary, not a promise t
 
 ## Acceptance Criteria
 
-- [ ] `NewClient` accepts exactly zero and positive `PermissionRefreshInterval` values strictly below five minutes, and rejects negative, exactly-five-minute, and above-five-minute values before constructing a Client.
-- [ ] Zero still selects the existing two-minute default in Allocation construction; accepted positive values remain unchanged, including the repository's 50-millisecond end-to-end cadence.
-- [ ] The public field comment names `PermissionRefreshInterval` and documents the zero default, strict upper bound, and rejection behavior without promising success under arbitrary operational delay.
-- [ ] No exported error, duplicate internal validation, silent clamp/default, timer rewrite, constructor abstraction, broad timing policy, wire change, worker change, or Allocation lifecycle change is introduced.
-- [ ] The finite duration and constructor-precedence table, static single-owner flow, ordinary suite, race suite, preflight, bounded review, and same-head hosted CI satisfy the declared terminating evidence plan without claiming refresh liveness or bounded cost for accepted explicit positives.
+- [x] `NewClient` accepts exactly zero and positive `PermissionRefreshInterval` values strictly below five minutes, and rejects negative, exactly-five-minute, and above-five-minute values before constructing a Client.
+- [x] Zero still selects the existing two-minute default in Allocation construction; accepted positive values remain unchanged, including the repository's 50-millisecond end-to-end cadence.
+- [x] The public field comment names `PermissionRefreshInterval` and documents the zero default, strict upper bound, and rejection behavior without promising success under arbitrary operational delay.
+- [x] No exported error, duplicate internal validation, silent clamp/default, timer rewrite, constructor abstraction, broad timing policy, wire change, worker change, or Allocation lifecycle change is introduced.
+- [x] The finite duration and constructor-precedence table, static single-owner flow, ordinary suite, race suite, preflight, bounded review, and same-head hosted CI satisfy the declared terminating evidence plan without claiming refresh liveness or bounded cost for accepted explicit positives.
 
 ## Validation Gates
 

--- a/docs/adr/2026-08-19-architecture-deepening-program.md
+++ b/docs/adr/2026-08-19-architecture-deepening-program.md
@@ -1,6 +1,6 @@
 # TURN Architecture Deepening Program — 2026-08-19
 
-**Status:** Active; Tracks 1, 2, and 3 complete, Track 4 has one audited frontier slice
+**Status:** Complete; Tracks 1–4 complete
 
 ## What this is
 
@@ -21,11 +21,11 @@ This program packages the 2026-08-19 architecture review and delegated grill of 
 | 1 | Server-bound outbound transport | [plan](2026-08-19-server-bound-transport-plan.md) | #65 | None | 1 | Complete via PR #72 |
 | 2 | Inbound Allocation delivery | [plan](2026-08-19-inbound-allocation-delivery-plan.md) | #66 | None | 1 | Complete via PR #74 |
 | 3 | Channel-binding readiness | [plan](2026-08-19-channel-binding-readiness-plan.md) | #67 | None | 1 | Complete via PR #76 |
-| 4 | Allocation construction timing validity | [plan](2026-08-19-allocation-construction-timing-validity-plan.md) | pending | None | 1 | T4.S1 frontier after issue publication |
+| 4 | Allocation construction timing validity | [plan](2026-08-19-allocation-construction-timing-validity-plan.md) | #79 | None | 1 | Complete via PR #81 |
 
-There are no genuine slice-level blocking edges. Tracks 1–3 are complete. Track 4 depended only on the completed Track 1 construction checkpoint and now has the sole frontier slice; its public configuration guard is independent of the completed inbound-delivery and binding-readiness seams.
+There are no genuine slice-level blocking edges. Tracks 1–4 are complete, and no implementation frontier remains.
 
-The required post-track checkpoints are closed. Allocation construction still admitted a reachable invalid public cadence after Track 1, producing Track 4's focused T4.S1. Attempt coalescing still lacked a policy-free single owner after Track 3 and closes without implementation.
+The required post-track checkpoints are closed. Track 4's focused T4.S1 closes the reachable invalid public cadence that remained after Track 1. Attempt coalescing still lacked a policy-free single owner after Track 3 and closes without implementation.
 
 ## Rules that bind every track
 

--- a/errors.go
+++ b/errors.go
@@ -62,6 +62,8 @@ var (
 	errNilConn       = errors.New("turn: conn cannot not be nil")
 	errInvalidServer = errors.New(
 		"turn: Server must be a canonical netip.AddrPort (unicast, unmapped, zone-free, nonzero port)")
+	errInvalidPermissionRefreshInterval = errors.New(
+		"turn: PermissionRefreshInterval must be zero or a positive duration less than 5 minutes")
 	errNilContext                   = errors.New("turn: context must not be nil")
 	errChannelBindNotFound          = errors.New("no binding found for channel")
 	errOneAllocateOnly              = errors.New("only one Allocate() caller is allowed")


### PR DESCRIPTION
Implements #79
Closes #80

Plan commit: `b9d8890e5c003e15b56f75c84ffb8f197ebc9a62`
Plan slice: `docs/adr/2026-08-19-allocation-construction-timing-validity-plan.md` — `Slice T4.S1 — Reject out-of-domain permission-refresh cadences at Client construction`

## Summary

- reject negative and at/above-five-minute permission refresh cadences in `NewClient`
- preserve zero-as-default and all positive cadences below five minutes
- correct the public field documentation
- add the accepted eight-row duration and constructor-precedence table

## Representation and evidence

Supported input is every Go `time.Duration` supplied through `ClientConfig.PermissionRefreshInterval`. `NewClient` owns universal classification of the finite predicate `d == 0 || (d > 0 && d < 5*time.Minute)`; `NewUDPConn` retains ownership of applying the accepted zero sentinel. Contract closure is not triggered.

Local evidence so far:

- focused eight-row constructor table
- existing 50 ms end-to-end cadence
- `go test ./...`
- `go test -race ./...`

The PR remains draft through bounded review and exact-head local certification.
