### PR TITLE
Build UDPConn before starting timers

### DIFF
--- a/allocation_test.go
+++ b/allocation_test.go
@@ -10,8 +10,6 @@ import (
 	"net"
 	"net/netip"
 	"reflect"
-	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -21,74 +19,6 @@ import (
 	"github.com/the-sarge/turn/v5/internal/client"
 	"github.com/the-sarge/turn/v5/internal/proto"
 )
-
-// allocHarness drives an Allocation over a UDPConn whose transactions are
-// scripted to succeed, capturing every base-socket write.
-type allocHarness struct {
-	alloc     *Allocation
-	permCount atomic.Int32
-	bindCount atomic.Int32
-	writes    struct {
-		sync.Mutex
-		data [][]byte
-	}
-}
-
-func newAllocHarness(t *testing.T) *allocHarness {
-	t.Helper()
-
-	harness := &allocHarness{}
-	conn := client.NewUDPConn(&client.AllocationConfig{
-		WriteTo: func(data []byte) (int, error) {
-			harness.writes.Lock()
-			harness.writes.data = append(harness.writes.data, append([]byte(nil), data...))
-			harness.writes.Unlock()
-
-			return len(data), nil
-		},
-		PerformTransaction: func(msg *stun.Message, _ bool) (client.TransactionResult, error) {
-			switch msg.Type.Method {
-			case stun.MethodCreatePermission:
-				harness.permCount.Add(1)
-
-				return client.TransactionResult{Msg: stun.MustBuild(
-					stun.NewType(stun.MethodCreatePermission, stun.ClassSuccessResponse),
-				)}, nil
-			case stun.MethodChannelBind:
-				harness.bindCount.Add(1)
-
-				return client.TransactionResult{Msg: stun.MustBuild(
-					stun.NewType(stun.MethodChannelBind, stun.ClassSuccessResponse),
-				)}, nil
-			default:
-				return client.TransactionResult{}, nil
-			}
-		},
-		OnDeallocated: func(net.Addr) {},
-		RelayedAddr:   &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 54321},
-		Username:      stun.NewUsername("user"),
-		Realm:         stun.NewRealm("realm"),
-		Integrity:     stun.NewShortTermIntegrity("pass"),
-		Nonce:         stun.NewNonce("nonce"),
-		Lifetime:      time.Hour,
-	}, func() {})
-	t.Cleanup(func() { _ = conn.Close() })
-
-	harness.alloc = newAllocation(conn, netip.MustParseAddrPort("127.0.0.1:54321"))
-
-	return harness
-}
-
-func (harness *allocHarness) lastWrite() []byte {
-	harness.writes.Lock()
-	defer harness.writes.Unlock()
-
-	if len(harness.writes.data) == 0 {
-		return nil
-	}
-
-	return harness.writes.data[len(harness.writes.data)-1]
-}
 
 // invalidPeers is the rejection table for the canonical netip.AddrPort peer
 // domain: every entry must fail PreparePeer and WriteTo with ErrInvalidPeer.
@@ -103,44 +33,46 @@ func invalidPeers() map[string]netip.AddrPort {
 }
 
 func TestAllocationRejectsInvalidPeers(t *testing.T) {
-	harness := newAllocHarness(t)
+	script := &scriptedAllocationScript{}
+	allocation, _ := newScriptedAllocation(t, script)
 
 	for name, peer := range invalidPeers() {
 		t.Run("PreparePeer "+name, func(t *testing.T) {
-			assert.ErrorIs(t, harness.alloc.PreparePeer(context.Background(), peer), ErrInvalidPeer)
+			assert.ErrorIs(t, allocation.PreparePeer(context.Background(), peer), ErrInvalidPeer)
 		})
 		t.Run("WriteTo "+name, func(t *testing.T) {
-			_, err := harness.alloc.WriteTo([]byte("data"), peer)
+			_, err := allocation.WriteTo([]byte("data"), peer)
 			assert.ErrorIs(t, err, ErrInvalidPeer)
 		})
 	}
 
-	assert.Equal(t, int32(0), harness.permCount.Load(), "rejected peers must not reach the permission machinery")
-	assert.Equal(t, int32(0), harness.bindCount.Load(), "rejected peers must not reach the binding machinery")
+	assert.Equal(t, int32(0), script.permissionCount.Load(), "rejected peers must not reach the permission machinery")
+	assert.Equal(t, int32(0), script.bindingCount.Load(), "rejected peers must not reach the binding machinery")
 }
 
 // TestAllocationPeerAliasCanonicalizes is the positive anchor: an IPv4-mapped
 // IPv6 spelling of a peer canonicalizes onto the same permission and channel
 // binding as the IPv4 literal, so writes after PreparePeer are ChannelData.
 func TestAllocationPeerAliasCanonicalizes(t *testing.T) {
-	harness := newAllocHarness(t)
+	script := &scriptedAllocationScript{}
+	allocation, _ := newScriptedAllocation(t, script)
 
 	mapped := netip.AddrPortFrom(
 		netip.AddrFrom16([16]byte{10: 0xff, 11: 0xff, 12: 127, 13: 0, 14: 0, 15: 1}), 1234)
 	require.True(t, mapped.Addr().Is4In6(), "test input must be the mapped spelling")
 
-	assert.NoError(t, harness.alloc.PreparePeer(context.Background(), mapped))
-	assert.Equal(t, int32(1), harness.permCount.Load())
-	assert.Equal(t, int32(1), harness.bindCount.Load())
+	assert.NoError(t, allocation.PreparePeer(context.Background(), mapped))
+	assert.Equal(t, int32(1), script.permissionCount.Load())
+	assert.Equal(t, int32(1), script.bindingCount.Load())
 
-	n, err := harness.alloc.WriteTo([]byte("hello"), netip.MustParseAddrPort("127.0.0.1:1234"))
+	n, err := allocation.WriteTo([]byte("hello"), netip.MustParseAddrPort("127.0.0.1:1234"))
 	assert.NoError(t, err)
 	assert.Equal(t, 5, n)
-	assert.True(t, proto.IsChannelData(harness.lastWrite()),
+	assert.True(t, proto.IsChannelData(script.lastWrite()),
 		"write to the unmapped spelling of a prepared mapped peer must be ChannelData")
-	assert.Equal(t, int32(1), harness.bindCount.Load(), "alias must not create a second binding")
+	assert.Equal(t, int32(1), script.bindingCount.Load(), "alias must not create a second binding")
 
-	assert.Equal(t, netip.MustParseAddrPort("127.0.0.1:54321"), harness.alloc.RelayedAddr())
+	assert.Equal(t, netip.MustParseAddrPort("127.0.0.1:54321"), allocation.RelayedAddr())
 }
 
 // scriptInvalidRelayedServer answers Allocate requests on serverSock with a

--- a/client_test.go
+++ b/client_test.go
@@ -222,60 +222,6 @@ func TestHandleInboundAdmitsOnlyServer(t *testing.T) {
 	})
 }
 
