### PR TITLE
docs: package the 2026-08-19 seam deepening program

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,59 @@
+# TURN client
+
+This context describes the language of GridSwarm's owned UDP TURN client library: the relay state a TURN server holds on the client's behalf, and the client-side facts the library keeps about that state. It is a glossary only; decisions live in `docs/adr/`.
+
+## Language
+
+### Server-side relay state
+
+**Allocation**:
+The relay state associated with one client-server five-tuple. It owns a relay transport address and the permissions and channel bindings created beneath it.
+_Avoid_: Session
+
+**Five-tuple**:
+The client transport address, server transport address, and transport protocol that together identify an allocation.
+_Avoid_: Connection ID
+
+**Relay transport address**:
+The server transport address allocated for communication between a client and its peers.
+_Avoid_: Relay address when the transport distinction matters
+
+**Permission**:
+An allocation-scoped authorization to communicate with a peer IP address, independent of the peer port.
+_Avoid_: Peer connection
+
+**Channel binding**:
+An allocation-scoped association between one channel number and one peer transport address. A channel binding also creates or refreshes the required permission.
+_Avoid_: Permission
+
+### Messages
+
+**Inbound TURN message**:
+A complete message received from the TURN server, represented as either a STUN-formatted message or ChannelData.
+_Avoid_: Request, packet
+
+**TURN request**:
+A STUN-formatted request asking a TURN server to perform a TURN method. Indications and ChannelData are not TURN requests.
+_Avoid_: Inbound TURN message when the distinction matters
+
+### Client-side facts
+
+**Prepared peer**:
+A peer for which the client's allocation holds a confirmed permission and channel binding, so that every later write to it is ChannelData or fails for the allocation's lifetime.
+_Avoid_: Bound peer, ready peer
+
+**Terminal cause**:
+The first error that sealed an allocation, whether the caller closed it or the allocation sealed itself; every later operation reports it.
+_Avoid_: Close reason
+
+**Attempt**:
+One in-flight CreatePermission exchange for a permission (per peer IP) or ChannelBind exchange for a channel binding (per peer transport address), shared by every concurrent PreparePeer caller for it until it resolves.
+_Avoid_: Request (that is the TURN message), retry
+
+**Readiness**:
+The client's own record of whether a permission or channel binding can be relied on for a peer; channel-binding readiness is a time-based state, permission readiness is the outcome of its attempt.
+_Avoid_: Status, state
+
+**Release**:
+The lifetime-zero Refresh that ends an allocation on the server; emitted exactly once per allocation.
+_Avoid_: Teardown

--- a/docs/adr/2026-08-19-allocate-admission-errors-plan.md
+++ b/docs/adr/2026-08-19-allocate-admission-errors-plan.md
@@ -1,0 +1,141 @@
+# Allocate Admission and Public Error Vocabulary Implementation Plan
+
+**Date:** 2026-08-19
+**Status:** Accepted; not yet implemented
+**Track:** 2 of 4 in the 2026-08-19 seam deepening program
+**Depends on:** Nothing — parallel-safe; T1.S1 is recommended first to reduce test churn but is not a blocker
+**Related:** [Program index](2026-08-19-seam-deepening-program.md), [Allocation lifecycle plan](2026-08-17-allocation-lifecycle-plan.md), [Modernize kept API plan](2026-08-15-modernize-kept-api-plan.md), [Allocation construction timing validity plan](2026-08-19-allocation-construction-timing-validity-plan.md)
+**Normative scope:** Current outcome, boundaries, invariants, acceptance evidence, blockers, and stop conditions
+**Audit history:** Self-grilled and independently slice-audited against `dad68d4868efc8b041114f7a4efdeaa3b229edfb` on 2026-08-19 (see the program index for the audit receipt)
+
+## Goal
+
+Give "at most one live or in-flight Allocation per Client" one guard and one public error, make the relayed address cross the Client→`UDPConn` seam in its canonical spelling or not at all, and make the public error vocabulary have one owner for identity, prose, and prefix. Root `Client` gets deeper (the admission rule is one place, tested through the public interface); `UDPConn` loses an unvalidated address and an unused callback parameter; callers learn one error set.
+
+## Current Shape (verified 2026-08-19 at `dad68d4868efc8b041114f7a4efdeaa3b229edfb`)
+
+`Client.Allocate` enforces the single-allocation invariant twice: `allocTryLock.Lock()` (`client.go:295-298`) returns `errOneAllocateOnly` wrapping the unexported internal `errDoubleLock` for a concurrent in-flight Allocate, then `relayedUDPConn() != nil` (`client.go:300-303`) returns exported `ErrAlreadyAllocated` formatted with `relayedConn.LocalAddr().String()`. Which error a caller sees depends on the race; neither `errOneAllocateOnly` nor `errDoubleLock` is matchable by a caller; both branches are uncovered. `TryLock` (`internal/client/trylock.go`, 28 lines, plus `trylock_test.go`, 66 lines) wraps one compare-and-swap and has exactly one caller.
+
+The server-reported relayed address crosses the seam three ways: `proto.RelayedAddress` from the response (`client.go:305`), an unvalidated `*net.UDPAddr` placed in `AllocationConfig.RelayedAddr` and stored as `UDPConn.relayedAddr` (`client.go:310-319`, `internal/client/udp_conn.go:63`), and the canonical `netip.AddrPort` computed afterwards (`client.go:331`) that `Allocation.RelayedAddr()` returns. The middle form has two consumers: `onDeallocated(c.relayedAddr)` (`internal/client/udp_conn.go:514`), whose root receiver ignores its parameter (`client.go:364`), and `UDPConn.LocalAddr()` (`internal/client/udp_conn.go:548`), whose only caller formats the `ErrAlreadyAllocated` message. `setRelayedUDPConn(relayedConn)` publishes the pointer to the inbound path (`client.go:329`) before `canonicalWireAddr` validates the address (`client.go:331`), so a datagram in that window is enqueued into a conn the caller will never receive.
+
+Error vocabulary is split across the seam: `errNilContext` exists in both packages with different text (`errors.go:67`, `internal/client/errors.go:51`); `Client.Allocate` checks nil ctx with root's (`client.go:289-291`), `UDPConn.PreparePeer` with internal's (`internal/client/udp_conn.go:202-204`), and root `Allocation.PreparePeer` does not check (`allocation.go:39-46`), so the internal sentinel escapes the public interface. `errFake` is a test-only sentinel in the production vocabulary (`internal/client/errors.go:39`). The six re-exported sentinels carry duplicated doc comments that have diverged (`errors.go:20-45` versus `internal/client/errors.go:14-36`). `errChannelBindNotFound`, `errFailedToDecodeSTUN`, `errUnexpectedSTUNRequestMessage`, and `errOneAllocateOnly` lack the `turn:` prefix every other root sentinel carries (`errors.go:68-72`), and all reach callers.
+
+## Decision
+
+**One admission rule.** `Client` keeps an `allocating` flag under its existing mutex. `Allocate` performs one guarded check-and-claim: if a live Allocation is published or another Allocate is in flight, return `ErrAlreadyAllocated`; otherwise claim. The claim is released in the same critical section that publishes the new `UDPConn`, or on any failure path. `TryLock`, `trylock_test.go`, `errOneAllocateOnly`, and `errDoubleLock` are deleted. `ErrAlreadyAllocated`'s message no longer embeds the relayed address (identity unchanged; callers match with `errors.Is`).
+
+**One relayed-address spelling.** `AllocationConfig.RelayedAddr`, `UDPConn.relayedAddr`, and `UDPConn.LocalAddr()` are deleted; `OnDeallocated` becomes `func()`. The canonical `netip.AddrPort` computed at Allocate remains the only spelling and continues to live on root `Allocation`. The construct-then-close rule for an invalid relayed address is preserved and tightened: Allocate constructs the `UDPConn`, validates, and on failure closes the unpublished conn (the lifetime-zero release is still emitted; Refresh carries no relayed address; STUN responses route through the registry, not the published pointer); on success it publishes the pointer and releases the claim in one critical section. A datagram arriving before publication is discarded exactly as when no Allocation is live.
+
+**One error vocabulary owner.** Root owns public error identity, prose, and the `turn:` prefix; `internal/client` owns only the identities it raises and re-exports. The nil-context programmer error is checked once, at the public ingress: `Allocation.PreparePeer` gains the check with root's `errNilContext`, performed first — mirroring `Allocate` — so the (nil context, invalid peer) double programmer error now returns `errNilContext` rather than `ErrInvalidPeer` (accepted); `UDPConn.PreparePeer` drops its check and `internal/client` drops its `errNilContext` (the same single-ingress reasoning T4.S1 applied to cadence validation). `errFake` moves to a test file. Internal sentinel doc comments become one-line pointers to the root prose. The unprefixed sentinels *defined in root `errors.go`* gain the `turn:` prefix (text change, identity unchanged); the six sentinels re-exported from `internal/client` keep their internal message text (non-goal: their text is an identity owned internally, root owns only their prose). Sentinels stay unexported where they are unexported today; no public error is added.
+
+**Rejected alternative (do not do this):** Keep two guards "for defense in depth." Two guards with two errors is the defect; one claim under one lock covers in-flight and live.
+
+**Rejected alternative (do not do this):** Replace `TryLock` with `sync.Mutex.TryLock` and keep the second guard. That preserves two error modes.
+
+**Rejected alternative (do not do this):** Keep `RelayedAddr` on `AllocationConfig` as `netip.AddrPort` "for symmetry." No `UDPConn` behavior reads it; carrying an unused fact across the seam is the leakage being removed. If a future consumer needs it, it is a one-field addition with a reader.
+
+**Rejected alternative (do not do this):** Export `ErrNilContext` or make nil context panic. Programmer-error sentinels stay unexported; panicking is a behavior change no consumer asked for.
+
+**Rejected alternative (do not do this):** Keep the internal nil-ctx check "as defense." T4.S1 established that duplicate enforcement at one public ingress splits ownership; the internal method is reached only through root and internal tests.
+
+**Non-goals:** No change to Client close semantics (abort-current, non-terminal), Allocation lifecycle ownership, release emission, wire bytes, public API shape beyond error text, `HandleInbound`'s error contract, or `turntest`. No new exported error. No validation in `NewUDPConn`. No change to the message text of the six re-exported sentinels.
+
+## Slice Graph
+
+| Slice | Status/disposition | Delivers | Blocked by | Removes temporary seam |
+|---|---|---|---|---|
+| T2.S1 | New | One admission rule and error for the single live Allocation; relayed address crosses the seam only as canonical `netip.AddrPort`; `TryLock`, `LocalAddr`, `RelayedAddr`, `OnDeallocated` parameter gone; publish-after-validate | None | Second guard; unvalidated relayed-address spelling |
+| T2.S2 | New | One owner for public error identity, prose, and prefix; nil-context checked once at the public ingress; `errFake` out of production vocabulary | None | Duplicate `errNilContext`; diverged prose |
+
+## Implementation Slices
+
+### Slice T2.S1 — One admission rule for the single live Allocation
+
+**What it delivers:** One PR replacing `TryLock` + pointer check with one guarded claim returning `ErrAlreadyAllocated` for in-flight and live cases, deleting `TryLock`/`trylock_test.go`/`errOneAllocateOnly`/`errDoubleLock`, deleting `AllocationConfig.RelayedAddr`/`UDPConn.relayedAddr`/`UDPConn.LocalAddr`, changing `OnDeallocated` to `func()`, publishing the Allocation only after canonical validation, and adding public-interface admission tests.
+
+**Existing-work disposition:** New slice.
+
+**Blocked by:** None. T1.S1 first is recommended (its helper is where `RelayedAddr` would otherwise be deleted from ten literals) but the slice is independently implementable.
+
+**Single owner after merge:** Root `Client.Allocate`, under the Client mutex, is the only owner of the in-flight claim and of publishing/clearing the live Allocation pointer (clearing via `onDeallocated`, which `UDPConn.startCloseLocked` invokes exactly as today). Root `Allocation` is the only holder of the relayed address. `UDPConn` owns no address.
+
+**Authority completeness:** No persisted fact. The claim is constructed, released on every failure path (context cancellation, Allocate transaction failure, invalid relayed address after the doomed conn's Close, Client close during Allocate), and consumed by the only destructive consumer (a second Allocate) within the slice.
+
+**Transitional-seam budget:** None at merge. No second guard, no `LocalAddr`, no address parameter on `OnDeallocated`, no `RelayedAddr` field may remain.
+
+**Blast radius:** `client.go:58-79,285-366`, `internal/client/allocation.go:19-35`, `internal/client/udp_conn.go:56-63,95-110,514,548`, `internal/client/trylock*.go`, `errors.go`, `internal/client/errors.go`, and every test that sets `RelayedAddr` or `OnDeallocated`. Concurrency: one new boolean under the existing Client mutex; no lock held across I/O (the claim is taken, the mutex released, the Allocate transaction performed, the mutex retaken to publish/clear). Ordering: construct → validate → (invalid: Close unpublished conn; valid: publish and release claim). Interfaces: `ErrAlreadyAllocated` text changes (identity unchanged); `AllocationConfig` loses a field and a callback parameter (internal). Failure modes: an invalid relayed address still emits exactly one lifetime-zero release; `HandleInbound` during the doomed conn's Close discards (no live Allocation) instead of enqueuing into an unreceivable conn; Client close during Allocate still wins with the closed error and releases the claim. Performance/security/dependencies: none. Untraced effects are not accepted: any path that leaves the claim held, any second release, or any HandleInbound delivery to an unpublished conn stops the slice.
+
+**Artifact classification:** The admission guard, publish-after-validate, and the seam narrowing are shipped behavior and required lifecycle enforcement. The admission tests are verification aids. Plans/issues are process metadata.
+
+**Representation contract:** Supported domain = the finite set of Allocate admission paths on one Client: first Allocate; concurrent second Allocate while the first is in flight; Allocate while an Allocation is live; Allocate after the live Allocation closed (caller Close and self-seal); Allocate that fails before construction; Allocate with an invalid relayed address; Client close during Allocate. Representation owner = `Client.Allocate` under the Client mutex. Guarantee = universal over that finite set. Terminating evidence = the matrix below, `go test -race ./...`, `task preflight`, hosted CI, one review plus at most one replacement.
+
+**Contract closure:** Triggered — a second live Allocation or an unreleased claim is a broken lifecycle obligation (server resource or a permanently un-Allocatable Client), and admission is reached through independent paths (concurrent callers, live pointer, invalid-address close, Client close) that one focused test cannot cover.
+
+| Semantic class | Expected disposition | Enforcement owner | Evidence | Guard mutation when required | Status |
+|---|---|---|---|---|---|
+| First Allocate on an idle Client | Claim, allocate, publish, release claim | `Client.Allocate` | Existing Allocate tests | n/a | Covered |
+| Second Allocate while the first is in flight | `ErrAlreadyAllocated`, no network output | `Client.Allocate` | Deterministic concurrent test (observer conn gates the first request) | Delete the in-flight branch and observe the test fail | Covered |
+| Allocate while an Allocation is live | `ErrAlreadyAllocated`, no network output | `Client.Allocate` | Focused public test | Covered by the same mutation | Covered |
+| Allocate after caller `Close` of the live Allocation | Succeeds (claim and pointer were cleared) | `Client.Allocate` + `onDeallocated` | Sequential re-Allocate test | n/a | Covered |
+| Allocate after the live Allocation self-sealed | Succeeds | `Client.Allocate` + `onDeallocated` | By composition: the internal refresh-failure suite proves self-seal invokes `onDeallocated` (`udp_conn.go:514`, the same call caller Close makes), and the root re-Allocate-after-Close test proves Allocate succeeds after `onDeallocated`; no root self-seal timing cell | n/a | Covered |
+| Allocate fails before construction (transaction error, cancellation) | Claim released; a later Allocate succeeds | `Client.Allocate` | Existing cancellation tests plus one re-Allocate assertion | n/a | Covered |
+| Invalid relayed address | Construct, do not publish, Close (one lifetime-zero release), `ErrInvalidRelayedAddress`, claim released; inbound during that window discards | `Client.Allocate` | Existing `TestAllocateRejectsInvalidRelayedAddress` extended with no-publication assertion | n/a | Covered |
+| Client `Close` during Allocate | Closed error wins; claim released; Client remains usable for a later Allocate | `Client.Allocate` + registry abort | Existing close-versus-cancel test plus one re-Allocate assertion | n/a | Covered |
+
+**Evidence budget:** The matrix rows are the complete budget: one deterministic concurrent-Allocate test, one live-Allocation rejection, two re-Allocate-after-end cases, one claim-release-after-failure assertion, one invalid-relayed no-publication assertion, one close-during-Allocate re-Allocate assertion; existing Allocate/lifecycle/refresh-failure suites; `go test -race ./...`. One guard mutation: delete the in-flight branch of the claim and observe the concurrent test fail. Negative evidence: no `TryLock`, `errOneAllocateOnly`, `errDoubleLock`, `LocalAddr`, or `RelayedAddr` symbol. No repetition counts, platforms, or timing cells.
+
+**TDD and preservation evidence:** Write the concurrent-Allocate and live-rejection tests first against the public interface (both branches are uncovered today); then replace the guards; then write the no-publication assertion and move publication after validation; then delete the seam fields and parameter; then delete `TryLock`. Preservation gates: `TestAllocateRejectsInvalidRelayedAddress` (one release), `TestAllocateCancelVsClientClose`, Allocation lifecycle tests, `HandleInbound` discard-without-live-Allocation tests.
+
+**Dispatch context budget:** This slice contract; `client.go:58-79,285-366`; `internal/client/allocation.go:16-35`; `internal/client/udp_conn.go:55-110,486-530,548-550`; `internal/client/trylock.go`; `errors.go`; `allocate_ctx_test.go`, `allocation_test.go:194-229`; the Allocation lifecycle plan. Fits one fresh context: one guard, one ordering move, three deletions, bounded tests.
+
+**Slice decision audit:** Strongest further split = admission rule in one PR, relayed-address seam narrowing in another. Rejected: the error message is the only consumer of `LocalAddr`, and the publish-after-validate move is part of the same admission ordering; splitting leaves `LocalAddr` alive for one PR solely to format a string. Strongest merge = fold T2.S2. Rejected: T2.S2 touches `PreparePeer` and public error text with no admission semantics; separate PRs keep each preservation argument narrow. No blocking edge is needed.
+
+**Stop conditions:** The Client mutex must be held across the Allocate transaction or any I/O (the claim itself is held across the transaction by design; the lock is not); the construct-then-close release cannot be preserved without publishing; a path is found where the claim is not released; `UDPConn` turns out to read the relayed address; or Client close semantics would need to change.
+
+### Slice T2.S2 — One owner for the public error vocabulary
+
+**What it delivers:** One PR adding the nil-context check to `Allocation.PreparePeer` with root's sentinel, removing the internal check and sentinel, moving `errFake` to a test file, reducing internal sentinel comments to pointers at the root prose, and adding the `turn:` prefix to the remaining unprefixed root sentinels.
+
+**Existing-work disposition:** New slice.
+
+**Blocked by:** None. T2.S1 first is recommended (it deletes `errOneAllocateOnly`, one of the unprefixed sentinels) but not required: if T2.S2 lands first it prefixes a sentinel T2.S1 later deletes.
+
+**Single owner after merge:** Root `errors.go` owns public error prose and prefix; root public entry points own programmer-error checks; `internal/client/errors.go` owns only identities.
+
+**Authority completeness:** No persisted fact. Both public nil-context ingresses (`Allocate`, `Allocation.PreparePeer`) are covered; the internal method's only callers are root and internal tests, which pass real contexts.
+
+**Transitional-seam budget:** None at merge. No second `errNilContext`, no `errFake` in production code, no duplicated prose.
+
+**Blast radius:** `errors.go`, `internal/client/errors.go`, `allocation.go:39-46`, `internal/client/udp_conn.go:202-204`, tests that reference the internal sentinel or `errFake`. Interfaces: error text of the root-defined unprefixed sentinels gains a prefix (identity unchanged; the sole consumer matches by identity per the README's typed-values statement); the six re-exported sentinels keep their text. Behavior: `Allocation.PreparePeer(nil, …)` returns root's sentinel instead of internal's; `UDPConn.PreparePeer(nil, …)` is no longer defended (internal, unreachable from the public surface). No concurrency, wire, performance, or dependency effect. Untraced effects are not accepted: any consumer found matching on error text stops the slice.
+
+**Artifact classification:** Public error text and the nil-context check are shipped behavior. Prose and comments are process/traceability metadata. Tests are verification aids.
+
+**Representation contract:** Supported domain = the sentinels defined in root `errors.go` (not the six re-exports) and the two public nil-context ingresses. Owner = root `errors.go` and the two public methods. Guarantee = universal over that finite set. Terminating evidence = one nil-context test per public ingress, a grep that every root-defined sentinel carries the prefix, `go test ./...`, `task preflight`, hosted CI, one review.
+
+**Contract closure:** Not triggered — text and a single programmer-error check; focused tests suffice.
+
+**Evidence budget:** Two focused tests (nil ctx to `Allocate` and to `Allocation.PreparePeer` return root's sentinel); existing suites green; negative grep for internal `errNilContext` and production `errFake`. No mutation, platforms, or repetitions.
+
+**TDD and preservation evidence:** Write the `Allocation.PreparePeer` nil-context test first; add the check; remove the internal check/sentinel; move `errFake`; edit prose and prefixes. Preservation: every `errors.Is` assertion in the suites is unchanged.
+
+**Dispatch context budget:** This slice contract; `errors.go`; `internal/client/errors.go`; `allocation.go`; `internal/client/udp_conn.go:201-205`; the README's typed-values statement. Fits trivially in one context.
+
+**Slice decision audit:** Strongest split = none sensible. Strongest merge = into T2.S1; rejected above. No blocking edge.
+
+**Stop conditions:** A consumer is found to depend on error text; or the nil-context decision would need a new exported error or a panic.
+
+## Acceptance Criteria
+
+- [ ] A concurrent second Allocate, or an Allocate while an Allocation is live, returns `ErrAlreadyAllocated` with zero network output, and an Allocate after the live Allocation ends (caller Close or self-seal) succeeds. Domain: the T2.S1 matrix; owner: `Client.Allocate`; guarantee: universal over that finite set; evidence: the matrix plus one guard mutation.
+- [ ] `TryLock`, `errOneAllocateOnly`, `errDoubleLock`, `UDPConn.LocalAddr`, `AllocationConfig.RelayedAddr`, and the `OnDeallocated` address parameter do not exist; the relayed address lives only on root `Allocation` as canonical `netip.AddrPort`.
+- [ ] An invalid relayed address still yields exactly one lifetime-zero release and `ErrInvalidRelayedAddress`, and the doomed Allocation is never published to the inbound path.
+- [ ] `Allocate(nil, …)` and `Allocation.PreparePeer(nil, …)` return root's `errNilContext` (checked first); no internal `errNilContext` or production `errFake` exists; every sentinel defined in root `errors.go` has a message starting with `turn:` (the six re-exports keep their text); sentinel identities are unchanged. Domain: root-defined sentinels and the two public ingresses; owner: root `errors.go`; guarantee: universal over that finite set; evidence: two ingress tests and one grep.
+- [ ] Client close semantics, Allocation lifecycle ownership, wire bytes, and public API shape (beyond error text) are unchanged.
+
+## Validation Gates
+
+Per slice: the focused tests in its evidence budget, `go test ./...`, `go test -race ./...`, and `task preflight`; draft through review and certification, ready, post-ready `ci-required` success on the exact head, squash merge.
+
+## Operating Discipline
+
+Follow the shared review-loop and contract-closure baselines supplied by `$implement-architecture-slice`; this repository has no overlay. Keep admission on `Client.Allocate`, the relayed address on root `Allocation`, lifecycle on `UDPConn`, and error prose at root. Stop rather than holding the Client mutex across I/O, adding an exported error, or changing Client close semantics.

--- a/docs/adr/2026-08-19-allocate-exchange-plan.md
+++ b/docs/adr/2026-08-19-allocate-exchange-plan.md
@@ -1,0 +1,94 @@
+# Allocate Exchange Implementation Plan
+
+**Date:** 2026-08-19
+**Status:** Accepted; not yet implemented
+**Track:** 4 of 4 in the 2026-08-19 seam deepening program
+**Depends on:** Nothing — parallel-safe with every other track (root-only)
+**Related:** [Program index](2026-08-19-seam-deepening-program.md), [Modernize kept API plan](2026-08-15-modernize-kept-api-plan.md), [Server-bound transport plan](2026-08-19-server-bound-transport-plan.md), [Allocation construction timing validity plan](2026-08-19-allocation-construction-timing-validity-plan.md), behaviour decision [#83](https://github.com/the-sarge/turn/issues/83)
+**Normative scope:** Current outcome, boundaries, invariants, acceptance evidence, blockers, and stop conditions
+**Audit history:** Self-grilled and independently slice-audited against `dad68d4868efc8b041114f7a4efdeaa3b229edfb` on 2026-08-19 (see the program index for the audit receipt)
+
+## Goal
+
+Make the Allocate exchange one module: it builds both Allocate requests from one setter list, derives the long-term credentials from the 401 challenge, and returns everything the Allocation needs as one value — so `Client` stops carrying credentials as mutable fields that a reader must know to read back, the emitted bytes are asserted at the wire instead of through three single-caller helpers, and the request construction cannot drift between the anonymous and authenticated forms. Emitted bytes and setter order are pinned, not changed; the protocol-ordering fact the wire test reveals is a separate behaviour decision (#83).
+
+## Current Shape (verified 2026-08-19 at `dad68d4868efc8b041114f7a4efdeaa3b229edfb`)
+
+Address-family selection is three single-caller pure functions — `inferAddressFamilyFromConn`, `getRequestedAddressFamily`, `appendRequestedAddressFamily` (`client.go:84-130`) — tested in isolation (`client_test.go:519-592`; the first two with real `udp4`/`udp6` listeners, the third by building messages without a socket). The inference fallback arm (`client.go:96-97,111`) is uncovered. Nothing asserts the attribute on an emitted datagram.
+
+`sendAllocateRequest` (`client.go:181-273`) writes the Allocate setter list twice: anonymous `[TransactionID, Type, RequestedTransport, (family), Fingerprint]` (`client.go:187-196`) and authenticated `[TransactionID, Type, RequestedTransport, Username, Realm, Nonce, Integrity, (family), Fingerprint]` (`client.go:222-235`). In the authenticated list `REQUESTED-ADDRESS-FAMILY` follows `MESSAGE-INTEGRITY`; pion/stun computes the integrity HMAC over the message up to the attribute preceding MESSAGE-INTEGRITY, and RFC 8489 §14.5 requires servers to ignore attributes after it other than FINGERPRINT. That ordering is inherited from upstream, unobserved by any test (`turntest` never reads the attribute), and is the subject of #83. The latent inference behaviour — `a.IP.To4() != nil` classifies a wildcard `::` socket as IPv6 — is likewise unobserved.
+
+Credentials are a hidden output: `sendAllocateRequest` returns `nonce` but writes `c.realm` and `c.integrity` onto `Client` fields documented `// Read-only` (`client.go:66-67,217-220`), which `Allocate` then reads back into `AllocationConfig` (`client.go:320-323`). No reuse across Allocations exists: a second Allocate after Close starts anonymous and re-derives them.
+
+`observerConn` already records exact outbound datagrams and scripts the 401 challenge (`allocate_ctx_test.go:30-110,153-199`); its `LocalAddr()` is hard-coded to `127.0.0.1:5555` (`allocate_ctx_test.go:94-96`). Production requests use `stun.TransactionID` (random), and MESSAGE-INTEGRITY and FINGERPRINT cover the header, so recorded bytes cannot be replayed literally; the repository's existing technique is txid-normalized equality — build the expected message from an explicit setter list with `stun.NewTransactionIDSetter(actual.TransactionID)` and compare `Raw` (`internal/client/udp_conn_test.go:194-213`).
+
+## Decision
+
+`sendAllocateRequest` becomes the Allocate exchange: it builds the anonymous request, performs the cancelable transaction, reads the 401 challenge's realm and nonce, derives the long-term integrity, builds the authenticated request, performs it, and returns one unexported value — relayed address, lifetime, realm, nonce, integrity — or an error. Both requests come from one setter builder that emits exactly today's order for each form, including today's placement of `REQUESTED-ADDRESS-FAMILY` (after `MESSAGE-INTEGRITY` in the authenticated form, before `FINGERPRINT` in both) and `FINGERPRINT` last. `Client` drops the mutable `realm` and `integrity` fields; `username` stays (config-derived, read-only). `Allocate` copies the returned credentials into the existing `AllocationConfig` fields — no `AllocationConfig` change. Address-family inference collapses to one unexported function computed once in `NewClient`, with behaviour unchanged (including the `::` classification).
+
+The wire is the test surface: a characterization table over recorded datagrams — socket family {IPv4, IPv6, non-`*net.UDPAddr` local address fallback} × request form {anonymous, authenticated} — asserts attribute presence/absence and position, `FINGERPRINT` last, and byte-identity after normalizing to the observed transaction ID: for each cell the test builds the expected message from an explicit, hard-coded setter list with `stun.NewTransactionIDSetter(actual.TransactionID)` and the scripted realm/nonce, and compares `Raw`; MESSAGE-INTEGRITY and FINGERPRINT then match iff order and values match. `observerConn` gains a settable local address (no other knob) to drive the IPv6 and fallback cells. The three helper tests are deleted. The slice does not move the attribute; if #83 decides to move it, that is a one-line change to the builder and an intentional update of the pinned bytes in its own PR.
+
+**Rejected alternative (do not do this):** Fix the post-integrity placement inside this slice because the test makes it visible. Every program rule pins emitted bytes and setter order; moving the attribute is a wire change that needs #83's decision and its own PR.
+
+**Rejected alternative (do not do this):** Keep `realm`/`integrity` on `Client` "for reuse." No reuse exists; the fields are carriers between two lines of one method.
+
+**Rejected alternative (do not do this):** Generalize into an authenticated-exchange module shared with Refresh/CreatePermission/ChannelBind. Closed by the 08-17 program; this stays inside Allocate.
+
+**Rejected alternative (do not do this):** Change the `::` inference, default family, or RFC 6156 semantics. Reported, not changed.
+
+**Non-goals:** No wire-byte or setter-order change; no `AllocationConfig` change; no change to the 401 flow, nonce handling, cancellation semantics, or `performAllocateTransaction`; no `turntest` change; no IPv6 relay behaviour change.
+
+## Slice Graph
+
+| Slice | Status/disposition | Delivers | Blocked by | Removes temporary seam |
+|---|---|---|---|---|
+| T4.S1 | New | One Allocate exchange returning one value; one setter builder; credentials off `Client`; wire-asserted characterization table replacing three helper tests | None | Duplicate setter lists; hidden credential output |
+
+## Implementation Slices
+
+### Slice T4.S1 — One Allocate exchange, wire-pinned
+
+**What it delivers:** One PR pinning the current anonymous and authenticated Allocate shape for each socket-family class as txid-normalized characterization tests, then refactoring `sendAllocateRequest` to one setter builder and one returned value, deleting `Client.realm`/`Client.integrity` and the three family helpers (inlined to one function), and deleting the three helper tests.
+
+**Existing-work disposition:** New slice.
+
+**Blocked by:** None.
+
+**Single owner after merge:** The Allocate exchange is the only builder of Allocate requests and the only deriver of long-term credentials; `NewClient` is the only place address family is inferred; `Allocate` is the only consumer of the returned value and the one production assembler of `AllocationConfig`.
+
+**Authority completeness:** No persisted fact. Both request forms, all three socket-family classes, the 401 challenge, and the single consumer are covered.
+
+**Transitional-seam budget:** None at merge. No second setter list, no mutable credential field on `Client`, no family helper beyond the one function.
+
+**Blast radius:** `client.go:58-130,181-273,310-328`; `client_test.go:519-589` (deleted) and `allocate_ctx_test.go` (extended). Wire: bytes and order identical — pinned by txid-normalized equality tests written against the current code before the refactor. Concurrency: none (Allocate is serialized by admission; the returned value removes writes to `Client` fields during Allocate). Interfaces: no public change. Failure modes: every existing attribute-missing arm of the response parse is preserved. Performance/security/dependencies: none. Untraced effects are not accepted: any byte difference in any of the six cells stops the slice.
+
+**Artifact classification:** The exchange and builder are shipped behavior. The characterization table is a verification aid; it is not a maintained product deliverable beyond this repository's ordinary test suite. #83 is process metadata.
+
+**Representation contract:** Supported domain = the two Allocate request forms × three socket-family classes (IPv4 UDP, IPv6 UDP, non-`*net.UDPAddr` local address) with the observed transaction ID and scripted credentials. Representation owner = the exchange's setter builder; pion/stun owns STUN encoding. Guarantee = universal over those six cells (byte-identical), example-level for server responses (the scripted 401 and success). Terminating evidence = the six txid-normalized cells, the existing Allocate/cancellation suites, `go test -race ./...`, `task preflight`, hosted CI, one review plus at most one replacement.
+
+**Contract closure:** Not triggered — the invariant (byte-identical requests) has one owner and a finite six-cell domain that the focused table covers directly.
+
+**Evidence budget:** Six txid-normalized byte-equality cells (expected setter lists written against the current code before the refactor, scripted realm/nonce); attribute-position assertions (`REQUESTED-ADDRESS-FAMILY` absent for IPv4 and fallback, present for IPv6 at today's position; `FINGERPRINT` last); one test that the returned value carries realm, nonce, and the derived integrity for a scripted 401; existing `TestAllocateTargetsConfiguredServer`, cancellation, and `turntest` E2E suites; `go test -race ./...`. No guard mutation (no enforcement guard). Negative evidence: no `Client.realm`/`Client.integrity` field; no `inferAddressFamilyFromConn`/`getRequestedAddressFamily`/`appendRequestedAddressFamily` symbol. No new platforms, repetitions, or timing.
+
+**TDD and preservation evidence:** Write the six txid-normalized cells and the position assertions first against the current code (they must pass before any refactor), extending `observerConn` with a settable local address; then introduce the builder and the returned value; then delete the helpers, fields, and helper tests. Preservation: the six cells are the gate.
+
+**Dispatch context budget:** This slice contract; `client.go:58-130,181-273,285-331`; `allocate_ctx_test.go:30-251` (extend `observerConn` with a settable `LocalAddr`, no other knob; reuse `assertRequestShape`'s technique from `internal/client/udp_conn_test.go:194-213`); `client_test.go:519-592`; #83 for context only. Root-only; no `internal/client` change; `sendAllocateRequest` overlaps T1.S2's `trRes.Msg` edits (rebase). Fits one fresh context.
+
+**Slice decision audit:** Strongest further split = land the characterization tests first as their own PR. Rejected: a test-only PR that pins bytes nobody is changing has no independent payoff; the tests are the first commit of this PR. Strongest merge = fold #83's fix in. Rejected: wire change needs its own decision. No blocking edge.
+
+**Stop conditions:** Any of the six cells differs after the refactor; the builder cannot reproduce both orders from one list without a flag that itself needs documenting (then keep two explicit lists inside the builder and stop widening); or a consumer of `Client.realm`/`integrity` outside Allocate appears.
+
+## Acceptance Criteria
+
+- [ ] Anonymous and authenticated Allocate requests are byte-identical, after transaction-ID normalization, to the pre-change shape for IPv4, IPv6, and fallback sockets; `REQUESTED-ADDRESS-FAMILY` is present only for IPv6 at today's position and `FINGERPRINT` is last. Domain: the six cells; owner: the exchange's builder; guarantee: universal over the six cells; evidence: the txid-normalized equality table.
+- [ ] `sendAllocateRequest` returns relayed address, lifetime, realm, nonce, and integrity as one value; `Client` has no `realm`/`integrity` field; `AllocationConfig` is unchanged.
+- [ ] One unexported family-inference function computed once in `NewClient`; the three helpers and their tests are gone; inference behaviour is unchanged.
+- [ ] #83 remains open and the attribute placement is unchanged by this slice.
+
+## Validation Gates
+
+The txid-normalized/position table, the returned-value test, existing Allocate and `turntest` suites, `go test ./...`, `go test -race ./...`, `task preflight`; draft through review and certification, ready, post-ready `ci-required` success on the exact head, squash merge.
+
+## Operating Discipline
+
+Follow the shared review-loop and contract-closure baselines supplied by `$implement-architecture-slice`; this repository has no overlay. Bytes are pinned; #83 owns any change to them. Stop rather than generalizing beyond Allocate.

--- a/docs/adr/2026-08-19-permission-owns-its-attempt.md
+++ b/docs/adr/2026-08-19-permission-owns-its-attempt.md
@@ -1,0 +1,14 @@
+# Permission owns its attempt; channel binding does not
+
+Channel-binding readiness is a time-based, multi-state machine (idle, request, unknown, ready, refresh, failed, with confirmation age, prepared history, and expiry), so the 2026-08-19 readiness track kept its durable readiness in `binding` and its attempt coordination — the in-flight attempt handle and its lock — on `UDPConn`. Permission has no durable machine to separate: its readiness *is* the outcome of one CreatePermission attempt (idle → attempting → permitted, or failed and removed). We decided (2026-08-19 seam deepening program, Track 3) that `permission` owns its attempt lifecycle and permitted fact behind intent-level operations with one private lock, while `UDPConn` keeps worker registration, the transaction and retry, seal precedence, map deletion, and refresh disposition. The resulting asymmetry between the two readiness modules is deliberate.
+
+## Considered options
+
+- Mirror binding's split for permission (durable readiness in `permission`, attempt handle on `UDPConn`): leaves a one-bit bag and keeps the attempt protocol in the caller — the shallow shape being removed.
+- Relocate binding's attempt handle and lock to match permission (into `binding`, or into a `UDPConn`-side map): a relocation with no demonstrated cost and no deletion-test signal; the readiness plan placed it deliberately. Rejected; do not re-suggest without a concrete lock-ownership defect.
+- One shared attempt helper or handle for both: closed without code by the 2026-08-19 program (attempt coalescing) because the two paths differ in map deletion, eligibility, transitions, worker rollback, and disposition.
+
+## Consequences
+
+- A reader will find the attempt handle on `permission` and on `UDPConn` for binding; this ADR is the reason.
+- Neither module may grow a shared attempt abstraction. If permission ever needs expiry or refresh eligibility of its own, revisit this decision rather than bolting a second machine onto the attempt.

--- a/docs/adr/2026-08-19-permission-readiness-plan.md
+++ b/docs/adr/2026-08-19-permission-readiness-plan.md
@@ -1,0 +1,105 @@
+# Permission Readiness Implementation Plan
+
+**Date:** 2026-08-19
+**Status:** Accepted; not yet implemented
+**Track:** 3 of 4 in the 2026-08-19 seam deepening program
+**Depends on:** Nothing — parallel-safe; T1.S1 first is recommended to avoid `prepare_test.go` conflicts but is not a blocker
+**Related:** [Program index](2026-08-19-seam-deepening-program.md), [Channel-binding readiness plan](2026-08-19-channel-binding-readiness-plan.md), [Prepared-only writes ADR](2026-08-15-prepared-only-writes.md), [Permission owns its attempt ADR](2026-08-19-permission-owns-its-attempt.md), [Allocation lifecycle plan](2026-08-17-allocation-lifecycle-plan.md)
+**Normative scope:** Current outcome, boundaries, invariants, acceptance evidence, blockers, and stop conditions
+**Audit history:** Self-grilled and independently slice-audited against `dad68d4868efc8b041114f7a4efdeaa3b229edfb` on 2026-08-19 (see the program index for the audit receipt)
+
+## Goal
+
+Make `permission` own its own readiness — the begin/join/resolve lifecycle of its CreatePermission attempt and the permitted fact that results — behind intent-level operations with one private lock never held across I/O, so `UDPConn` asks whether a peer is permitted and joins or starts an attempt instead of driving three sync primitives and raw fields declared in another file. `UDPConn` keeps worker registration, the CreatePermission transaction and stale-nonce retry, seal precedence, map deletion on failure, and refresh disposition. This is the last raw-accessor module in `internal/client`; it is deliberately *not* given channel binding's durable/attempt split because permission has no durable machine to separate (see the ADR).
+
+## Current Shape (verified 2026-08-19 at `dad68d4868efc8b041114f7a4efdeaa3b229edfb`)
+
+`permission` exposes two raw accessors `state()`/`setState()` over a two-value atomic enum, two raw fields `attemptDone`/`attemptErr`, and three locks — `mutex`, `attemptMutex`, and `permissionMap.mutex` (`internal/client/permission.go:13-39`). Every transition is driven from `UDPConn`: `createPermission` holds `perm.mutex` across the whole CreatePermission transaction (`internal/client/udp_conn.go:178-193`), yet its only caller is the single in-flight attempt worker that `ensurePermissionAttempt` guarantees (`internal/client/udp_conn.go:269-306`), so that lock is vestigial; `awaitPermission` polls `state()` and reads `attemptErr` under the permission's `attemptMutex` (`internal/client/udp_conn.go:233-264`); `ensurePermissionAttempt` creates, publishes, and clears `attemptDone`/`attemptErr` from the worker goroutine (`internal/client/udp_conn.go:269-306`). `createPermission` deletes the map entry on *every* non-nil CreatePermission result, including a stale-nonce 438 that the retry loop then retries (`udp_conn.go:184-185`), so a 438-then-success sequence today leaves a permitted permission outside `permMap` (unrefreshed, and re-created by the next PreparePeer); this is unobserved by any test. `permissionMap.insert` and `find` have no production caller (`internal/client/permission.go:49-56,75-81`; test callers at `prepare_test.go:172,206,237`, `udp_conn_test.go:899,925`, `permission_test.go`), and the `pm.insert(addr, &permission{st: permStatePermitted})` setup at `udp_conn_test.go:899-925` is dead: `WriteTo` never reads `permMap`.
+
+The verified permission lifecycle is: idle (in map, no attempt) → attempting (`attemptDone != nil`) → permitted (permanent for the object) | failed (first attempt failed: `attemptErr` set, entry deleted from `permMap`; the next `PreparePeer` creates a fresh permission). Permission refresh failure never changes permission state — it terminalizes prepared bindings via `failPreparedBindings` (`internal/client/allocation.go:142-155`, `udp_conn.go:406-411`). `permissionMap.addrs()` returns every map entry, permitted or still attempting (`permission.go:89-99`). There is no per-permission expiry. A waiter that joins an attempt after the Allocation seals receives the recorded terminal cause (seal precedence, `udp_conn.go:287-292`). Permission identity is per canonical peer IP (`permission.go:41-46`).
+
+Tests probe readiness by `permMap.find(peer).state() == permStatePermitted` (`prepare_test.go:172,206,237`); the seal-precedence test calls `ensurePermissionAttempt` and reads `perm.attemptMutex`/`attemptErr` directly (`prepare_test.go:610-640`); and `permission_test.go` (76 lines) tests the accessors and map CRUD rather than any transition.
+
+## Decision
+
+`permission` owns its readiness storage and attempt lifecycle behind three operations: `beginOrJoin()` returns the in-flight attempt's done signal and whether the caller started a fresh attempt (and must therefore run it and resolve it); `resolve(err)` applies one attempt result — nil marks permitted, non-nil records the failure — publishes it, closes the done signal, and clears the in-flight marker; `state()` reports permitted-or-not plus the last resolved failure. Exact private spellings may vary; there is no other mutation path, no raw accessor, no exported-to-package lock. One private lock guards all of it and is never held across a transaction, a worker registration, or a wait. The `permState` enum, the atomics, `perm.mutex`, `permissionMap.insert`, and `permissionMap.find` are deleted; `permissionMap` keeps `getOrCreate`, `delete`, and `addrs` and its per-IP key.
+
+`UDPConn.awaitPermission` becomes: loop { if permitted, return nil; `done, fresh := perm.beginOrJoin()`; if fresh { register a worker — if registration fails because the Allocation is closing, `perm.resolve(closedErr)` so joined waiters wake with the terminal cause — else start the worker }; select on done, ctx, closeCh; read `state()`: permitted → nil, failure → that error, neither → loop }. The worker runs the existing `maxRetryAttempts`/`errTryAgain` loop around the CreatePermission transaction with the existing seal-precedence check. On a final CreatePermission failure `UDPConn` deletes the map entry **before** calling `perm.resolve(err)`, preserving today's delete-before-wake order (`udp_conn.go:185` precedes `:298-302`) so that a caller arriving after the wake-up always gets a fresh permission from `getOrCreate`; the seal-precedence short-circuit and the registration-failure path resolve without deleting, as today. One accepted correction: the map entry is deleted only on the *final* failure, not on an intermediate 438 — a 438-then-success sequence leaves the permitted permission in the map (refreshed, and joined by later callers), where today it is orphaned. `createPermission` no longer takes any permission lock. Refresh membership (`permMap.addrs()` covering permitted-but-unbound peers), `refreshPermissions`, `failPreparedBindings`, retry count, stale-nonce retry, worker accounting, and waiter-local cancellation are unchanged.
+
+**Rejected alternative (do not do this):** Mirror channel binding's split — durable readiness in `permission`, attempt coordination in `UDPConn`. Permission's durable readiness is one bit; the split would leave a bool-bag and keep the attempt protocol in the caller. The ADR records why the asymmetry with binding is deliberate.
+
+**Rejected alternative (do not do this):** Share an attempt helper, handle type, or join loop between permission and binding. Attempt coalescing was closed without code in the 08-19 program because the two paths differ in map deletion, eligibility, transitions, worker rollback, and disposition; this slice must not reopen it.
+
+**Rejected alternative (do not do this):** Move worker registration, the CreatePermission transaction, retry, map deletion, or refresh disposition into `permission`. Those are `UDPConn` policy.
+
+**Rejected alternative (do not do this):** Add per-permission expiry, permission removal on refresh failure, or any change to refresh membership. Not observed behavior; not in scope.
+
+**Non-goals:** No change to permission identity, CreatePermission bytes, retry count, refresh cadence or membership rule (every map entry), prepared-binding terminalization on refresh failure, seal precedence, worker join, public API, channel binding, or `bindingAttempt`/`muBind` placement (the ADR closes that relocation). The only accepted behavior change is the 438 orphan correction named above.
+
+## Slice Graph
+
+| Slice | Status/disposition | Delivers | Blocked by | Removes temporary seam |
+|---|---|---|---|---|
+| T3.S1 | New | `permission` owns begin/join/resolve and the permitted fact behind three operations; `UDPConn` drives no permission lock or raw field; vestigial lock, enum, atomics, `insert`/`find` gone | None | Raw permission state protocol in `UDPConn` |
+
+## Implementation Slices
+
+### Slice T3.S1 — Permission owns its attempt and readiness
+
+**What it delivers:** One PR introducing the three permission operations, migrating `awaitPermission`/`ensurePermissionAttempt`/`createPermission` to them, deleting the raw accessors, enum, atomics, `perm.mutex`, `insert`, `find`, and the dead `pm.insert` test setup, and replacing accessor/CRUD tests with a table over begin/join/resolve plus preserved PreparePeer behavior.
+
+**Existing-work disposition:** New slice.
+
+**Blocked by:** None.
+
+**Single owner after merge:** `permission` is the only mutation owner of the permitted fact, the in-flight attempt marker, the done signal, and the last resolved failure. `UDPConn` is the only owner of worker registration, the CreatePermission transaction and retry, seal precedence, `permMap` deletion, and refresh disposition. `permissionMap` owns per-IP identity.
+
+**Authority completeness:** No persisted fact. The slice covers construction (`getOrCreate`), every producer (fresh attempt success, fresh attempt failure, worker-registration failure while closing, seal during attempt), every consumer (`awaitPermission` waiters, `refreshPermissions` membership), and deletion.
+
+**Transitional-seam budget:** None at merge. No raw accessor, second lock, or caller-side attempt bookkeeping may remain; no shared helper with binding may be introduced.
+
+**Blast radius:** `internal/client/permission.go`, `udp_conn.go:178-306`, `permission_test.go`, `prepare_test.go` readiness probes and the seal-precedence test (`:610-640`, rewritten against `beginOrJoin`/`state`), `udp_conn_test.go:895-930`. Accepted behavior change: a permission that succeeds after an intermediate 438 stays in `permMap` (refresh membership gains that entry; today it is orphaned). Concurrency: one private permission lock replaces three primitives; it is never held across I/O, registration, or waiting; no lock order with `closeMutex` or binding locks is introduced (worker registration and seal checks happen outside the permission lock, as today). Ordering: waiters joining an attempt after seal still observe the terminal cause; a fresh attempt that cannot register a worker resolves with the closed error so joined waiters wake. Failure modes: a finally failed fresh attempt still deletes the map entry before waking waiters; stale-nonce retry unchanged except that an intermediate 438 no longer deletes the entry. Interfaces: none public. Performance/security/dependencies: none. Untraced effects are not accepted: a lock held across the transaction, a waiter that can block forever, or a changed refresh membership stops the slice.
+
+**Artifact classification:** Permission readiness operations are shipped behavior and required lifecycle enforcement (waiter wake-up). The transition table and migrated tests are verification aids. Plans/issues are process metadata.
+
+**Representation contract:** Supported domain = one permission's finite lifecycle: idle; fresh attempt started; joined in-flight attempt; resolve success; resolve failure; resolve with closed error when the Allocation is closing; waiter cancellation; waiter observing seal; join after resolve. Owner = `permission` for state and attempt handle; `UDPConn` for policy. Guarantee = universal over that finite matrix, not over server behavior. Terminating evidence = the matrix below, preserved PreparePeer tables, `go test -race ./...`, `task preflight`, hosted CI, one review plus at most one replacement.
+
+**Contract closure:** Triggered — a waiter that never wakes or a permission marked permitted without a successful attempt is a broken lifecycle obligation, and the lifecycle is reached independently through fresh callers, joining callers, cancellation, worker-registration failure, and seal.
+
+| Semantic class | Expected disposition | Enforcement owner | Evidence | Guard mutation when required | Status |
+|---|---|---|---|---|---|
+| Idle permission, first caller | Fresh attempt; caller becomes the runner | `permission.beginOrJoin` | Table | n/a | Covered |
+| Second caller while attempt in flight | Joins the same done signal; does not start a second attempt; CreatePermission sent once | `permission.beginOrJoin` | Table plus existing shared-attempt PreparePeer test | n/a | Covered |
+| Resolve success | Permitted; done closed; later callers return without an attempt | `permission.resolve` | Table | Delete the permitted transition and observe the repeat-PreparePeer test fail | Covered |
+| Resolve failure (fresh attempt) | Failure recorded; done closed; waiters receive the error; `UDPConn` deletes the map entry; next caller gets a fresh permission | `permission.resolve` + `UDPConn` | Table plus existing permission-rejection PreparePeer test | n/a | Covered |
+| Worker registration fails (Allocation closing) | Resolve with the closed error; joined waiters wake with the terminal cause | `UDPConn` + `permission.resolve` | Controlled closing-before-registration case | n/a | Covered |
+| Seal during attempt | Runner observes seal precedence and resolves with the terminal cause; waiters wake; no map deletion | `UDPConn` worker + `permission.resolve` | Seal-precedence test rewritten against `beginOrJoin`/`state` | n/a | Covered |
+| Stale-nonce 438 then success | Permitted; map entry retained; CreatePermission sent twice | `UDPConn` worker + `permission.resolve` | Focused PreparePeer case (accepted correction) | n/a | Covered |
+| Waiter cancellation | Only that waiter returns `context.Cause`; attempt continues; a later caller joins or observes the result | `UDPConn.awaitPermission` | Existing waiter-local cancellation test | n/a | Covered |
+| Join after resolve | Observes state without waiting | `permission.state` | Table | n/a | Covered |
+| Refresh membership | Every map entry (permitted or attempting) is included in refresh exactly as today; refresh neither adds nor removes entries; finally failed entries leave via the worker's deletion | `permissionMap.addrs` (unchanged) | Existing refresh tests | n/a | Covered |
+
+**Evidence budget:** The matrix rows are the complete budget: a table over begin/join/resolve/state with no `UDPConn`; the existing shared-attempt, rejection, cancellation, and refresh PreparePeer tests retained with `permMap.find(...).state()` probes replaced by observed PreparePeer outcomes and permission-count assertions; the seal-precedence test rewritten against the new operations; one focused 438-then-success case; `go test -race ./...`. One guard mutation: bypass the permitted transition and observe a repeat PreparePeer start a second attempt. Negative evidence: no `permState`, `setState`, `state()` raw accessor, `perm.mutex`, `attemptMutex`, `insert`, or `find` symbol. No fake clock, repetition, platform, or fuzz scope.
+
+**TDD and preservation evidence:** Write the permission transition table first; introduce the three operations beside the raw fields; migrate `awaitPermission` and the worker; delete `perm.mutex` from `createPermission`; delete raw accessors, enum, `insert`/`find`, and the dead test setup last. Preserved gates: PreparePeer behavior tables, CreatePermission request-shape test, refresh-failure terminalization, close/join tests.
+
+**Dispatch context budget:** This slice contract; `internal/client/permission.go`; `internal/client/udp_conn.go:178-306,406-411`; `internal/client/allocation.go:102-112,142-155`; `permission_test.go`; the readiness probes in `prepare_test.go`; the channel-binding readiness plan (for the asymmetry reasoning) and the permission ADR. No binding, transaction, or root code. Fits one fresh context: one ~100-line module, three `UDPConn` methods, bounded tests.
+
+**Slice decision audit:** Strongest further split = introduce the operations first, delete raw access later. Rejected: leaves two mutation paths for one PR with no payoff. Strongest merge = relocate binding's attempt handle in the same PR for symmetry. Rejected by the ADR: different module, different ownership argument, and the program forbids a shared attempt helper. No blocking edge is needed.
+
+**Stop conditions:** The permission lock must be held across the transaction or a wait; a waiter can block with no resolve; the design wants a shared attempt helper or handle with binding; refresh membership or prepared-binding terminalization would change; or `UDPConn` still needs a raw accessor.
+
+## Acceptance Criteria
+
+- [ ] Every permission state and attempt transition in the supported finite domain has one owner in `permission`; `UDPConn` drives no permission lock or raw field. Domain: the matrix; owner: `permission`; guarantee: universal over the finite matrix; evidence: table, preserved PreparePeer tests, one guard mutation.
+- [ ] Concurrent PreparePeer callers for one peer IP share one CreatePermission attempt; a failed fresh attempt wakes waiters with its error and the next caller starts fresh; a closing Allocation wakes joined waiters with the terminal cause.
+- [ ] `permState`, `setState`, the raw `state()` accessor, `perm.mutex`, `attemptMutex`, `permissionMap.insert`, `permissionMap.find`, and the dead `pm.insert` test setup do not exist; no shared helper with channel binding exists.
+- [ ] Permission identity, CreatePermission bytes, retry count, refresh cadence and membership rule, prepared-binding terminalization, seal precedence, waiter-local cancellation, and public API are unchanged; the only behavior change is that a permission succeeding after an intermediate 438 remains in `permMap`.
+
+## Validation Gates
+
+The transition table, the preserved PreparePeer/refresh/close tests, `go test ./...`, `go test -race ./...`, `task preflight`; draft through review and certification, ready, post-ready `ci-required` success on the exact head, squash merge.
+
+## Operating Discipline
+
+Follow the shared review-loop and contract-closure baselines supplied by `$implement-architecture-slice`; this repository has no overlay. Keep readiness and the attempt handle on `permission`, policy and workers on `UDPConn`, identity on `permissionMap`. Stop rather than sharing anything with channel binding or holding a lock across I/O.

--- a/docs/adr/2026-08-19-seam-deepening-program.md
+++ b/docs/adr/2026-08-19-seam-deepening-program.md
@@ -1,0 +1,41 @@
+# TURN Seam Deepening Program — 2026-08-19
+
+**Status:** Accepted; tracks not yet implemented
+
+## What this is
+
+This program packages the third architecture review of `the-sarge/turn` (2026-08-19, after the completed [08-17](2026-08-17-architecture-deepening-program.md) and [08-19](2026-08-19-architecture-deepening-program.md) deepening programs) and its self-grilled design. Seven candidates were grilled; six survive as four tracks and six slices, one is closed without code. The four track plans are the normative source of truth for outcomes, boundaries, ownership, evidence, blockers, and stop conditions. GitHub issues and the OmniFocus mirror carry stable identities, current state, and pointers only. This program reopens no settled ownership decision of the earlier programs.
+
+Audit receipt: all six slices were independently slice-audited against `dad68d4868efc8b041114f7a4efdeaa3b229edfb` on 2026-08-19 before publication; the audit's accepted corrections are folded into the plans and are not repeated here.
+
+## Outcomes that require no implementation
+
+- Do not relocate the channel-binding attempt handle (`bindingAttempt`, `muBind`) either into `binding` or into a `UDPConn`-side structure. The 08-19 channel-binding readiness plan placed attempt coordination on `UDPConn` deliberately; no cost has been demonstrated; the relocation has no deletion-test signal. The asymmetry with permission (which owns its attempt in Track 3) is principled and recorded in the [permission owns its attempt ADR](2026-08-19-permission-owns-its-attempt.md).
+- Do not move `REQUESTED-ADDRESS-FAMILY` before `MESSAGE-INTEGRITY` inside any slice. The authenticated Allocate's post-integrity placement is a wire fact; Track 4 pins current bytes, and [#83](https://github.com/the-sarge/turn/issues/83) owns the behaviour decision.
+- Do not build a general scripted-responder harness, add queue-size/lock/timer/clock knobs to the test constructors, or introduce an options/builder layer for `UDPConn` (Track 1 ceilings). Do not pass the transaction registry into `UDPConn` in place of the two crossing closures.
+- Do not add a second admission guard, export a nil-context error, make nil context panic, or keep the relayed address on `AllocationConfig` "for symmetry" (Track 2 ceilings).
+- Do not share an attempt helper, handle, or join loop between permission and channel binding; attempt coalescing stays closed (Track 3 ceiling).
+- Do not generalize the Allocate exchange into a shared authenticated-exchange module, and do not change address-family inference semantics (Track 4 ceilings).
+- Observed and not proposed: 428 shipped lines in `internal/proto` with no shipped consumer, including `stun_conn.go`'s second copy of ChannelData framing (kept by the cut-and-stabilize plan: proto wholesale, fuzz targets, proto-only upstream watch); the channel-number range constants duplicated in `binding.go:16-20` and `proto/chann.go:56-57` with disagreeing comments; `ClientConfig`'s unexported test-only `bindingRefreshInterval`/`bindingCheckInterval`; `PeriodicTimer.IsRunning` with no production caller; the six minimal-conn `UDPConn{}` literals (capacity-one queue, completion-versus-seal, attempt-result ownership) retained by Track 1; `turntest` knobs unused by this repository's tests (possibly wiremux's; not touched).
+- Domain terms: this program names **Attempt**, **Readiness**, and **Release** in `CONTEXT.md`; no other term changes.
+
+## Tracks, dependencies, and frontier
+
+| # | Track | Plan | Parent issue | Blocked by | Slices | Status |
+|---|---|---|---|---|---|---|
+| 1 | UDPConn construction and transaction crossing | [plan](2026-08-19-udpconn-construction-crossing-plan.md) | pending | None | 2 | FRONTIER (T1.S1, T1.S2) |
+| 2 | Allocate admission and public error vocabulary | [plan](2026-08-19-allocate-admission-errors-plan.md) | pending | None | 2 | FRONTIER (T2.S1, T2.S2) |
+| 3 | Permission readiness | [plan](2026-08-19-permission-readiness-plan.md) | pending | None | 1 | FRONTIER (T3.S1) |
+| 4 | Allocate exchange | [plan](2026-08-19-allocate-exchange-plan.md) | pending | None | 1 | FRONTIER (T4.S1) |
+
+There are no genuine blocking edges; every slice is independently green. T1.S1 → T1.S2 is the strongly recommended order (T1.S1's helpers are where T1.S2's crossing closures are scripted), and the recommended overall dispatch order to minimize rebases — advice, not a blocker — is T1.S1 → T1.S2 → T2.S1 → T2.S2 → T3.S1 → T4.S1. Known file overlaps: T1 and T3 both touch `internal/client/prepare_test.go`; T1.S2 and T2.S1 both touch `AllocationConfig`; T4.S1 is root-only but shares `client.go` (`sendAllocateRequest`, `Allocate`) with T1.S2 and T2.S1. Text conflicts between independently implemented slices require rebasing, not artificial blockers. T3.S1 and T4.S1 share no files with each other. Recommended starter: T1.S1.
+
+## Rules that bind every track
+
+- Plan docs are normative. One audited slice maps to exactly one child issue, one intended PR, one fresh implementation context, and one OmniFocus slice task.
+- Public API and emitted Allocate, Refresh, CreatePermission, ChannelBind, and ChannelData bytes and setter order remain unchanged. Track 4 pins bytes; #83 owns any change. Error-text changes in Track 2 keep every error identity.
+- The caller owns `ClientConfig.Conn`; the fork never closes it, sets deadlines, or interrupts in-flight I/O. Client remains bound to one canonical TURN server and its close remains abort-current and non-terminal.
+- Root `Client` keeps server-source admission, TURN wire demultiplexing and decoding, Data-indication peer canonicalization, transaction completion, Allocate admission, and the one production assembler of `AllocationConfig`. `UDPConn` remains the sole Allocation lifecycle owner: seal, abort-before-release ordering, exactly one lifetime-zero release, terminal cause, worker registration, and caller join. `TransactionRegistry` owns transaction semantics. `binding` and `permission` own their readiness as their plans state.
+- Writes remain prepared-only ChannelData. Permission identity remains per canonical peer IP; channel-binding identity remains per canonical peer transport address. Inbound data is not made prepared-only.
+- Shared review-loop and contract-closure baselines govern every slice; this repository has no overlay. Each PR uses TDD-shaped focused evidence, finite evidence and review budgets, exact-head `task preflight`, a draft-to-ready transition only after local certification, successful same-head hosted CI, merge, `append-dev-journal`, and then pointer/task updates.
+- Representation and artifact gates in each plan are ceilings as well as floors. Do not broaden test harnesses, protocol syntax, timing matrices, cleanup, or verification infrastructure during review. Diagnose failures before reruns and stop when representation ownership, accepted outcome, blast radius, or the one-PR boundary changes.

--- a/docs/adr/2026-08-19-udpconn-construction-crossing-plan.md
+++ b/docs/adr/2026-08-19-udpconn-construction-crossing-plan.md
@@ -1,0 +1,133 @@
+# UDPConn Construction and Transaction Crossing Implementation Plan
+
+**Date:** 2026-08-19
+**Status:** Accepted; not yet implemented
+**Track:** 1 of 4 in the 2026-08-19 seam deepening program
+**Depends on:** Nothing — safe to start first; T1.S1 first is strongly recommended for T1.S2 but is not a blocker
+**Related:** [Program index](2026-08-19-seam-deepening-program.md), [Allocation lifecycle plan](2026-08-17-allocation-lifecycle-plan.md), [Transaction registry plan](2026-08-17-transaction-registry-plan.md), [Server-bound transport plan](2026-08-19-server-bound-transport-plan.md), [Allocation construction timing validity plan](2026-08-19-allocation-construction-timing-validity-plan.md)
+**Normative scope:** Current outcome, boundaries, invariants, acceptance evidence, blockers, and stop conditions
+**Audit history:** Self-grilled and independently slice-audited against `dad68d4868efc8b041114f7a4efdeaa3b229edfb` on 2026-08-19 (see the program index for the audit receipt)
+
+## Goal
+
+Make `NewUDPConn` the only way a `UDPConn` comes to exist — in production and, apart from six retained internal-seam literals, in tests — by separating building an Allocation (every invariant established, no goroutines) from starting it (timers armed), and make the Client→`UDPConn` transaction crossing two named operations instead of one function with a mode flag. The `UDPConn` interface shrinks (no mode flag, no result bag), tests enter through the constructor rather than the field set, and the crossing's production adapters become plain method values on the transaction registry.
+
+## Current Shape (verified 2026-08-19 at `dad68d4868efc8b041114f7a4efdeaa3b229edfb`)
+
+`NewUDPConn` builds every field and starts three `PeriodicTimer` goroutines in one call (`internal/client/udp_conn.go:95-161`). Because no production path needs a built-but-quiescent Allocation, tests that want one bypass the constructor: `udp_conn_test.go` constructs `UDPConn{…}` struct literals at 13 sites (`internal/client/udp_conn_test.go:74,93,108,271,358,373,910,940,970,1005,1019,1043,1070`), each populating a different subset of private fields; `mockClient.configure` writes the three private func fields `writeTo`, `performTransaction`, and `onDeallocated` after the fact (`internal/client/client_test.go:12-47`); and one test invokes the refresh worker directly (`internal/client/udp_conn_test.go:280`). Seven of those literals (`:271,358,373,910,940,1043,1070`) exist only to carry credentials and/or the mock; the remaining six build a minimal conn to force a capacity-one read queue (`:74,93,108`), a completion-versus-seal linearization (`:970`), or a minimal-conn attempt-result-ownership check (`:1005,1019`), which the inbound delivery and channel-binding readiness plans accepted as controlled internal tests.
+
+Across packages, `AllocationConfig{…}` is hand-built ten times (`close_latency_test.go:45`, `allocation_test.go:41`, `client_test.go:242`, `internal/client/refresh_failure_test.go:76`, `internal/client/prepare_test.go:100`, `internal/client/udp_conn_test.go:56,132,674,756,819`), the same CreatePermission/ChannelBind "succeed" script is written nine times, and the credential quintet appears fourteen times. Root harnesses `allocHarness` (`allocation_test.go:27-88`) and `inboundDeliveryHarness` (`client_test.go:225-277`) do the same job as the internal `prepareHarness` (`internal/client/prepare_test.go:24-135`).
+
+The transaction crossing is `AllocationConfig.PerformTransaction func(msg *stun.Message, dontWait bool) (TransactionResult, error)` (`internal/client/allocation.go:19-23`). One boolean is re-split at five layers: `refreshAllocation(lifetime, dontWait)` returns before reading the response when true (`internal/client/allocation.go:46-68`); the crossing carries it; root `Client.performTransaction(msg, ignoreResult)` branches to `registry.Start` or `registry.Perform` (`client.go:344-352`); `begin(msg, ignoreResult)` allocates or omits the result channel (`internal/client/transaction.go:106-117`). With the flag true the returned `TransactionResult` is always zero and `Msg` must not be read — an invariant documented nowhere on `AllocationConfig`. Exactly two call sites exist: the waited refresh (`internal/client/allocation.go:129`) and the lifetime-zero release emitted from `startCloseLocked` (`internal/client/udp_conn.go:516`). `TransactionResult{Msg, Err}` duplicates the returned error: every entry point returns `(result, result.Err)` (`internal/client/transaction.go:214-220`) and `Msg` is the only field any caller reads. Tests use the flag as a de facto method name (`internal/client/refresh_failure_test.go:45-58`) or sniff `MethodRefresh && dontWait` to detect release ordering (`close_latency_test.go:46-50`).
+
+Root `Client` still owns one production assembler of `AllocationConfig` (`client.go:315-328`), validates configuration at `NewClient` only (T4.S1), and never validates in `NewUDPConn`. That ownership is preserved.
+
+## Decision
+
+**Build, then start.** `internal/client` gains an unexported build step that allocates every `UDPConn` field — maps, channels, the read queue, the three `PeriodicTimer`s constructed but not started — and establishes every invariant a method relies on (`closeCh`, `permMap`, `bindingMgr`, `readCh` non-nil; intervals defaulted), and an unexported `start()` that arms the timers. Exported `NewUDPConn(config, abort)` is exactly build followed by start and remains the single production constructor; its observable behavior, including the panic on a missing abort capability, is unchanged. Calling `Close` on a built-but-unstarted conn is valid and joins nothing: `PeriodicTimer.Stop`/`StopAndWait` on a never-started timer are already no-ops (`internal/client/periodic_timer.go:72-96`).
+
+**One scripted constructor per test package.** `internal/client` tests construct through one helper that builds (unstarted) a `UDPConn` with default credentials and a caller-supplied script — the three crossing closures plus write capture — held by the harness so a test may rescript after construction without touching private fields; a test that needs timers calls `start()` explicitly. `mockClient` and `configure` are deleted. The seven credential-carrying struct literals and the direct worker invocation migrate to the helper. The six capacity-one-queue, completion-versus-seal, and minimal-conn attempt-result literals stay as they are: they are the accepted way to force an ordering or a minimal state, and widening the helper with queue-size or lock knobs is the harness growth this track refuses. Root tests keep `client.NewUDPConn` (timers started at long intervals, as today) behind one `newScriptedAllocation(t)` helper that replaces `allocHarness` and `inboundDeliveryHarness`; `close_latency_test.go` keeps its own harness because it exercises real `Client` wiring, a different job. Root harness count goes from three to two, not to one.
+
+**Two named crossings.** `AllocationConfig` carries `PerformTransaction func(*stun.Message) (*stun.Message, error)` and `StartTransaction func(*stun.Message) error`. `TransactionResult` is deleted: `TransactionRegistry.Perform` and `PerformWithContext` return `(*stun.Message, error)` and keep a private result type on the channel; `Start` keeps returning `error`. Root passes method values — `PerformTransaction: c.transactions.Perform`, `StartTransaction: c.transactions.Start` — and deletes `Client.performTransaction`; `performAllocateTransaction` stays because it adds the cancelable wait. Inside `UDPConn`, `refreshAllocation(lifetime)` waits and parses and `emitRelease()` builds the lifetime-zero Refresh and calls `StartTransaction`; both share one private request builder. `startCloseLocked` calls `emitRelease` at the same point it calls `refreshAllocation(0, true)` today, so abort → `onDeallocated` → release ordering, exactly-one release, and terminal-cause joining are unchanged. `TestClientNonceExpiration`, the refresh-failure flows, and the close-latency ordering test are retained with their assertions rephrased against the named closures.
+
+Exact private Go spellings (`newUDPConn`, `start`, `newTestConn`, `emitRelease`, `buildRefresh`) may vary; the operations and ownership above are the contract.
+
+**Rejected alternative (do not do this):** Add an options struct, functional options, builder, or timing module for `UDPConn` construction. T4.S1 closed construction regrouping; this track changes when goroutines start, not how configuration is shaped.
+
+**Rejected alternative (do not do this):** Grow the test helper into a general scripted-responder framework with queue-size, lock, timer, or clock knobs. The 08-17 program deferred broad responder consolidation and the 08-19 program rejected a shared responder-harness program; one constructor-shaped helper per package is the ceiling.
+
+**Rejected alternative (do not do this):** Keep `dontWait` but document it, or keep `TransactionResult` as a one-field bag. The registry already exposes the two operations by name; the seam should carry them by name.
+
+**Rejected alternative (do not do this):** Pass the `*TransactionRegistry` itself into `UDPConn` instead of two closures. The closure seam is the test seam (one production adapter, one scripted adapter); passing the registry would force every internal test to drive it at the wire.
+
+**Non-goals:** No change to emitted bytes, setter order, retransmission policy, abort-before-release ordering, Allocation lifecycle ownership, `AllocationConfig` validation or field regrouping beyond the two crossing fields, public API, clock, timer semantics, queue size, or `turntest`. No fake clock; no removal of the accepted controlled-linearization tests; no root test helper beyond `newScriptedAllocation`.
+
+## Slice Graph
+
+| Slice | Status/disposition | Delivers | Blocked by | Removes temporary seam |
+|---|---|---|---|---|
+| T1.S1 | New | `UDPConn` built by one constructor in production and tests; `mockClient.configure` and credential-carrying struct literals gone; one scripted helper per package | None | Private-field test construction |
+| T1.S2 | New | Two named transaction crossings; `TransactionResult` and the `dontWait` flag gone; release emission has a name | None (T1.S1 first strongly recommended) | Mode flag on the crossing |
+
+## Implementation Slices
+
+### Slice T1.S1 — Build, then start: one construction seam for UDPConn
+
+**What it delivers:** One PR splitting `NewUDPConn` into unexported build and start steps (`NewUDPConn` = both, behavior unchanged), adding one scripted internal test constructor and one root `newScriptedAllocation` helper, deleting `mockClient`/`configure`, migrating the seven credential-carrying struct literals and the direct worker invocation to the helper, and collapsing the duplicated `AllocationConfig`/script/credential literals to the helper in both packages.
+
+**Existing-work disposition:** New slice. No open PR, branch, or review finding targets this seam as of 2026-08-19.
+
+**Blocked by:** None.
+
+**Single owner after merge:** `newUDPConn` is the only place a `UDPConn`'s invariants are established; `start()` is the only place its timers are armed; `NewUDPConn` is the only production constructor. Allocation lifecycle, seal, release, and join stay on `UDPConn` exactly as the Allocation lifecycle plan assigns them. Root `Client.Allocate` remains the one production assembler of `AllocationConfig`.
+
+**Authority completeness:** No persisted fact. The construction invariants (non-nil channels/maps, defaulted intervals) are established in the build step and relied on by every method; the slice covers the constructor, `Close` on a built-unstarted conn, and every test construction path.
+
+**Transitional-seam budget:** None at merge. The six accepted literals (`udp_conn_test.go:74,93,108,970,1005,1019` today: capacity-one queue, completion-versus-seal, minimal-conn attempt-result ownership) are retained deliberately as internal-seam tests, not as a second construction path; they construct minimal state to force an ordering and must not grow. No `mockClient`, `configure`, or credential-carrying literal may remain.
+
+**Blast radius:** Internal package construction and its tests; root test harnesses. No production behavior change: `NewUDPConn` still returns a started conn with identical timer intervals and the same panic on missing abort. Concurrency: `start()` arms the same three timers at the same point; no new lock, goroutine, or ordering. Interfaces: no public API or `AllocationConfig` change. Failure modes: `Close` on an unstarted conn returns the same emission result and joins no goroutines. Performance, security, dependencies: none. Untraced effects are not accepted: any behavior difference observable through `NewUDPConn`, any new helper knob, or any remaining private-field write from a test stops the slice.
+
+**Artifact classification:** The build/start split is shipped behavior (construction of the Allocation). The internal and root test helpers, migrated tests, and retained linearization tests are verification aids and do not become maintained product deliverables. Plans, issues, and tasks are process metadata.
+
+**Representation contract:** Supported domain = construction of one `UDPConn` from one valid `AllocationConfig` plus abort capability, in production (built and started) and in tests (built; optionally started); the six retained literal sites. Representation owner = `newUDPConn` for invariants and `start` for timers. Guarantee = universal over the finite set of construction paths in this repository (the production call, the helper, and the enumerated retained literals), verified by grep-level negative evidence, not over arbitrary future tests. Terminating evidence = the focused constructor tests, the migrated suites green under `-race`, the negative-grep checks below, `task preflight`, same-head hosted CI, one review plus at most one replacement.
+
+**Contract closure:** Not triggered. Production behavior is unchanged and construction has one reachable production path; focused constructor tests and the existing lifecycle suite are proportionate.
+
+**Evidence budget:** One focused test that a built-unstarted conn has no running timers, accepts `Close`, and emits exactly one release; one new focused test that `NewUDPConn` returns a conn whose three timers report `IsRunning()` (the existing `PeriodicTimer` tests are retained); migrated `prepare_test`, `refresh_failure_test`, `udp_conn_test`, root `allocation_test`/`client_test` green; `go test -race ./...`. Negative evidence: no `mockClient` or `configure` symbol; no test outside the six retained sites constructs `UDPConn{`; the retained sites are listed in the PR description. No guard mutation is required (no enforcement guard changes). No new platforms, repetitions, or timing cells.
+
+**TDD and preservation evidence:** Write the built-unstarted constructor test first (no goroutines, `Close` valid, one release), then split the constructor; write the internal helper and migrate one harness at a time keeping each suite green; write `newScriptedAllocation` and migrate `allocation_test` then `client_test`; delete `mockClient`/`configure` last. Preserved behavior gates: existing request-shape, lifecycle, refresh-failure, prepared-only, and inbound-delivery tests unchanged in assertion.
+
+**Dispatch context budget:** This slice contract; `internal/client/udp_conn.go:95-161`; `internal/client/client_test.go`; `internal/client/prepare_test.go:24-135`; `internal/client/refresh_failure_test.go:25-86`; the `UDPConn{` and `mockClient{` sites in `internal/client/udp_conn_test.go`; root `allocation_test.go:27-88`, `client_test.go:225-277`, `close_latency_test.go:25-79`; the Allocation lifecycle plan. No root inbound/transaction implementation, no `turntest`, and no historical review transcript is required. The change is one constructor split plus mechanical harness consolidation and fits one fresh context; any helper knob beyond script and write capture exceeds it.
+
+**Slice decision audit:** Strongest further split = split the constructor in one PR and consolidate harnesses in another. Rejected: the split alone has no observable payoff and leaves the private-field fossil in place, so the first PR would not be independently valuable. Strongest merge = fold T1.S2 in because both touch `AllocationConfig` literals. Rejected: T1.S2 changes a crossing's semantics while T1.S1 changes only construction; keeping them apart keeps each PR's preservation argument simple, and T1.S1 first makes T1.S2 cheaper. No blocking edge is needed in either direction.
+
+**Stop conditions:** Any production-observable difference between old and new `NewUDPConn`; a test that still needs a private-field write after migration (other than the six retained sites) — indicates the helper shape is wrong; pressure to add queue-size, lock, timer, or clock knobs; a root test that needs an unexported internal constructor; or the migration cannot stay green suite by suite.
+
+### Slice T1.S2 — Two named transaction crossings
+
+**What it delivers:** One PR replacing `PerformTransaction(msg, dontWait) (TransactionResult, error)` with `PerformTransaction(msg) (*stun.Message, error)` plus `StartTransaction(msg) error`, deleting `TransactionResult` and root `Client.performTransaction`, wiring root with registry method values, splitting `refreshAllocation(lifetime)` from `emitRelease()` inside `UDPConn`, and rephrasing the refresh-failure and close-latency tests against the named closures.
+
+**Existing-work disposition:** New slice.
+
+**Blocked by:** None. T1.S1 first is strongly recommended: its helpers are where the crossing closures are scripted, so the signature change lands in two helpers plus mechanical return-type edits in every scripted `performTransaction` closure (`TransactionResult` has roughly 110 references across seven test files) instead of also rewriting ten literals and `mockClient`. Not a blocker; the slice is independently green either way, and text conflicts are rebased.
+
+**Single owner after merge:** `TransactionRegistry` is the only owner of wait-versus-fire-and-forget semantics (already true; the flag re-split it); `UDPConn.emitRelease` is the only emitter of the lifetime-zero Refresh; `startCloseLocked` remains the only caller of it and the only owner of abort → `onDeallocated` → release ordering.
+
+**Authority completeness:** No persisted fact. Both crossing operations, their production adapters (registry method values), their scripted adapters (helpers), and both `UDPConn` consumers (waited refresh, release) are covered in the slice.
+
+**Transitional-seam budget:** None at merge. `TransactionResult`, the `dontWait`/`ignoreResult` parameters, and `Client.performTransaction` must be absent; no compatibility shim may translate the old shape.
+
+**Blast radius:** `internal/client/allocation.go`, `udp_conn.go:56-62,516`, `transaction.go` return types, root `client.go:203-208,242-246` (`sendAllocateRequest` reads `trRes.Msg`), `client.go:315-360` (wiring and `performAllocateTransaction` return type), `internal/client/transaction_test.go`, and the scripted helpers; `sendAllocateRequest` overlaps T4.S1's edits (rebase, not a blocker). Ordering: `emitRelease` is called at the same point `refreshAllocation(0, true)` is called today, inside `startCloseLocked` after `abortTransactions()` and `onDeallocated`; exactly-one release and terminal-cause joining are unchanged. Bytes: the Refresh request built by the shared builder is byte-identical after normalizing to the observed transaction ID (same setters, same order). Failure modes: a `StartTransaction` send error is still joined into the terminal cause exactly as today's `emitErr`. Public API: none (`TransactionResult` is internal). Performance/security/dependencies: none. Untraced effects are not accepted: any change in release ordering, count, or bytes stops the slice.
+
+**Artifact classification:** The crossing shape and `emitRelease` are shipped behavior. Rephrased tests are verification aids. Plans/issues are process metadata.
+
+**Representation contract:** Supported domain = the two in-contract crossing operations and their two `UDPConn` consumers; Refresh request bytes for lifetime L and lifetime 0. Representation owner = `TransactionRegistry` for transaction semantics, `UDPConn` for which operation each consumer uses. Guarantee = universal over that finite set. Terminating evidence = focused tests below, existing lifecycle and close-latency tests, `go test -race ./...`, `task preflight`, hosted CI, one review plus at most one replacement.
+
+**Contract closure:** Not triggered. The invariant (release emitted once, fire-and-forget, at the accepted point) has one enforcement owner and one reachable path; the existing abort/release ordering tests plus the focused tests below cover it.
+
+**Evidence budget:** One focused test that the waited refresh uses `PerformTransaction` and parses the response; one that release uses `StartTransaction` with a lifetime-zero Refresh byte-identical to today's after normalizing to the observed transaction ID, using the existing `assertRequestShape` technique (`internal/client/udp_conn_test.go:194-213`: expected bytes built from an explicit setter list with `stun.NewTransactionIDSetter(actual.TransactionID)`; `TestRefreshAllocationPreservesRequestAndRetriesStaleNonce` already pins lifetime L, add the lifetime-0 case); retained `TestClientNonceExpiration`, refresh-failure flows, abort/release ordering, and close-latency tests with assertions rephrased; `go test -race ./...`. Negative evidence: no `TransactionResult`, `dontWait`, `ignoreResult`, or `Client.performTransaction` symbol remains. At most one guard mutation: skip `emitRelease` in `startCloseLocked` and observe the existing exactly-one-release test fail.
+
+**TDD and preservation evidence:** Pin the current lifetime-zero Refresh shape (txid-normalized) and the waited-refresh flow as characterization tests first; introduce `StartTransaction` alongside, migrate release, then migrate waited refresh, then delete the old field and `TransactionResult`; rephrase tests last. Preserved gates: request-shape tests, `close_latency_test` ordering, refresh-failure terminal-cause tests.
+
+**Dispatch context budget:** This slice contract; `internal/client/allocation.go`; `internal/client/udp_conn.go:56-62,486-530`; `internal/client/transaction.go:21-25,53-104,198-220`; `internal/client/transaction_test.go`; root `client.go:181-273,315-360`; the scripted helpers (post-T1.S1) or the literals they replace; the Allocation lifecycle and transaction registry plans. Fits one fresh context: two field renames, one method split, one type deletion, and bounded test edits.
+
+**Slice decision audit:** Strongest further split = rename the crossing first, delete `TransactionResult` later. Rejected: the deletion is the point (the result bag is the duplicated error), and both are mechanical. Strongest merge = fold into T1.S1. Rejected above. No edge is necessary; T1.S1 first reduces churn.
+
+**Stop conditions:** The release must be emitted anywhere other than `startCloseLocked`; the shared Refresh builder cannot reproduce today's bytes; a caller needs the response of a fire-and-forget transaction; or a third crossing operation becomes necessary.
+
+## Acceptance Criteria
+
+- [ ] `NewUDPConn` behaves exactly as before (started timers, same intervals, same abort panic) and is the only production constructor; an unexported build step establishes every invariant without goroutines and `Close` on a built-unstarted conn is valid. Domain: the finite construction paths in this repository; owner: `newUDPConn`/`start`; guarantee: universal over that set via the negative-grep evidence in T1.S1.
+- [ ] No test writes `UDPConn` private func fields after construction; `mockClient` and `configure` do not exist; `UDPConn{` literals exist only at the six retained controlled-linearization/queue sites named in the T1.S1 PR.
+- [ ] One scripted internal constructor and one root `newScriptedAllocation` replace `prepareHarness`'s construction, `allocHarness`, and `inboundDeliveryHarness`; `close_latency_test` keeps its own harness.
+- [ ] `AllocationConfig` exposes `PerformTransaction(msg) (*stun.Message, error)` and `StartTransaction(msg) error`; `TransactionResult`, `dontWait`, `ignoreResult`, and `Client.performTransaction` are absent; root wires registry method values.
+- [ ] The lifetime-zero release is emitted once from `startCloseLocked` via `StartTransaction`, byte-identical to today's after transaction-ID normalization, after abort and `onDeallocated`, and a failed emission is still joined into the terminal cause. Domain: the one release path; owner: `UDPConn.emitRelease`; guarantee: universal; evidence: txid-normalized byte equality plus the existing exactly-one-release and ordering tests.
+- [ ] Emitted Allocate/Refresh/CreatePermission/ChannelBind/ChannelData bytes, setter order, retransmission policy, public API, and Allocation lifecycle ownership are unchanged.
+
+## Validation Gates
+
+Per slice: the focused tests named in its evidence budget, `go test ./...`, `go test -race ./...`, and `task preflight`. Keep each PR draft through bounded review and exact-head local certification, mark it ready afterward, and require the latest post-ready `ci` run's `ci-required` job to succeed on the exact live head before squash merge.
+
+## Operating Discipline
+
+Follow the shared review-loop and contract-closure baselines supplied by `$implement-architecture-slice` for every slice/PR; this repository has no overlay. Keep construction on `newUDPConn`/`start`, transaction semantics on `TransactionRegistry`, release emission on `UDPConn.emitRelease`, and the one production assembler on root `Client.Allocate`. Stop rather than adding a helper knob, an options layer, a clock, or a third crossing.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -15,7 +15,7 @@ If any of these files don't exist, **proceed silently**. Don't flag their absenc
 
 ```
 /
-├── CONTEXT.md                 ← not yet created; /domain-modeling creates it lazily
+├── CONTEXT.md                 ← the glossary (created 2026-08-19; /domain-modeling maintains it)
 ├── docs/adr/
 │   ├── 2026-08-14-owned-library-fork.md
 │   ├── 2026-08-15-prepared-only-writes.md


### PR DESCRIPTION
## Summary

- add the 2026-08-19 seam deepening program index and four audited track plans (six slices): UDPConn construction and transaction crossing (T1.S1, T1.S2), Allocate admission and public error vocabulary (T2.S1, T2.S2), permission readiness (T3.S1), Allocate exchange (T4.S1)
- record the permission-owns-its-attempt ADR (closes the bind-attempt-handle relocation without code)
- create `CONTEXT.md` (glossary seeded from the grill notes; adds Attempt, Readiness, Release) and point `docs/agents/domain.md` at it
- reference behaviour decision #83 (REQUESTED-ADDRESS-FAMILY after MESSAGE-INTEGRITY) from Track 4, which pins current bytes

## Validation

- independent architecture-handoff slice audit: PASS at `dad68d4868efc8b041114f7a4efdeaa3b229edfb` (corrections folded in)
- `task docs-check`

No implementation is included in this PR.