-type inboundDeliveryHarness struct {
-	client     *Client
-	allocation *Allocation
-	conn       *client.UDPConn
-	server     netip.AddrPort
-	peer       netip.AddrPort
-	channel    proto.ChannelNumber
-}
-
-func newInboundDeliveryHarness(t *testing.T) *inboundDeliveryHarness {
-	t.Helper()
-
-	harness := &inboundDeliveryHarness{
-		server: netip.MustParseAddrPort("192.0.2.1:3478"),
-		peer:   netip.MustParseAddrPort("198.51.100.10:5000"),
-	}
-	harness.client = &Client{server: harness.server}
-	harness.conn = client.NewUDPConn(&client.AllocationConfig{
-		WriteTo: func(data []byte) (int, error) {
-			return len(data), nil
-		},
-		PerformTransaction: func(msg *stun.Message, _ bool) (client.TransactionResult, error) {
-			switch msg.Type.Method {
-			case stun.MethodCreatePermission:
-				return client.TransactionResult{Msg: stun.MustBuild(
-					stun.NewType(stun.MethodCreatePermission, stun.ClassSuccessResponse),
-				)}, nil
-			case stun.MethodChannelBind:
-				require.NoError(t, harness.channel.GetFrom(msg))
-
-				return client.TransactionResult{Msg: stun.MustBuild(
-					stun.NewType(stun.MethodChannelBind, stun.ClassSuccessResponse),
-				)}, nil
-			default:
-				return client.TransactionResult{}, nil
-			}
-		},
-		OnDeallocated: func(net.Addr) {
-			harness.client.setRelayedUDPConn(nil)
-		},
-		RelayedAddr: &net.UDPAddr{IP: net.ParseIP("203.0.113.1"), Port: 54321},
-		Username:    stun.NewUsername("user"),
-		Realm:       stun.NewRealm("realm"),
-		Integrity:   stun.NewShortTermIntegrity("pass"),
-		Nonce:       stun.NewNonce("nonce"),
-		Lifetime:    time.Hour,
-	}, func() {})
-	harness.client.setRelayedUDPConn(harness.conn)
-	harness.allocation = newAllocation(harness.conn, netip.MustParseAddrPort("203.0.113.1:54321"))
-	t.Cleanup(func() { _ = harness.conn.Close() })
-
-	return harness
-}
-
 func buildDataIndication(t *testing.T, payload []byte, peer netip.AddrPort) []byte {
 	t.Helper()
 
@@ -326,57 +272,80 @@ func readAllocation(t *testing.T, allocation *Allocation, size int) allocationRe
 
 func TestHandleInboundDeliversDecodedPeerDataThroughAllocation(t *testing.T) {
 	t.Run("Data indication", func(t *testing.T) {
-		harness := newInboundDeliveryHarness(t)
+		server := netip.MustParseAddrPort("192.0.2.1:3478")
+		peer := netip.MustParseAddrPort("198.51.100.10:5000")
+		turnClient := &Client{server: server}
+		script := &scriptedAllocationScript{
+			onDeallocated: func(net.Addr) { turnClient.setRelayedUDPConn(nil) },
+		}
+		allocation, conn := newScriptedAllocation(t, script)
+		turnClient.setRelayedUDPConn(conn)
 		payload := []byte("indication payload")
-		raw := buildDataIndication(t, payload, harness.peer)
+		raw := buildDataIndication(t, payload, peer)
 
-		require.NoError(t, harness.client.HandleInbound(raw, net.UDPAddrFromAddrPort(harness.server)))
+		require.NoError(t, turnClient.HandleInbound(raw, net.UDPAddrFromAddrPort(server)))
 		for i := range raw {
 			raw[i] = 0
 		}
 
-		result := readAllocation(t, harness.allocation, len(payload))
+		result := readAllocation(t, allocation, len(payload))
 		require.NoError(t, result.err)
 		assert.Equal(t, len(payload), result.n)
-		assert.Equal(t, harness.peer, result.from)
+		assert.Equal(t, peer, result.from)
 		assert.Equal(t, []byte("indication payload"), result.data)
 	})
 
 	t.Run("ChannelData", func(t *testing.T) {
-		harness := newInboundDeliveryHarness(t)
-		require.NoError(t, harness.allocation.PreparePeer(context.Background(), harness.peer))
+		server := netip.MustParseAddrPort("192.0.2.1:3478")
+		peer := netip.MustParseAddrPort("198.51.100.10:5000")
+		turnClient := &Client{server: server}
+		var channel proto.ChannelNumber
+		script := &scriptedAllocationScript{
+			onDeallocated: func(net.Addr) { turnClient.setRelayedUDPConn(nil) },
+			onChannelBind: func(msg *stun.Message) { require.NoError(t, channel.GetFrom(msg)) },
+		}
+		allocation, conn := newScriptedAllocation(t, script)
+		turnClient.setRelayedUDPConn(conn)
+		require.NoError(t, allocation.PreparePeer(context.Background(), peer))
 		payload := []byte("channel payload")
-		raw := buildChannelData(payload, harness.channel)
+		raw := buildChannelData(payload, channel)
 
-		require.NoError(t, harness.client.HandleInbound(raw, net.UDPAddrFromAddrPort(harness.server)))
+		require.NoError(t, turnClient.HandleInbound(raw, net.UDPAddrFromAddrPort(server)))
 		for i := range raw {
 			raw[i] = 0
 		}
 
-		result := readAllocation(t, harness.allocation, len(payload))
+		result := readAllocation(t, allocation, len(payload))
 		require.NoError(t, result.err)
 		assert.Equal(t, len(payload), result.n)
-		assert.Equal(t, harness.peer, result.from)
+		assert.Equal(t, peer, result.from)
 		assert.Equal(t, []byte("channel payload"), result.data)
 	})
 }
 
 func TestHandleInboundLiveUnknownChannelReturnsExistingErrorWithoutDelivery(t *testing.T) {
-	harness := newInboundDeliveryHarness(t)
+	server := netip.MustParseAddrPort("192.0.2.1:3478")
+	peer := netip.MustParseAddrPort("198.51.100.10:5000")
+	turnClient := &Client{server: server}
+	script := &scriptedAllocationScript{
+		onDeallocated: func(net.Addr) { turnClient.setRelayedUDPConn(nil) },
+	}
+	allocation, conn := newScriptedAllocation(t, script)
+	turnClient.setRelayedUDPConn(conn)
 	unknown := proto.ChannelNumber(proto.MinChannelNumber)
 
-	err := harness.client.HandleInbound(
+	err := turnClient.HandleInbound(
 		buildChannelData([]byte("unknown"), unknown),
-		net.UDPAddrFromAddrPort(harness.server),
+		net.UDPAddrFromAddrPort(server),
 	)
 
 	assert.ErrorIs(t, err, errChannelBindNotFound)
 	assert.EqualError(t, err, "no binding found for channel: 16384")
-	require.NoError(t, harness.client.HandleInbound(
-		buildDataIndication(t, []byte("marker"), harness.peer),
-		net.UDPAddrFromAddrPort(harness.server),
+	require.NoError(t, turnClient.HandleInbound(
+		buildDataIndication(t, []byte("marker"), peer),
+		net.UDPAddrFromAddrPort(server),
 	))
-	result := readAllocation(t, harness.allocation, len("marker"))
+	result := readAllocation(t, allocation, len("marker"))
 	require.NoError(t, result.err)
 	assert.Equal(t, []byte("marker"), result.data, "an unknown channel must not add a queue entry")
 }
@@ -397,22 +366,31 @@ func TestHandleInboundSilentlyDiscardsDecodedPeerDataWithoutLiveAllocation(t *te
 }
 
 func TestHandleInboundSilentlyDiscardsDecodedPeerDataThroughStaleSealedAllocation(t *testing.T) {
-	harness := newInboundDeliveryHarness(t)
-	require.NoError(t, harness.allocation.PreparePeer(context.Background(), harness.peer))
-	require.NoError(t, harness.conn.Close())
-	harness.client.setRelayedUDPConn(harness.conn)
+	server := netip.MustParseAddrPort("192.0.2.1:3478")
+	peer := netip.MustParseAddrPort("198.51.100.10:5000")
+	turnClient := &Client{server: server}
+	var channel proto.ChannelNumber
+	script := &scriptedAllocationScript{
+		onDeallocated: func(net.Addr) { turnClient.setRelayedUDPConn(nil) },
+		onChannelBind: func(msg *stun.Message) { require.NoError(t, channel.GetFrom(msg)) },
+	}
+	allocation, conn := newScriptedAllocation(t, script)
+	turnClient.setRelayedUDPConn(conn)
+	require.NoError(t, allocation.PreparePeer(context.Background(), peer))
+	require.NoError(t, conn.Close())
+	turnClient.setRelayedUDPConn(conn)
 
-	assert.NoError(t, harness.client.HandleInbound(
-		buildDataIndication(t, []byte("indication"), harness.peer),
-		net.UDPAddrFromAddrPort(harness.server),
+	assert.NoError(t, turnClient.HandleInbound(
+		buildDataIndication(t, []byte("indication"), peer),
+		net.UDPAddrFromAddrPort(server),
 	))
-	assert.NoError(t, harness.client.HandleInbound(
-		buildChannelData([]byte("known channel"), harness.channel),
-		net.UDPAddrFromAddrPort(harness.server),
+	assert.NoError(t, turnClient.HandleInbound(
+		buildChannelData([]byte("known channel"), channel),
+		net.UDPAddrFromAddrPort(server),
 	))
-	assert.NoError(t, harness.client.HandleInbound(
-		buildChannelData([]byte("unknown channel"), harness.channel+1),
-		net.UDPAddrFromAddrPort(harness.server),
+	assert.NoError(t, turnClient.HandleInbound(
+		buildChannelData([]byte("unknown channel"), channel+1),
+		net.UDPAddrFromAddrPort(server),
 	))
 }
 

--- a/docs/adr/2026-08-19-seam-deepening-program.md
+++ b/docs/adr/2026-08-19-seam-deepening-program.md
@@ -1,6 +1,6 @@
 # TURN Seam Deepening Program — 2026-08-19
 
-**Status:** Accepted; tracks not yet implemented
+**Status:** Accepted; T1.S1 implemented by PR #96; remaining slices not yet implemented
 
 ## What this is
 
@@ -23,12 +23,12 @@ Audit receipt: all six slices were independently slice-audited against `dad68d48
 
 | # | Track | Plan | Parent issue | Blocked by | Slices | Status |
 |---|---|---|---|---|---|---|
-| 1 | UDPConn construction and transaction crossing | [plan](2026-08-19-udpconn-construction-crossing-plan.md) | pending | None | 2 | FRONTIER (T1.S1, T1.S2) |
+| 1 | UDPConn construction and transaction crossing | [plan](2026-08-19-udpconn-construction-crossing-plan.md) | [#85](https://github.com/the-sarge/turn/issues/85) | None | 2 | FRONTIER (T1.S2); T1.S1 complete via PR #96 |
 | 2 | Allocate admission and public error vocabulary | [plan](2026-08-19-allocate-admission-errors-plan.md) | pending | None | 2 | FRONTIER (T2.S1, T2.S2) |
 | 3 | Permission readiness | [plan](2026-08-19-permission-readiness-plan.md) | pending | None | 1 | FRONTIER (T3.S1) |
 | 4 | Allocate exchange | [plan](2026-08-19-allocate-exchange-plan.md) | pending | None | 1 | FRONTIER (T4.S1) |
 
-There are no genuine blocking edges; every slice is independently green. T1.S1 → T1.S2 is the strongly recommended order (T1.S1's helpers are where T1.S2's crossing closures are scripted), and the recommended overall dispatch order to minimize rebases — advice, not a blocker — is T1.S1 → T1.S2 → T2.S1 → T2.S2 → T3.S1 → T4.S1. Known file overlaps: T1 and T3 both touch `internal/client/prepare_test.go`; T1.S2 and T2.S1 both touch `AllocationConfig`; T4.S1 is root-only but shares `client.go` (`sendAllocateRequest`, `Allocate`) with T1.S2 and T2.S1. Text conflicts between independently implemented slices require rebasing, not artificial blockers. T3.S1 and T4.S1 share no files with each other. Recommended starter: T1.S1.
+There are no genuine blocking edges; every remaining slice is independently green. T1.S1 landed before T1.S2 as strongly recommended, and the recommended remaining dispatch order to minimize rebases — advice, not a blocker — is T1.S2 → T2.S1 → T2.S2 → T3.S1 → T4.S1. Known file overlaps: T1 and T3 both touch `internal/client/prepare_test.go`; T1.S2 and T2.S1 both touch `AllocationConfig`; T4.S1 is root-only but shares `client.go` (`sendAllocateRequest`, `Allocate`) with T1.S2 and T2.S1. Text conflicts between independently implemented slices require rebasing, not artificial blockers. T3.S1 and T4.S1 share no files with each other. Recommended next slice: T1.S2.
 
 ## Rules that bind every track
 

--- a/docs/adr/2026-08-19-udpconn-construction-crossing-plan.md
+++ b/docs/adr/2026-08-19-udpconn-construction-crossing-plan.md
@@ -1,7 +1,7 @@
 # UDPConn Construction and Transaction Crossing Implementation Plan
 
 **Date:** 2026-08-19
-**Status:** Accepted; not yet implemented
+**Status:** T1.S1 implemented by PR #96; T1.S2 accepted and not yet implemented
 **Track:** 1 of 4 in the 2026-08-19 seam deepening program
 **Depends on:** Nothing — safe to start first; T1.S1 first is strongly recommended for T1.S2 but is not a blocker
 **Related:** [Program index](2026-08-19-seam-deepening-program.md), [Allocation lifecycle plan](2026-08-17-allocation-lifecycle-plan.md), [Transaction registry plan](2026-08-17-transaction-registry-plan.md), [Server-bound transport plan](2026-08-19-server-bound-transport-plan.md), [Allocation construction timing validity plan](2026-08-19-allocation-construction-timing-validity-plan.md)
@@ -46,7 +46,7 @@ Exact private Go spellings (`newUDPConn`, `start`, `newTestConn`, `emitRelease`,
 
 | Slice | Status/disposition | Delivers | Blocked by | Removes temporary seam |
 |---|---|---|---|---|
-| T1.S1 | New | `UDPConn` built by one constructor in production and tests; `mockClient.configure` and credential-carrying struct literals gone; one scripted helper per package | None | Private-field test construction |
+| T1.S1 | Complete via PR #96 | `UDPConn` built by one constructor in production and tests; `mockClient.configure` and credential-carrying struct literals gone; one scripted helper per package | None | Private-field test construction |
 | T1.S2 | New | Two named transaction crossings; `TransactionResult` and the `dontWait` flag gone; release emission has a name | None (T1.S1 first strongly recommended) | Mode flag on the crossing |
 
 ## Implementation Slices
@@ -54,6 +54,8 @@ Exact private Go spellings (`newUDPConn`, `start`, `newTestConn`, `emitRelease`,
 ### Slice T1.S1 — Build, then start: one construction seam for UDPConn
 
 **What it delivers:** One PR splitting `NewUDPConn` into unexported build and start steps (`NewUDPConn` = both, behavior unchanged), adding one scripted internal test constructor and one root `newScriptedAllocation` helper, deleting `mockClient`/`configure`, migrating the seven credential-carrying struct literals and the direct worker invocation to the helper, and collapsing the duplicated `AllocationConfig`/script/credential literals to the helper in both packages.
+
+**Implementation:** PR #96 is this slice's one product PR.
 
 **Existing-work disposition:** New slice. No open PR, branch, or review finding targets this seam as of 2026-08-19.
 
@@ -117,9 +119,9 @@ Exact private Go spellings (`newUDPConn`, `start`, `newTestConn`, `emitRelease`,
 
 ## Acceptance Criteria
 
-- [ ] `NewUDPConn` behaves exactly as before (started timers, same intervals, same abort panic) and is the only production constructor; an unexported build step establishes every invariant without goroutines and `Close` on a built-unstarted conn is valid. Domain: the finite construction paths in this repository; owner: `newUDPConn`/`start`; guarantee: universal over that set via the negative-grep evidence in T1.S1.
-- [ ] No test writes `UDPConn` private func fields after construction; `mockClient` and `configure` do not exist; `UDPConn{` literals exist only at the six retained controlled-linearization/queue sites named in the T1.S1 PR.
-- [ ] One scripted internal constructor and one root `newScriptedAllocation` replace `prepareHarness`'s construction, `allocHarness`, and `inboundDeliveryHarness`; `close_latency_test` keeps its own harness.
+- [x] `NewUDPConn` behaves exactly as before (started timers, same intervals, same abort panic) and is the only production constructor; an unexported build step establishes every invariant without goroutines and `Close` on a built-unstarted conn is valid. Domain: the finite construction paths in this repository; owner: `newUDPConn`/`start`; guarantee: universal over that set via the negative-grep evidence in T1.S1.
+- [x] No test writes `UDPConn` private func fields after construction; `mockClient` and `configure` do not exist; `UDPConn{` literals exist only at the six retained controlled-linearization/queue sites named in the T1.S1 PR.
+- [x] One scripted internal constructor and one root `newScriptedAllocation` replace `prepareHarness`'s construction, `allocHarness`, and `inboundDeliveryHarness`; `close_latency_test` keeps its own harness.
 - [ ] `AllocationConfig` exposes `PerformTransaction(msg) (*stun.Message, error)` and `StartTransaction(msg) error`; `TransactionResult`, `dontWait`, `ignoreResult`, and `Client.performTransaction` are absent; root wires registry method values.
 - [ ] The lifetime-zero release is emitted once from `startCloseLocked` via `StartTransaction`, byte-identical to today's after transaction-ID normalization, after abort and `onDeallocated`, and a failed emission is still joined into the terminal cause. Domain: the one release path; owner: `UDPConn.emitRelease`; guarantee: universal; evidence: txid-normalized byte equality plus the existing exactly-one-release and ordering tests.
 - [ ] Emitted Allocate/Refresh/CreatePermission/ChannelBind/ChannelData bytes, setter order, retransmission policy, public API, and Allocation lifecycle ownership are unchanged.

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -5,43 +5,89 @@ package client
 
 import (
 	"net"
+	"sync"
+	"testing"
+	"time"
 
 	"github.com/pion/stun/v3"
 )
 
-type mockClient struct {
+// testConnScript is the single internal test adapter for UDPConn's package
+// crossings. Method values read these fields at call time, so tests may
+// rescript an already-built connection without writing its private fields.
+type testConnScript struct {
 	writeTo            func(data []byte) (int, error)
 	performTransaction func(msg *stun.Message, dontWait bool) (TransactionResult, error)
 	onDeallocated      func(relayedAddr net.Addr)
+
+	writes struct {
+		sync.Mutex
+		data [][]byte
+	}
 }
 
-func (c *mockClient) WriteTo(data []byte) (int, error) {
-	if c.writeTo != nil {
-		return c.writeTo(data)
+func (s *testConnScript) WriteTo(data []byte) (int, error) {
+	s.writes.Lock()
+	s.writes.data = append(s.writes.data, append([]byte(nil), data...))
+	s.writes.Unlock()
+
+	if s.writeTo != nil {
+		return s.writeTo(data)
 	}
 
-	return 0, nil
+	return len(data), nil
 }
 
-func (c *mockClient) PerformTransaction(msg *stun.Message, dontWait bool) (TransactionResult, error) {
-	if c.performTransaction != nil {
-		return c.performTransaction(msg, dontWait)
+func (s *testConnScript) PerformTransaction(msg *stun.Message, dontWait bool) (TransactionResult, error) {
+	if s.performTransaction != nil {
+		return s.performTransaction(msg, dontWait)
 	}
 
 	return TransactionResult{}, errFake
 }
 
-func (c *mockClient) OnDeallocated(relayedAddr net.Addr) {
-	if c.onDeallocated != nil {
-		c.onDeallocated(relayedAddr)
+func (s *testConnScript) OnDeallocated(relayedAddr net.Addr) {
+	if s.onDeallocated != nil {
+		s.onDeallocated(relayedAddr)
 	}
 }
 
-// configure installs the mock's package-crossing operations on conn. The
-// method values dispatch through the mock's fields at call time, so a test
-// may rescript the mock after the allocation is built.
-func (c *mockClient) configure(conn *UDPConn) {
-	conn.writeTo = c.WriteTo
-	conn.performTransaction = c.PerformTransaction
-	conn.onDeallocated = c.OnDeallocated
+func (s *testConnScript) writeCount() int {
+	s.writes.Lock()
+	defer s.writes.Unlock()
+
+	return len(s.writes.data)
+}
+
+func (s *testConnScript) lastWrite() []byte {
+	s.writes.Lock()
+	defer s.writes.Unlock()
+
+	if len(s.writes.data) == 0 {
+		return nil
+	}
+
+	return s.writes.data[len(s.writes.data)-1]
+}
+
+func testAllocationConfig(script *testConnScript) *AllocationConfig {
+	return &AllocationConfig{
+		WriteTo:            script.WriteTo,
+		PerformTransaction: script.PerformTransaction,
+		OnDeallocated:      script.OnDeallocated,
+		RelayedAddr:        &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 54321},
+		Username:           stun.NewUsername("user"),
+		Realm:              stun.NewRealm("realm"),
+		Integrity:          stun.NewShortTermIntegrity("pass"),
+		Nonce:              stun.NewNonce("nonce"),
+		Lifetime:           time.Hour,
+	}
+}
+
+// newTestConn builds an unstarted UDPConn through the same invariant-owning
+// constructor as production. Tests that exercise timers call start explicitly.
+func newTestConn(t *testing.T, script *testConnScript) *UDPConn {
+	t.Helper()
+
+	return newUDPConn(testAllocationConfig(script), func() {})
 }

--- a/internal/client/prepare_test.go
+++ b/internal/client/prepare_test.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -23,7 +22,7 @@ import (
 // prepareHarness drives a NewUDPConn against a scripted mock TURN server.
 type prepareHarness struct {
 	conn       *UDPConn
-	mock       *mockClient
+	script     *testConnScript
 	peer       netip.AddrPort
 	permCount  atomic.Int32
 	bindCount  atomic.Int32
@@ -31,10 +30,6 @@ type prepareHarness struct {
 	permGate   chan struct{} // If non-nil, CreatePermission transactions block on it
 	failPerms  atomic.Bool   // If set, CreatePermission transactions return 403
 	staleNonce atomic.Bool   // If set, CreatePermission transactions return 438
-	writes     struct {
-		sync.Mutex
-		data [][]byte
-	}
 }
 
 func newPrepareHarness(t *testing.T, gateBinds bool) *prepareHarness {
@@ -47,7 +42,7 @@ func newPrepareHarness(t *testing.T, gateBinds bool) *prepareHarness {
 		harness.bindGate = make(chan struct{})
 	}
 
-	mock := &mockClient{
+	script := &testConnScript{
 		performTransaction: func(msg *stun.Message, _ bool) (TransactionResult, error) {
 			switch msg.Type.Method {
 			case stun.MethodCreatePermission:
@@ -87,48 +82,21 @@ func newPrepareHarness(t *testing.T, gateBinds bool) *prepareHarness {
 				return TransactionResult{}, errFake
 			}
 		},
-		writeTo: func(data []byte) (int, error) {
-			harness.writes.Lock()
-			harness.writes.data = append(harness.writes.data, append([]byte(nil), data...))
-			harness.writes.Unlock()
-
-			return len(data), nil
-		},
 	}
 
-	harness.mock = mock
-	harness.conn = NewUDPConn(&AllocationConfig{
-		WriteTo:            mock.WriteTo,
-		PerformTransaction: mock.PerformTransaction,
-		OnDeallocated:      mock.OnDeallocated,
-		RelayedAddr:        &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 54321},
-		Username:           stun.NewUsername("user"),
-		Realm:              stun.NewRealm("realm"),
-		Integrity:          stun.NewShortTermIntegrity("pass"),
-		Nonce:              stun.NewNonce("nonce"),
-		Lifetime:           time.Hour,
-	}, func() {})
+	harness.script = script
+	harness.conn = newTestConn(t, script)
 	t.Cleanup(func() { _ = harness.conn.Close() })
 
 	return harness
 }
 
 func (harness *prepareHarness) writeCount() int {
-	harness.writes.Lock()
-	defer harness.writes.Unlock()
-
-	return len(harness.writes.data)
+	return harness.script.writeCount()
 }
 
 func (harness *prepareHarness) lastWrite() []byte {
-	harness.writes.Lock()
-	defer harness.writes.Unlock()
-
-	if len(harness.writes.data) == 0 {
-		return nil
-	}
-
-	return harness.writes.data[len(harness.writes.data)-1]
+	return harness.script.lastWrite()
 }
 
 func fillBindingManager(t *testing.T, mgr *bindingManager) {
@@ -485,7 +453,7 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 		harness := newPrepareHarness(t, false)
 
 		// First permission succeeds, but every ChannelBind transaction fails.
-		mock := harness.mock
+		mock := harness.script
 		inner := mock.performTransaction
 		mock.performTransaction = func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
 			if msg.Type.Method == stun.MethodChannelBind {
@@ -510,7 +478,7 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 	t.Run("joined bind failure is attempt-local for every waiter", func(t *testing.T) {
 		harness := newPrepareHarness(t, false)
 		gate := make(chan struct{})
-		mock := harness.mock
+		mock := harness.script
 		inner := mock.performTransaction
 		mock.performTransaction = func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
 			if msg.Type.Method == stun.MethodChannelBind {
@@ -543,7 +511,7 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 	t.Run("server bind rejection surfaces typed TURN error", func(t *testing.T) {
 		harness := newPrepareHarness(t, false)
 
-		mock := harness.mock
+		mock := harness.script
 		inner := mock.performTransaction
 		mock.performTransaction = func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
 			if msg.Type.Method == stun.MethodChannelBind {

--- a/internal/client/refresh_failure_test.go
+++ b/internal/client/refresh_failure_test.go
@@ -41,7 +41,7 @@ func newRefreshFailureHarness(
 	t.Helper()
 
 	harness := &refreshFailureHarness{waitedRefresh: waited, emitErr: emitErr}
-	mock := &mockClient{
+	script := &testConnScript{
 		performTransaction: func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
 			switch msg.Type.Method {
 			case stun.MethodRefresh:
@@ -73,17 +73,7 @@ func newRefreshFailureHarness(
 		},
 	}
 
-	harness.conn = NewUDPConn(&AllocationConfig{
-		WriteTo:            mock.WriteTo,
-		PerformTransaction: mock.PerformTransaction,
-		OnDeallocated:      mock.OnDeallocated,
-		RelayedAddr:        &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 54321},
-		Username:           stun.NewUsername("user"),
-		Realm:              stun.NewRealm("realm"),
-		Integrity:          stun.NewShortTermIntegrity("pass"),
-		Nonce:              stun.NewNonce("nonce"),
-		Lifetime:           time.Hour, // The periodic timer never fires inside a test.
-	}, func() {})
+	harness.conn = newTestConn(t, script)
 
 	return harness
 }

--- a/internal/client/udp_conn.go
+++ b/internal/client/udp_conn.go
@@ -93,6 +93,15 @@ type UDPConn struct {
 // required capability: every allocation must be able to wake its pending
 // transaction waits before deallocation and lifetime-zero release.
 func NewUDPConn(config *AllocationConfig, abortTransactions func()) *UDPConn {
+	conn := newUDPConn(config, abortTransactions)
+	conn.start()
+
+	return conn
+}
+
+// newUDPConn builds a UDPConn with every construction invariant established
+// but no timer goroutines started.
+func newUDPConn(config *AllocationConfig, abortTransactions func()) *UDPConn {
 	if abortTransactions == nil {
 		panic("client: missing abort capability") //nolint:forbidigo // Programmer-invalid internal construction.
 	}
@@ -150,11 +159,14 @@ func NewUDPConn(config *AllocationConfig, abortTransactions func()) *UDPConn {
 		bindingCheckInterval,
 	)
 
-	conn.refreshAllocTimer.Start()
-	conn.refreshPermsTimer.Start()
-	conn.checkBindingsTimer.Start()
-
 	return conn
+}
+
+// start arms every timer owned by the allocation.
+func (c *UDPConn) start() {
+	c.refreshAllocTimer.Start()
+	c.refreshPermsTimer.Start()
+	c.checkBindingsTimer.Start()
 }
 
 // ReadFrom reads one relayed datagram, copying the payload into p. It returns

--- a/internal/client/udp_conn_test.go
+++ b/internal/client/udp_conn_test.go
@@ -49,25 +49,52 @@ func (e *timeoutError) Timeout() bool {
 }
 
 func TestNewUDPConnRejectsMissingAbortBeforeStartingWork(t *testing.T) {
-	mock := &mockClient{}
+	mock := &testConnScript{}
 	var conn *UDPConn
 
 	require.Panics(t, func() {
-		conn = NewUDPConn(&AllocationConfig{
-			WriteTo:            mock.WriteTo,
-			PerformTransaction: mock.PerformTransaction,
-			OnDeallocated:      mock.OnDeallocated,
-			RelayedAddr:        &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 54321},
-			Username:           stun.NewUsername("user"),
-			Realm:              stun.NewRealm("realm"),
-			Integrity:          stun.NewShortTermIntegrity("pass"),
-			Nonce:              stun.NewNonce("nonce"),
-			Lifetime:           time.Hour,
-		}, nil)
+		conn = NewUDPConn(testAllocationConfig(mock), nil)
 	})
 	if conn != nil {
 		_ = conn.Close()
 	}
+}
+
+func TestNewUDPConnBuildsUnstartedAndClosesOnce(t *testing.T) {
+	var releases atomic.Int32
+	mock := &testConnScript{
+		performTransaction: func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
+			if msg.Type.Method == stun.MethodRefresh && dontWait {
+				releases.Add(1)
+			}
+
+			return TransactionResult{}, nil
+		},
+	}
+	conn := newTestConn(t, mock)
+
+	assert.False(t, conn.refreshAllocTimer.IsRunning())
+	assert.False(t, conn.refreshPermsTimer.IsRunning())
+	assert.False(t, conn.checkBindingsTimer.IsRunning())
+	require.NoError(t, conn.Close())
+	assert.Equal(t, int32(1), releases.Load())
+	assert.False(t, conn.refreshAllocTimer.IsRunning())
+	assert.False(t, conn.refreshPermsTimer.IsRunning())
+	assert.False(t, conn.checkBindingsTimer.IsRunning())
+}
+
+func TestNewUDPConnStartsTimers(t *testing.T) {
+	mock := &testConnScript{
+		performTransaction: func(*stun.Message, bool) (TransactionResult, error) {
+			return TransactionResult{}, nil
+		},
+	}
+	conn := NewUDPConn(testAllocationConfig(mock), func() {})
+	t.Cleanup(func() { _ = conn.Close() })
+
+	assert.True(t, conn.refreshAllocTimer.IsRunning())
+	assert.True(t, conn.refreshPermsTimer.IsRunning())
+	assert.True(t, conn.checkBindingsTimer.IsRunning())
 }
 
 func TestUDPConnHandleDataIndicationOwnsQueuedPayload(t *testing.T) {
@@ -129,24 +156,11 @@ func TestUDPConnHandleChannelDataDeliversAssignedUnpreparedBinding(t *testing.T)
 func newInboundDeliveryConn(t *testing.T) *UDPConn {
 	t.Helper()
 
-	conn := NewUDPConn(&AllocationConfig{
-		WriteTo: func(data []byte) (int, error) {
-			return len(data), nil
-		},
-		PerformTransaction: func(*stun.Message, bool) (TransactionResult, error) {
+	return newTestConn(t, &testConnScript{
+		performTransaction: func(*stun.Message, bool) (TransactionResult, error) {
 			return TransactionResult{}, nil
 		},
-		OnDeallocated: func(net.Addr) {},
-		RelayedAddr:   &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 54321},
-		Username:      stun.NewUsername("user"),
-		Realm:         stun.NewRealm("realm"),
-		Integrity:     stun.NewShortTermIntegrity("pass"),
-		Nonce:         stun.NewNonce("nonce"),
-		Lifetime:      time.Hour,
-	}, func() {})
-	t.Cleanup(func() { _ = conn.Close() })
-
-	return conn
+	})
 }
 
 func TestUDPConnDecodedDeliveryQueueAndSealDispositions(t *testing.T) {
@@ -213,11 +227,11 @@ func assertRequestShape(
 }
 
 func TestRefreshAllocationPreservesRequestAndRetriesStaleNonce(t *testing.T) {
-	const lifetime = 10 * time.Minute
+	const lifetime = time.Hour
 	username := stun.NewUsername("user")
 	realm := stun.NewRealm("realm")
 	integrity := stun.NewShortTermIntegrity("pass")
-	oldNonce := stun.NewNonce("old-nonce")
+	oldNonce := stun.NewNonce("nonce")
 	freshNonce := stun.NewNonce("fresh-nonce")
 
 	for _, tt := range []struct {
@@ -230,7 +244,7 @@ func TestRefreshAllocationPreservesRequestAndRetriesStaleNonce(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			calls := 0
-			mock := &mockClient{
+			script := &testConnScript{
 				performTransaction: func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
 					calls++
 					assert.False(t, dontWait)
@@ -268,14 +282,7 @@ func TestRefreshAllocationPreservesRequestAndRetriesStaleNonce(t *testing.T) {
 					)}, nil
 				},
 			}
-			conn := UDPConn{
-				username:  username,
-				realm:     realm,
-				integrity: integrity,
-				_nonce:    oldNonce,
-				_lifetime: lifetime,
-			}
-			mock.configure(&conn)
+			conn := newTestConn(t, script)
 
 			conn.refreshAllocationWithRetries()
 
@@ -297,10 +304,8 @@ func TestPermissionAndBindingRequestShapes(t *testing.T) {
 	nonce := stun.NewNonce("nonce")
 	peerA := netip.MustParseAddrPort("192.0.2.1:5000")
 	peerB := netip.MustParseAddrPort("192.0.2.2:6000")
-	bindingMgr := newBindingManager()
-	bound := requireBinding(t, bindingMgr, peerA)
-
-	mock := &mockClient{
+	var bound *binding
+	script := &testConnScript{
 		performTransaction: func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
 			assert.False(t, dontWait)
 			switch msg.Type.Method {
@@ -355,28 +360,16 @@ func TestPermissionAndBindingRequestShapes(t *testing.T) {
 			}
 		},
 	}
-	conn := UDPConn{
-		username:   username,
-		realm:      realm,
-		integrity:  integrity,
-		_nonce:     nonce,
-		bindingMgr: bindingMgr,
-	}
-	mock.configure(&conn)
+	conn := newTestConn(t, script)
+	bound = requireBinding(t, conn.bindingMgr, peerA)
 
 	require.NoError(t, conn.CreatePermissions(peerA, peerB))
 	require.NoError(t, conn.bind(bound))
 }
 
 func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
-	makeConn := func(client *mockClient, bm *bindingManager) *UDPConn {
-		conn := UDPConn{
-			bindingMgr:             bm,
-			bindingRefreshInterval: defaultBindingRefreshInterval,
-		}
-		client.configure(&conn)
-
-		return &conn
+	makeConn := func(script *testConnScript) *UDPConn {
+		return newTestConn(t, script)
 	}
 
 	staleNonceMsg := func() *stun.Message {
@@ -396,13 +389,12 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 
 	t.Run("maybeBind()", func(t *testing.T) {
 		t.Run("fresh success becomes preparable", func(t *testing.T) {
-			bm := newBindingManager()
-			bound := requireBinding(t, bm, netip.MustParseAddrPort("127.0.0.1:1234"))
-			conn := makeConn(&mockClient{
+			conn := makeConn(&testConnScript{
 				performTransaction: func(*stun.Message, bool) (TransactionResult, error) {
 					return TransactionResult{Msg: new(stun.Message)}, nil
 				},
-			}, bm)
+			})
+			bound := requireBinding(t, conn.bindingMgr, netip.MustParseAddrPort("127.0.0.1:1234"))
 
 			conn.maybeBind(bound)
 			assert.Eventually(t, func() bool {
@@ -417,34 +409,32 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		})
 
 		t.Run("recent confirmation does not refresh", func(t *testing.T) {
-			bm := newBindingManager()
-			bound := requireBinding(t, bm, netip.MustParseAddrPort("127.0.0.1:1234"))
-			confirmBindingAt(t, bound, time.Now())
 			var attempts atomic.Int32
-			conn := makeConn(&mockClient{
+			conn := makeConn(&testConnScript{
 				performTransaction: func(*stun.Message, bool) (TransactionResult, error) {
 					attempts.Add(1)
 
 					return TransactionResult{Msg: new(stun.Message)}, nil
 				},
-			}, bm)
+			})
+			bound := requireBinding(t, conn.bindingMgr, netip.MustParseAddrPort("127.0.0.1:1234"))
+			confirmBindingAt(t, bound, time.Now())
 
 			conn.maybeBind(bound)
 			assert.Equal(t, int32(0), attempts.Load())
 		})
 
 		t.Run("stale confirmation refreshes", func(t *testing.T) {
-			bm := newBindingManager()
-			bound := requireBinding(t, bm, netip.MustParseAddrPort("127.0.0.1:1234"))
-			confirmBindingAt(t, bound, time.Now().Add(-defaultBindingRefreshInterval-time.Minute))
 			var attempts atomic.Int32
-			conn := makeConn(&mockClient{
+			conn := makeConn(&testConnScript{
 				performTransaction: func(*stun.Message, bool) (TransactionResult, error) {
 					attempts.Add(1)
 
 					return TransactionResult{Msg: new(stun.Message)}, nil
 				},
-			}, bm)
+			})
+			bound := requireBinding(t, conn.bindingMgr, netip.MustParseAddrPort("127.0.0.1:1234"))
+			confirmBindingAt(t, bound, time.Now().Add(-defaultBindingRefreshInterval-time.Minute))
 
 			conn.maybeBind(bound)
 			assert.Eventually(t, func() bool { return attempts.Load() == 1 }, 5*time.Second, 10*time.Millisecond)
@@ -523,9 +513,8 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				bm := newBindingManager()
-				bound := requireBinding(t, bm, netip.MustParseAddrPort("127.0.0.1:1234"))
-				conn := makeConn(&mockClient{performTransaction: tt.transactionFn}, bm)
+				conn := makeConn(&testConnScript{performTransaction: tt.transactionFn})
+				bound := requireBinding(t, conn.bindingMgr, netip.MustParseAddrPort("127.0.0.1:1234"))
 
 				nonceT0 := conn.nonce()
 
@@ -548,14 +537,14 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 				}
 
 				if tt.expectBindingDeleted {
-					assert.Empty(t, bm.chanMap)
-					assert.Empty(t, bm.addrMap)
+					assert.Empty(t, conn.bindingMgr.chanMap)
+					assert.Empty(t, conn.bindingMgr.addrMap)
 				} else {
 					// Binding should remain so we don't re-bind the same peer with a different channel number
 					// after a lost/failed ChannelBind transaction.
-					assert.NotEmpty(t, bm.chanMap)
-					assert.NotEmpty(t, bm.addrMap)
-					b2, ok := bm.findByAddr(bound.addr)
+					assert.NotEmpty(t, conn.bindingMgr.chanMap)
+					assert.NotEmpty(t, conn.bindingMgr.addrMap)
+					b2, ok := conn.bindingMgr.findByAddr(bound.addr)
 					assert.True(t, ok)
 					assert.Equal(t, bound.number, b2.number)
 				}
@@ -572,16 +561,15 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 	})
 
 	t.Run("bindChannel exhausts stale nonce retries without a typed TURN error", func(t *testing.T) {
-		bm := newBindingManager()
-		bound := requireBinding(t, bm, netip.MustParseAddrPort("127.0.0.1:1234"))
 		var attempts atomic.Int32
-		conn := makeConn(&mockClient{
+		conn := makeConn(&testConnScript{
 			performTransaction: func(*stun.Message, bool) (TransactionResult, error) {
 				attempts.Add(1)
 
 				return TransactionResult{Msg: staleNonceMsg()}, nil
 			},
-		}, bm)
+		})
+		bound := requireBinding(t, conn.bindingMgr, netip.MustParseAddrPort("127.0.0.1:1234"))
 
 		token, class, started := bound.beginAttempt(time.Now(), defaultBindingRefreshInterval)
 		require.True(t, started)
@@ -598,10 +586,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 	t.Run("maybeBind() retries unknown binding after transaction failure", func(t *testing.T) {
 		var failed atomic.Bool
 
-		bm := newBindingManager()
-		bound := requireBinding(t, bm, netip.MustParseAddrPort("127.0.0.1:1234"))
-		originalCh := bound.number
-		conn := makeConn(&mockClient{
+		conn := makeConn(&testConnScript{
 			performTransaction: func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
 				if failed.CompareAndSwap(false, true) {
 					return TransactionResult{}, errFake
@@ -609,7 +594,9 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 
 				return TransactionResult{Msg: new(stun.Message)}, nil
 			},
-		}, bm)
+		})
+		bound := requireBinding(t, conn.bindingMgr, netip.MustParseAddrPort("127.0.0.1:1234"))
+		originalCh := bound.number
 
 		conn.maybeBind(bound)
 		assert.Eventually(t, func() bool {
@@ -629,7 +616,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 			return final && err == nil
 		}, 5*time.Second, 10*time.Millisecond)
 
-		b2, ok := bm.findByAddr(bound.addr)
+		b2, ok := conn.bindingMgr.findByAddr(bound.addr)
 		assert.True(t, ok)
 		assert.Equal(t, originalCh, b2.number)
 	})
@@ -642,7 +629,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		refreshDontWaitCh := make(chan bool, 1)
 		refreshErrCh := make(chan error, 1)
 
-		client := &mockClient{
+		script := &testConnScript{
 			performTransaction: func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
 				switch msg.Type.Method {
 				case stun.MethodChannelBind:
@@ -671,18 +658,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 			},
 		}
 
-		conn := NewUDPConn(&AllocationConfig{
-			WriteTo:            client.WriteTo,
-			PerformTransaction: client.PerformTransaction,
-			OnDeallocated:      client.OnDeallocated,
-			RelayedAddr:        relayedAddr,
-			Username:           stun.NewUsername("user"),
-			Realm:              stun.NewRealm("realm"),
-			Integrity:          stun.NewShortTermIntegrity("pass"),
-			Nonce:              stun.NewNonce("nonce"),
-			Lifetime:           time.Hour,
-		}, func() {})
-		defer func() { _ = conn.Close() }()
+		conn := newTestConn(t, script)
 
 		bound := requireBinding(t, conn.bindingMgr, peerAddr)
 		conn.maybeBind(bound)
@@ -734,7 +710,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		var channelBindAttempts atomic.Int32
 		deallocatedCh := make(chan net.Addr, 1)
 
-		client := &mockClient{
+		script := &testConnScript{
 			performTransaction: func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
 				switch msg.Type.Method {
 				case stun.MethodChannelBind:
@@ -753,18 +729,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 				deallocatedCh <- addr
 			},
 		}
-		conn := NewUDPConn(&AllocationConfig{
-			WriteTo:            client.WriteTo,
-			PerformTransaction: client.PerformTransaction,
-			OnDeallocated:      client.OnDeallocated,
-			RelayedAddr:        relayedAddr,
-			Username:           stun.NewUsername("user"),
-			Realm:              stun.NewRealm("realm"),
-			Integrity:          stun.NewShortTermIntegrity("pass"),
-			Nonce:              stun.NewNonce("nonce"),
-			Lifetime:           time.Hour,
-		}, func() {})
-		defer func() { _ = conn.Close() }()
+		conn := newTestConn(t, script)
 
 		bound := requireBinding(t, conn.bindingMgr, peerAddr)
 
@@ -796,11 +761,10 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 	})
 
 	t.Run("ChannelBind 400 after lost ready refresh keeps saved binding", func(t *testing.T) {
-		relayedAddr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 54321}
 		peerAddr := netip.MustParseAddrPort("127.0.0.1:1234")
 		var channelBindAttempts atomic.Int32
 
-		client := &mockClient{
+		script := &testConnScript{
 			performTransaction: func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
 				switch msg.Type.Method {
 				case stun.MethodChannelBind:
@@ -816,18 +780,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 				}
 			},
 		}
-		conn := NewUDPConn(&AllocationConfig{
-			WriteTo:            client.WriteTo,
-			PerformTransaction: client.PerformTransaction,
-			OnDeallocated:      client.OnDeallocated,
-			RelayedAddr:        relayedAddr,
-			Username:           stun.NewUsername("user"),
-			Realm:              stun.NewRealm("realm"),
-			Integrity:          stun.NewShortTermIntegrity("pass"),
-			Nonce:              stun.NewNonce("nonce"),
-			Lifetime:           time.Hour,
-		}, func() {})
-		defer func() { _ = conn.Close() }()
+		conn := newTestConn(t, script)
 
 		bound := requireBinding(t, conn.bindingMgr, peerAddr)
 		staleRefreshedAt := time.Now().Add(-(defaultBindingRefreshInterval + time.Minute))
@@ -858,18 +811,17 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 	})
 
 	t.Run("ChannelBind 400 refresh keeps saved binding", func(t *testing.T) {
-		bm := newBindingManager()
-		bound := requireBinding(t, bm, netip.MustParseAddrPort("127.0.0.1:1234"))
 		staleRefreshedAt := time.Now().Add(-(defaultBindingRefreshInterval + time.Minute))
 		var channelBindAttempts atomic.Int32
-		confirmBindingAt(t, bound, staleRefreshedAt)
-		conn := makeConn(&mockClient{
+		conn := makeConn(&testConnScript{
 			performTransaction: func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
 				channelBindAttempts.Add(1)
 
 				return TransactionResult{Msg: badRequestMsg()}, nil
 			},
-		}, bm)
+		})
+		bound := requireBinding(t, conn.bindingMgr, netip.MustParseAddrPort("127.0.0.1:1234"))
+		confirmBindingAt(t, bound, staleRefreshedAt)
 
 		conn.maybeBind(bound)
 		assert.Eventually(t, func() bool {
@@ -884,7 +836,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 	})
 
 	t.Run("WriteTo()", func(t *testing.T) {
-		client := &mockClient{
+		script := &testConnScript{
 			performTransaction: func(*stun.Message, bool) (TransactionResult, error) {
 				return TransactionResult{}, errFake
 			},
@@ -895,23 +847,16 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 
 		addr := netip.MustParseAddrPort("127.0.0.1:1234")
 
-		pm := newPermissionMap()
-		assert.True(t, pm.insert(addr, &permission{
+		conn := newTestConn(t, script)
+		assert.True(t, conn.permMap.insert(addr, &permission{
 			st: permStatePermitted,
 		}))
 
-		bm := newBindingManager()
-		binding := requireBinding(t, bm, addr)
+		binding := requireBinding(t, conn.bindingMgr, addr)
 		confirmBindingAt(t, binding, time.Now())
 		final, err := binding.preparationAccess(time.Now())
 		require.True(t, final)
 		require.NoError(t, err)
-
-		conn := UDPConn{
-			permMap:    pm,
-			bindingMgr: bm,
-		}
-		client.configure(&conn)
 
 		buf := []byte("Hello")
 		n, err := conn.WriteTo(buf, addr)
@@ -921,14 +866,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 
 	t.Run("ChannelBind transaction failure retains channel number", func(t *testing.T) {
 		addr := netip.MustParseAddrPort("127.0.0.1:9999")
-		pm := newPermissionMap()
-		assert.True(t, pm.insert(addr, &permission{st: permStatePermitted}))
-
-		bm := newBindingManager()
-		bound := requireBinding(t, bm, addr)
-		originalCh := bound.number
-
-		client := &mockClient{
+		script := &testConnScript{
 			performTransaction: func(*stun.Message, bool) (TransactionResult, error) {
 				return TransactionResult{}, errFake
 			},
@@ -936,16 +874,10 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 				return len(data), nil
 			},
 		}
-
-		conn := UDPConn{
-			permMap:    pm,
-			username:   stun.NewUsername("user"),
-			realm:      stun.NewRealm("realm"),
-			integrity:  stun.NewShortTermIntegrity("pass"),
-			_nonce:     stun.NewNonce("nonce"),
-			bindingMgr: bm,
-		}
-		client.configure(&conn)
+		conn := newTestConn(t, script)
+		assert.True(t, conn.permMap.insert(addr, &permission{st: permStatePermitted}))
+		bound := requireBinding(t, conn.bindingMgr, addr)
+		originalCh := bound.number
 
 		// A failed bind attempt should not remove the binding: the same peer keeps
 		// its channel number, and a write (which fails, unprepared) does not
@@ -956,7 +888,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		_, err = conn.WriteTo([]byte("hi"), addr)
 		assert.ErrorIs(t, err, ErrNotPrepared)
 
-		b2, ok := bm.findByAddr(addr)
+		b2, ok := conn.bindingMgr.findByAddr(addr)
 		assert.True(t, ok)
 		assert.Equal(t, originalCh, b2.number)
 	})
@@ -1030,7 +962,7 @@ func TestUDPConnBindingAttemptResultOwnership(t *testing.T) {
 func TestCreatePermissions(t *testing.T) {
 	t.Run("CreatePermissions success", func(t *testing.T) {
 		called := false
-		client := &mockClient{
+		script := &testConnScript{
 			performTransaction: func(msg *stun.Message, _ bool) (TransactionResult, error) {
 				called = true
 				// Simulate a successful response
@@ -1040,13 +972,7 @@ func TestCreatePermissions(t *testing.T) {
 				return TransactionResult{Msg: res}, nil
 			},
 		}
-		conn := &UDPConn{
-			username:  stun.NewUsername("user"),
-			realm:     stun.NewRealm("realm"),
-			integrity: stun.NewShortTermIntegrity("pass"),
-			_nonce:    stun.NewNonce("nonce"),
-		}
-		client.configure(conn)
+		conn := newTestConn(t, script)
 		addr := netip.MustParseAddrPort("5.6.7.8:12345")
 		err := conn.CreatePermissions(addr)
 		assert.NoError(t, err)
@@ -1054,7 +980,7 @@ func TestCreatePermissions(t *testing.T) {
 	})
 
 	t.Run("CreatePermissions error", func(t *testing.T) {
-		client := &mockClient{
+		script := &testConnScript{
 			performTransaction: func(msg *stun.Message, _ bool) (TransactionResult, error) {
 				res := stun.New()
 				res.Type = stun.NewType(stun.MethodCreatePermission, stun.ClassErrorResponse)
@@ -1067,13 +993,7 @@ func TestCreatePermissions(t *testing.T) {
 				return TransactionResult{Msg: res}, nil
 			},
 		}
-		conn := &UDPConn{
-			username:  stun.NewUsername("user"),
-			realm:     stun.NewRealm("realm"),
-			integrity: stun.NewShortTermIntegrity("pass"),
-			_nonce:    stun.NewNonce("nonce"),
-		}
-		client.configure(conn)
+		conn := newTestConn(t, script)
 		addr := netip.MustParseAddrPort("5.6.7.8:12345")
 		err := conn.CreatePermissions(addr)
 		var turnErr *stun.TurnError

--- a/scripted_allocation_test.go
+++ b/scripted_allocation_test.go
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+//go:build !js
+
+package turn
+
+import (
+	"net"
+	"net/netip"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pion/stun/v3"
+	"github.com/the-sarge/turn/v5/internal/client"
+)
+
+type scriptedAllocationScript struct {
+	performTransaction func(msg *stun.Message, dontWait bool) (client.TransactionResult, error)
+	onDeallocated      func(relayedAddr net.Addr)
+	onChannelBind      func(msg *stun.Message)
+	permissionCount    atomic.Int32
+	bindingCount       atomic.Int32
+
+	writes struct {
+		sync.Mutex
+		data [][]byte
+	}
+}
+
+func (s *scriptedAllocationScript) writeTo(data []byte) (int, error) {
+	s.writes.Lock()
+	s.writes.data = append(s.writes.data, append([]byte(nil), data...))
+	s.writes.Unlock()
+
+	return len(data), nil
+}
+
+func (s *scriptedAllocationScript) transact(
+	msg *stun.Message, dontWait bool,
+) (client.TransactionResult, error) {
+	if s.performTransaction != nil {
+		return s.performTransaction(msg, dontWait)
+	}
+
+	switch msg.Type.Method {
+	case stun.MethodCreatePermission:
+		s.permissionCount.Add(1)
+
+		return client.TransactionResult{Msg: stun.MustBuild(
+			stun.NewType(stun.MethodCreatePermission, stun.ClassSuccessResponse),
+		)}, nil
+	case stun.MethodChannelBind:
+		s.bindingCount.Add(1)
+		if s.onChannelBind != nil {
+			s.onChannelBind(msg)
+		}
+
+		return client.TransactionResult{Msg: stun.MustBuild(
+			stun.NewType(stun.MethodChannelBind, stun.ClassSuccessResponse),
+		)}, nil
+	default:
+		return client.TransactionResult{}, nil
+	}
+}
+
+func (s *scriptedAllocationScript) deallocated(relayedAddr net.Addr) {
+	if s.onDeallocated != nil {
+		s.onDeallocated(relayedAddr)
+	}
+}
+
+func (s *scriptedAllocationScript) lastWrite() []byte {
+	s.writes.Lock()
+	defer s.writes.Unlock()
+
+	if len(s.writes.data) == 0 {
+		return nil
+	}
+
+	return s.writes.data[len(s.writes.data)-1]
+}
+
+func newScriptedAllocation(
+	t *testing.T, script *scriptedAllocationScript,
+) (*Allocation, *client.UDPConn) {
+	t.Helper()
+
+	relayed := netip.MustParseAddrPort("127.0.0.1:54321")
+	conn := client.NewUDPConn(&client.AllocationConfig{
+		WriteTo:            script.writeTo,
+		PerformTransaction: script.transact,
+		OnDeallocated:      script.deallocated,
+		RelayedAddr:        net.UDPAddrFromAddrPort(relayed),
+		Username:           stun.NewUsername("user"),
+		Realm:              stun.NewRealm("realm"),
+		Integrity:          stun.NewShortTermIntegrity("pass"),
+		Nonce:              stun.NewNonce("nonce"),
+		Lifetime:           time.Hour,
+	}, func() {})
+	t.Cleanup(func() { _ = conn.Close() })
+
+	return newAllocation(conn, relayed), conn
+}


### PR DESCRIPTION
## Summary

- split UDPConn construction into an invariant-owning build step and one timer-start seam
- replace mutable private-field test setup with one scripted constructor per package
- retain only the six audited minimal-state UDPConn literals

Closes #89
Parent: #85
Plan: `docs/adr/2026-08-19-udpconn-construction-crossing-plan.md`
Plan commit: `dfee1df4bbd4d828f9185b1fa6afc94161b4139d`
Slice: `Slice T1.S1 — Build, then start: one construction seam for UDPConn`

## Contract

Supported domain: the finite production, helper, and six retained construction paths in this repository. `newUDPConn` owns construction invariants; `start` owns timer arming. The guarantee is universal over that finite set. Test fixtures are verification aids, not maintained product deliverables. Contract closure is not triggered.

## Validation

- `go test ./... -count=1`
- `go test -race ./... -count=1`
- negative census: no `mockClient` or `configure`; exactly six retained `UDPConn{` sites; timer starts centralized in `start`

## Retained internal-seam literals

The six retained sites are the three capacity-one queue cases, the completion-versus-seal case, and the two minimal attempt-result ownership cases in `internal/client/udp_conn_test.go`.