### PR TITLE
Name waited and fire-and-forget transaction crossings

### DIFF
--- a/allocation_test.go
+++ b/allocation_test.go
@@ -189,5 +189,9 @@ func TestDeletedSurfaceDoesNotResolve(t *testing.T) {
 
 	performTransaction, ok := allocationConfig.FieldByName("PerformTransaction")
 	require.True(t, ok)
-	assert.Equal(t, 2, performTransaction.Type.NumIn(), "Allocation transactions accept message and wait policy only")
+	assert.Equal(t, 1, performTransaction.Type.NumIn(), "waited Allocation transactions accept one message")
+
+	startTransaction, ok := allocationConfig.FieldByName("StartTransaction")
+	require.True(t, ok)
+	assert.Equal(t, 1, startTransaction.Type.NumIn(), "fire-and-forget Allocation transactions accept one message")
 }

--- a/client.go
+++ b/client.go
@@ -200,12 +200,10 @@ func (c *Client) sendAllocateRequest(ctx context.Context, protocol proto.Protoco
 		return relayed, lifetime, nonce, err
 	}
 
-	trRes, err := c.performAllocateTransaction(ctx, msg)
+	res, err := c.performAllocateTransaction(ctx, msg)
 	if err != nil {
 		return relayed, lifetime, nonce, err
 	}
-
-	res := trRes.Msg
 
 	// Anonymous allocate failed, trying to authenticate.
 	if err = nonce.GetFrom(res); err != nil {
@@ -239,11 +237,10 @@ func (c *Client) sendAllocateRequest(ctx context.Context, protocol proto.Protoco
 		return relayed, lifetime, nonce, err
 	}
 
-	trRes, err = c.performAllocateTransaction(ctx, msg)
+	res, err = c.performAllocateTransaction(ctx, msg)
 	if err != nil {
 		return relayed, lifetime, nonce, err
 	}
-	res = trRes.Msg
 
 	if res.Type.Class == stun.ClassErrorResponse {
 		var code stun.ErrorCodeAttribute
@@ -314,7 +311,8 @@ func (c *Client) Allocate(ctx context.Context) (*Allocation, error) {
 
 	relayedConn = client.NewUDPConn(&client.AllocationConfig{
 		WriteTo:                   c.sendToServer,
-		PerformTransaction:        c.performTransaction,
+		PerformTransaction:        c.transactions.Perform,
+		StartTransaction:          c.transactions.Start,
 		OnDeallocated:             c.onDeallocated,
 		RelayedAddr:               relayedAddr,
 		Realm:                     c.realm,
@@ -340,21 +338,10 @@ func (c *Client) Allocate(ctx context.Context) (*Allocation, error) {
 	return newAllocation(relayedConn, canonicalRelayed), nil
 }
 
-// performTransaction performs STUN transaction.
-func (c *Client) performTransaction(msg *stun.Message, ignoreResult bool) (client.TransactionResult,
-	error,
-) {
-	if ignoreResult {
-		return client.TransactionResult{}, c.transactions.Start(msg)
-	}
-
-	return c.transactions.Perform(msg)
-}
-
 // performAllocateTransaction delegates Allocate's private cancelable wait to
 // the transaction registry; cancellation does not cancel shared peer work.
 func (c *Client) performAllocateTransaction(ctx context.Context, msg *stun.Message) (
-	client.TransactionResult, error,
+	*stun.Message, error,
 ) {
 	return c.transactions.PerformWithContext(ctx, msg)
 }

--- a/client_test.go
+++ b/client_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/pion/stun/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/the-sarge/turn/v5/internal/client"
 	"github.com/the-sarge/turn/v5/internal/proto"
 	"github.com/the-sarge/turn/v5/turntest"
 )
@@ -143,7 +142,7 @@ func TestHandleInboundAdmitsOnlyServer(t *testing.T) {
 
 	// pendingResponse starts work through the Client's transaction seam and
 	// returns the matching success plus the observable waiter result.
-	pendingResponse := func(t *testing.T, c *Client, conn *observerConn) ([]byte, <-chan client.TransactionResult) {
+	pendingResponse := func(t *testing.T, c *Client, conn *observerConn) ([]byte, <-chan *stun.Message) {
 		t.Helper()
 		req := stun.MustBuild(stun.TransactionID, stun.BindingRequest)
 		res, err := stun.Build(
@@ -152,9 +151,9 @@ func TestHandleInboundAdmitsOnlyServer(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		waited := make(chan client.TransactionResult, 1)
+		waited := make(chan *stun.Message, 1)
 		go func() {
-			result, _ := c.performTransaction(req, false)
+			result, _ := c.transactions.Perform(req)
 			waited <- result
 		}()
 		awaitWrite(t, conn, 1)
@@ -162,18 +161,17 @@ func TestHandleInboundAdmitsOnlyServer(t *testing.T) {
 		return res.Raw, waited
 	}
 
-	expectDelivered := func(t *testing.T, waited <-chan client.TransactionResult) {
+	expectDelivered := func(t *testing.T, waited <-chan *stun.Message) {
 		t.Helper()
 		select {
 		case res := <-waited:
-			assert.NoError(t, res.Err)
-			assert.NotNil(t, res.Msg)
+			assert.NotNil(t, res)
 		case <-time.After(time.Second):
 			assert.Fail(t, "waiter was not woken by a delivered server response")
 		}
 	}
 
-	expectIgnored := func(t *testing.T, waited <-chan client.TransactionResult) {
+	expectIgnored := func(t *testing.T, waited <-chan *stun.Message) {
 		t.Helper()
 		select {
 		case res := <-waited:
@@ -405,12 +403,12 @@ func TestClientCloseIsAnAbortCutNotATerminalState(t *testing.T) {
 		stun.NewType(stun.MethodBinding, stun.ClassSuccessResponse),
 	)
 	type outcome struct {
-		result client.TransactionResult
+		result *stun.Message
 		err    error
 	}
 	resultCh := make(chan outcome, 1)
 	go func() {
-		result, err := cl.performTransaction(request, false)
+		result, err := cl.transactions.Perform(request)
 		resultCh <- outcome{result: result, err: err}
 	}()
 	awaitWrite(t, conn, 1)
@@ -419,7 +417,7 @@ func TestClientCloseIsAnAbortCutNotATerminalState(t *testing.T) {
 	select {
 	case got := <-resultCh:
 		assert.NoError(t, got.err)
-		assert.NotNil(t, got.result.Msg)
+		assert.NotNil(t, got.result)
 	case <-time.After(time.Second):
 		assert.Fail(t, "transaction begun after Client.Close did not complete")
 	}
@@ -433,7 +431,7 @@ func TestClientCloseWinsBlockedInitialSendWithoutRearm(t *testing.T) {
 
 	resultCh := make(chan error, 1)
 	go func() {
-		_, err := cl.performTransaction(request, false)
+		_, err := cl.transactions.Perform(request)
 		resultCh <- err
 	}()
 	select {

--- a/close_latency_test.go
+++ b/close_latency_test.go
@@ -43,13 +43,14 @@ func newSilentServerAllocation(t *testing.T) (*client.UDPConn, <-chan string) {
 	closeOrder := make(chan string, 3)
 
 	config := &client.AllocationConfig{
-		WriteTo: cl.sendToServer,
-		PerformTransaction: func(msg *stun.Message, dontWait bool) (client.TransactionResult, error) {
-			if msg.Type.Method == stun.MethodRefresh && dontWait {
+		WriteTo:            cl.sendToServer,
+		PerformTransaction: cl.transactions.Perform,
+		StartTransaction: func(msg *stun.Message) error {
+			if msg.Type.Method == stun.MethodRefresh {
 				closeOrder <- "release"
 			}
 
-			return cl.performTransaction(msg, dontWait)
+			return cl.transactions.Start(msg)
 		},
 		OnDeallocated: func(addr net.Addr) {
 			closeOrder <- "deallocated"

--- a/docs/adr/2026-08-19-seam-deepening-program.md
+++ b/docs/adr/2026-08-19-seam-deepening-program.md
@@ -1,6 +1,6 @@
 # TURN Seam Deepening Program — 2026-08-19
 
-**Status:** Accepted; T1.S1 implemented by PR #96; remaining slices not yet implemented
+**Status:** Accepted; Track 1 implemented by PRs #96 and #98; remaining slices not yet implemented
 
 ## What this is
 
@@ -23,12 +23,12 @@ Audit receipt: all six slices were independently slice-audited against `dad68d48
 
 | # | Track | Plan | Parent issue | Blocked by | Slices | Status |
 |---|---|---|---|---|---|---|
-| 1 | UDPConn construction and transaction crossing | [plan](2026-08-19-udpconn-construction-crossing-plan.md) | [#85](https://github.com/the-sarge/turn/issues/85) | None | 2 | FRONTIER (T1.S2); T1.S1 complete via PR #96 |
+| 1 | UDPConn construction and transaction crossing | [plan](2026-08-19-udpconn-construction-crossing-plan.md) | [#85](https://github.com/the-sarge/turn/issues/85) | None | 2 | Complete via PRs #96 and #98 |
 | 2 | Allocate admission and public error vocabulary | [plan](2026-08-19-allocate-admission-errors-plan.md) | pending | None | 2 | FRONTIER (T2.S1, T2.S2) |
 | 3 | Permission readiness | [plan](2026-08-19-permission-readiness-plan.md) | pending | None | 1 | FRONTIER (T3.S1) |
 | 4 | Allocate exchange | [plan](2026-08-19-allocate-exchange-plan.md) | pending | None | 1 | FRONTIER (T4.S1) |
 
-There are no genuine blocking edges; every remaining slice is independently green. T1.S1 landed before T1.S2 as strongly recommended, and the recommended remaining dispatch order to minimize rebases — advice, not a blocker — is T1.S2 → T2.S1 → T2.S2 → T3.S1 → T4.S1. Known file overlaps: T1 and T3 both touch `internal/client/prepare_test.go`; T1.S2 and T2.S1 both touch `AllocationConfig`; T4.S1 is root-only but shares `client.go` (`sendAllocateRequest`, `Allocate`) with T1.S2 and T2.S1. Text conflicts between independently implemented slices require rebasing, not artificial blockers. T3.S1 and T4.S1 share no files with each other. Recommended next slice: T1.S2.
+There are no genuine blocking edges; every remaining slice is independently green. T1.S1 and T1.S2 landed in the strongly recommended order, and the recommended remaining dispatch order to minimize rebases — advice, not a blocker — is T2.S1 → T2.S2 → T3.S1 → T4.S1. Known file overlaps: T1 and T3 both touch `internal/client/prepare_test.go`; T1.S2 and T2.S1 both touch `AllocationConfig`; T4.S1 is root-only but shares `client.go` (`sendAllocateRequest`, `Allocate`) with T1.S2 and T2.S1. Text conflicts between independently implemented slices require rebasing, not artificial blockers. T3.S1 and T4.S1 share no files with each other. Recommended next slice: T2.S1.
 
 ## Rules that bind every track
 

--- a/docs/adr/2026-08-19-udpconn-construction-crossing-plan.md
+++ b/docs/adr/2026-08-19-udpconn-construction-crossing-plan.md
@@ -1,7 +1,7 @@
 # UDPConn Construction and Transaction Crossing Implementation Plan
 
 **Date:** 2026-08-19
-**Status:** T1.S1 implemented by PR #96; T1.S2 accepted and not yet implemented
+**Status:** Implemented by PRs #96 and #98
 **Track:** 1 of 4 in the 2026-08-19 seam deepening program
 **Depends on:** Nothing — safe to start first; T1.S1 first is strongly recommended for T1.S2 but is not a blocker
 **Related:** [Program index](2026-08-19-seam-deepening-program.md), [Allocation lifecycle plan](2026-08-17-allocation-lifecycle-plan.md), [Transaction registry plan](2026-08-17-transaction-registry-plan.md), [Server-bound transport plan](2026-08-19-server-bound-transport-plan.md), [Allocation construction timing validity plan](2026-08-19-allocation-construction-timing-validity-plan.md)
@@ -47,7 +47,7 @@ Exact private Go spellings (`newUDPConn`, `start`, `newTestConn`, `emitRelease`,
 | Slice | Status/disposition | Delivers | Blocked by | Removes temporary seam |
 |---|---|---|---|---|
 | T1.S1 | Complete via PR #96 | `UDPConn` built by one constructor in production and tests; `mockClient.configure` and credential-carrying struct literals gone; one scripted helper per package | None | Private-field test construction |
-| T1.S2 | New | Two named transaction crossings; `TransactionResult` and the `dontWait` flag gone; release emission has a name | None (T1.S1 first strongly recommended) | Mode flag on the crossing |
+| T1.S2 | Complete via PR #98 | Two named transaction crossings; `TransactionResult` and the `dontWait` flag gone; release emission has a name | None (T1.S1 first strongly recommended) | Mode flag on the crossing |
 
 ## Implementation Slices
 
@@ -89,6 +89,8 @@ Exact private Go spellings (`newUDPConn`, `start`, `newTestConn`, `emitRelease`,
 
 **What it delivers:** One PR replacing `PerformTransaction(msg, dontWait) (TransactionResult, error)` with `PerformTransaction(msg) (*stun.Message, error)` plus `StartTransaction(msg) error`, deleting `TransactionResult` and root `Client.performTransaction`, wiring root with registry method values, splitting `refreshAllocation(lifetime)` from `emitRelease()` inside `UDPConn`, and rephrasing the refresh-failure and close-latency tests against the named closures.
 
+**Implementation:** PR #98 is this slice's one product PR.
+
 **Existing-work disposition:** New slice.
 
 **Blocked by:** None. T1.S1 first is strongly recommended: its helpers are where the crossing closures are scripted, so the signature change lands in two helpers plus mechanical return-type edits in every scripted `performTransaction` closure (`TransactionResult` has roughly 110 references across seven test files) instead of also rewriting ten literals and `mockClient`. Not a blocker; the slice is independently green either way, and text conflicts are rebased.
@@ -122,9 +124,9 @@ Exact private Go spellings (`newUDPConn`, `start`, `newTestConn`, `emitRelease`,
 - [x] `NewUDPConn` behaves exactly as before (started timers, same intervals, same abort panic) and is the only production constructor; an unexported build step establishes every invariant without goroutines and `Close` on a built-unstarted conn is valid. Domain: the finite construction paths in this repository; owner: `newUDPConn`/`start`; guarantee: universal over that set via the negative-grep evidence in T1.S1.
 - [x] No test writes `UDPConn` private func fields after construction; `mockClient` and `configure` do not exist; `UDPConn{` literals exist only at the six retained controlled-linearization/queue sites named in the T1.S1 PR.
 - [x] One scripted internal constructor and one root `newScriptedAllocation` replace `prepareHarness`'s construction, `allocHarness`, and `inboundDeliveryHarness`; `close_latency_test` keeps its own harness.
-- [ ] `AllocationConfig` exposes `PerformTransaction(msg) (*stun.Message, error)` and `StartTransaction(msg) error`; `TransactionResult`, `dontWait`, `ignoreResult`, and `Client.performTransaction` are absent; root wires registry method values.
-- [ ] The lifetime-zero release is emitted once from `startCloseLocked` via `StartTransaction`, byte-identical to today's after transaction-ID normalization, after abort and `onDeallocated`, and a failed emission is still joined into the terminal cause. Domain: the one release path; owner: `UDPConn.emitRelease`; guarantee: universal; evidence: txid-normalized byte equality plus the existing exactly-one-release and ordering tests.
-- [ ] Emitted Allocate/Refresh/CreatePermission/ChannelBind/ChannelData bytes, setter order, retransmission policy, public API, and Allocation lifecycle ownership are unchanged.
+- [x] `AllocationConfig` exposes `PerformTransaction(msg) (*stun.Message, error)` and `StartTransaction(msg) error`; `TransactionResult`, `dontWait`, `ignoreResult`, and `Client.performTransaction` are absent; root wires registry method values.
+- [x] The lifetime-zero release is emitted once from `startCloseLocked` via `StartTransaction`, byte-identical to today's after transaction-ID normalization, after abort and `onDeallocated`, and a failed emission is still joined into the terminal cause. Domain: the one release path; owner: `UDPConn.emitRelease`; guarantee: universal; evidence: txid-normalized byte equality plus the existing exactly-one-release and ordering tests.
+- [x] Emitted Allocate/Refresh/CreatePermission/ChannelBind/ChannelData bytes, setter order, retransmission policy, public API, and Allocation lifecycle ownership are unchanged.
 
 ## Validation Gates
 

--- a/internal/client/allocation.go
+++ b/internal/client/allocation.go
@@ -18,7 +18,9 @@ type AllocationConfig struct {
 	// WriteTo sends data to the configured server on the client's base socket.
 	WriteTo func(data []byte) (int, error)
 	// PerformTransaction runs a STUN transaction against the configured server.
-	PerformTransaction func(msg *stun.Message, dontWait bool) (TransactionResult, error)
+	PerformTransaction func(msg *stun.Message) (*stun.Message, error)
+	// StartTransaction starts a fire-and-forget STUN transaction against the configured server.
+	StartTransaction func(msg *stun.Message) error
 	// OnDeallocated is called once de-allocation of the relayed address is complete.
 	OnDeallocated func(relayedAddr net.Addr)
 
@@ -43,7 +45,7 @@ func (c *UDPConn) setNonceFromMsg(msg *stun.Message) {
 	}
 }
 
-func (c *UDPConn) refreshAllocation(lifetime time.Duration, dontWait bool) error {
+func (c *UDPConn) buildRefresh(lifetime time.Duration) (*stun.Message, error) {
 	msg, err := stun.Build(
 		stun.TransactionID,
 		stun.NewType(stun.MethodRefresh, stun.ClassRequest),
@@ -55,19 +57,22 @@ func (c *UDPConn) refreshAllocation(lifetime time.Duration, dontWait bool) error
 		stun.Fingerprint,
 	)
 	if err != nil {
-		return fmt.Errorf("%w: %w", errFailedToBuildRefreshRequest, err)
+		return nil, fmt.Errorf("%w: %w", errFailedToBuildRefreshRequest, err)
 	}
 
-	trRes, err := c.performTransaction(msg, dontWait)
+	return msg, nil
+}
+
+func (c *UDPConn) refreshAllocation(lifetime time.Duration) error {
+	msg, err := c.buildRefresh(lifetime)
+	if err != nil {
+		return err
+	}
+
+	res, err := c.performTransaction(msg)
 	if err != nil {
 		return fmt.Errorf("%w: %w", errFailedToRefreshAllocation, err)
 	}
-
-	if dontWait {
-		return nil
-	}
-
-	res := trRes.Msg
 	if res.Type.Class == stun.ClassErrorResponse {
 		var code stun.ErrorCodeAttribute
 		if err = code.GetFrom(res); err == nil {
@@ -99,6 +104,19 @@ func (c *UDPConn) refreshAllocation(lifetime time.Duration, dontWait bool) error
 	return nil
 }
 
+func (c *UDPConn) emitRelease() error {
+	msg, err := c.buildRefresh(0)
+	if err != nil {
+		return err
+	}
+
+	if err = c.startTransaction(msg); err != nil {
+		return fmt.Errorf("%w: %w", errFailedToRefreshAllocation, err)
+	}
+
+	return nil
+}
+
 func (c *UDPConn) refreshPermissions() error {
 	addrs := c.permMap.addrs()
 	if len(addrs) == 0 {
@@ -126,7 +144,7 @@ func (c *UDPConn) refreshAllocationWithRetries() {
 	// Limit the max retries on errTryAgain to 3
 	// when stale nonce returns, sencond retry should succeed
 	for range maxRetryAttempts {
-		err = c.refreshAllocation(lifetime, false)
+		err = c.refreshAllocation(lifetime)
 		if !errors.Is(err, errTryAgain) {
 			break
 		}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -17,7 +17,8 @@ import (
 // rescript an already-built connection without writing its private fields.
 type testConnScript struct {
 	writeTo            func(data []byte) (int, error)
-	performTransaction func(msg *stun.Message, dontWait bool) (TransactionResult, error)
+	performTransaction func(msg *stun.Message) (*stun.Message, error)
+	startTransaction   func(msg *stun.Message) error
 	onDeallocated      func(relayedAddr net.Addr)
 
 	writes struct {
@@ -38,12 +39,20 @@ func (s *testConnScript) WriteTo(data []byte) (int, error) {
 	return len(data), nil
 }
 
-func (s *testConnScript) PerformTransaction(msg *stun.Message, dontWait bool) (TransactionResult, error) {
+func (s *testConnScript) PerformTransaction(msg *stun.Message) (*stun.Message, error) {
 	if s.performTransaction != nil {
-		return s.performTransaction(msg, dontWait)
+		return s.performTransaction(msg)
 	}
 
-	return TransactionResult{}, errFake
+	return nil, errFake
+}
+
+func (s *testConnScript) StartTransaction(msg *stun.Message) error {
+	if s.startTransaction != nil {
+		return s.startTransaction(msg)
+	}
+
+	return nil
 }
 
 func (s *testConnScript) OnDeallocated(relayedAddr net.Addr) {
@@ -74,6 +83,7 @@ func testAllocationConfig(script *testConnScript) *AllocationConfig {
 	return &AllocationConfig{
 		WriteTo:            script.WriteTo,
 		PerformTransaction: script.PerformTransaction,
+		StartTransaction:   script.StartTransaction,
 		OnDeallocated:      script.OnDeallocated,
 		RelayedAddr:        &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 54321},
 		Username:           stun.NewUsername("user"),

--- a/internal/client/prepare_test.go
+++ b/internal/client/prepare_test.go
@@ -43,7 +43,7 @@ func newPrepareHarness(t *testing.T, gateBinds bool) *prepareHarness {
 	}
 
 	script := &testConnScript{
-		performTransaction: func(msg *stun.Message, _ bool) (TransactionResult, error) {
+		performTransaction: func(msg *stun.Message) (*stun.Message, error) {
 			switch msg.Type.Method {
 			case stun.MethodCreatePermission:
 				harness.permCount.Add(1)
@@ -51,35 +51,33 @@ func newPrepareHarness(t *testing.T, gateBinds bool) *prepareHarness {
 					<-harness.permGate
 				}
 				if harness.failPerms.Load() {
-					return TransactionResult{Msg: stun.MustBuild(
+					return stun.MustBuild(
 						stun.NewType(stun.MethodCreatePermission, stun.ClassErrorResponse),
 						stun.ErrorCodeAttribute{Code: stun.CodeForbidden, Reason: []byte("Forbidden")},
-					)}, nil
+					), nil
 				}
 				if harness.staleNonce.Load() {
-					return TransactionResult{Msg: stun.MustBuild(
+					return stun.MustBuild(
 						stun.NewType(stun.MethodCreatePermission, stun.ClassErrorResponse),
 						stun.ErrorCodeAttribute{Code: stun.CodeStaleNonce, Reason: []byte("Stale Nonce")},
 						stun.NewNonce("nonce2"),
-					)}, nil
+					), nil
 				}
 
-				return TransactionResult{Msg: stun.MustBuild(
+				return stun.MustBuild(
 					stun.NewType(stun.MethodCreatePermission, stun.ClassSuccessResponse),
-				)}, nil
+				), nil
 			case stun.MethodChannelBind:
 				harness.bindCount.Add(1)
 				if harness.bindGate != nil {
 					<-harness.bindGate
 				}
 
-				return TransactionResult{Msg: stun.MustBuild(
+				return stun.MustBuild(
 					stun.NewType(stun.MethodChannelBind, stun.ClassSuccessResponse),
-				)}, nil
-			case stun.MethodRefresh:
-				return TransactionResult{}, nil
+				), nil
 			default:
-				return TransactionResult{}, errFake
+				return nil, errFake
 			}
 		},
 	}
@@ -455,14 +453,14 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 		// First permission succeeds, but every ChannelBind transaction fails.
 		mock := harness.script
 		inner := mock.performTransaction
-		mock.performTransaction = func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
+		mock.performTransaction = func(msg *stun.Message) (*stun.Message, error) {
 			if msg.Type.Method == stun.MethodChannelBind {
 				harness.bindCount.Add(1)
 
-				return TransactionResult{}, errFake
+				return nil, errFake
 			}
 
-			return inner(msg, dontWait)
+			return inner(msg)
 		}
 
 		err := harness.conn.PreparePeer(context.Background(), harness.peer)
@@ -480,15 +478,15 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 		gate := make(chan struct{})
 		mock := harness.script
 		inner := mock.performTransaction
-		mock.performTransaction = func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
+		mock.performTransaction = func(msg *stun.Message) (*stun.Message, error) {
 			if msg.Type.Method == stun.MethodChannelBind {
 				harness.bindCount.Add(1)
 				<-gate
 
-				return TransactionResult{}, errFake
+				return nil, errFake
 			}
 
-			return inner(msg, dontWait)
+			return inner(msg)
 		}
 
 		results := make(chan error, 2)
@@ -513,17 +511,17 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 
 		mock := harness.script
 		inner := mock.performTransaction
-		mock.performTransaction = func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
+		mock.performTransaction = func(msg *stun.Message) (*stun.Message, error) {
 			if msg.Type.Method == stun.MethodChannelBind {
 				harness.bindCount.Add(1)
 
-				return TransactionResult{Msg: stun.MustBuild(
+				return stun.MustBuild(
 					stun.NewType(stun.MethodChannelBind, stun.ClassErrorResponse),
 					stun.ErrorCodeAttribute{Code: stun.CodeForbidden, Reason: []byte("Forbidden")},
-				)}, nil
+				), nil
 			}
 
-			return inner(msg, dontWait)
+			return inner(msg)
 		}
 
 		err := harness.conn.PreparePeer(context.Background(), harness.peer)

--- a/internal/client/refresh_failure_test.go
+++ b/internal/client/refresh_failure_test.go
@@ -25,10 +25,10 @@ import (
 type refreshFailureHarness struct {
 	conn *UDPConn
 
-	// waitedRefresh scripts the outcome of a waited (dontWait=false) Refresh
+	// waitedRefresh scripts the outcome of a waited Refresh
 	// transaction. Read on every waited refresh.
-	waitedRefresh func() (TransactionResult, error)
-	// emitErr, when non-nil, fails the lifetime-0 (dontWait=true) emission.
+	waitedRefresh func() (*stun.Message, error)
+	// emitErr, when non-nil, fails the lifetime-zero Release emission.
 	emitErr error
 
 	waitedCount atomic.Int32
@@ -36,37 +36,34 @@ type refreshFailureHarness struct {
 }
 
 func newRefreshFailureHarness(
-	t *testing.T, waited func() (TransactionResult, error), emitErr error,
+	t *testing.T, waited func() (*stun.Message, error), emitErr error,
 ) *refreshFailureHarness {
 	t.Helper()
 
 	harness := &refreshFailureHarness{waitedRefresh: waited, emitErr: emitErr}
 	script := &testConnScript{
-		performTransaction: func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
+		performTransaction: func(msg *stun.Message) (*stun.Message, error) {
 			switch msg.Type.Method {
 			case stun.MethodRefresh:
-				if dontWait {
-					harness.emitCount.Add(1)
-					if harness.emitErr != nil {
-						return TransactionResult{}, harness.emitErr
-					}
-
-					return TransactionResult{}, nil
-				}
 				harness.waitedCount.Add(1)
 
 				return harness.waitedRefresh()
 			case stun.MethodCreatePermission:
-				return TransactionResult{Msg: stun.MustBuild(
+				return stun.MustBuild(
 					stun.NewType(stun.MethodCreatePermission, stun.ClassSuccessResponse),
-				)}, nil
+				), nil
 			case stun.MethodChannelBind:
-				return TransactionResult{Msg: stun.MustBuild(
+				return stun.MustBuild(
 					stun.NewType(stun.MethodChannelBind, stun.ClassSuccessResponse),
-				)}, nil
+				), nil
 			default:
-				return TransactionResult{}, errFake
+				return nil, errFake
 			}
+		},
+		startTransaction: func(*stun.Message) error {
+			harness.emitCount.Add(1)
+
+			return harness.emitErr
 		},
 		writeTo: func(data []byte) (int, error) {
 			return len(data), nil
@@ -99,7 +96,7 @@ func TestRefreshFailureTerminalizes(t *testing.T) {
 	tests := []struct {
 		name string
 		// waited scripts every waited refresh outcome.
-		waited func() (TransactionResult, error)
+		waited func() (*stun.Message, error)
 		// wantWaited is the number of waited refresh transactions the retry
 		// loop is expected to run before the failure is permanent.
 		wantWaited int32
@@ -110,24 +107,24 @@ func TestRefreshFailureTerminalizes(t *testing.T) {
 	}{
 		{
 			name: "exhausted refresh transaction",
-			waited: func() (TransactionResult, error) {
-				return TransactionResult{}, fmt.Errorf("%w: transaction test", ErrTransactionTimeout)
+			waited: func() (*stun.Message, error) {
+				return nil, fmt.Errorf("%w: transaction test", ErrTransactionTimeout)
 			},
 			wantWaited: 1,
 			underlying: ErrTransactionTimeout,
 		},
 		{
 			name: "well-formed non-438 error response",
-			waited: func() (TransactionResult, error) {
-				return TransactionResult{Msg: turnErrorResponse(stun.CodeServerError)}, nil
+			waited: func() (*stun.Message, error) {
+				return turnErrorResponse(stun.CodeServerError), nil
 			},
 			wantWaited:    1,
 			wantTurnError: true,
 		},
 		{
 			name: "stale-nonce retry exhaustion",
-			waited: func() (TransactionResult, error) {
-				return TransactionResult{Msg: staleNonceResponse()}, nil
+			waited: func() (*stun.Message, error) {
+				return staleNonceResponse(), nil
 			},
 			wantWaited: maxRetryAttempts,
 		},
@@ -197,8 +194,8 @@ func TestRefreshFailureTerminalizes(t *testing.T) {
 }
 
 func TestConcurrentCallerCloses(t *testing.T) {
-	harness := newRefreshFailureHarness(t, func() (TransactionResult, error) {
-		return TransactionResult{}, errFake
+	harness := newRefreshFailureHarness(t, func() (*stun.Message, error) {
+		return nil, errFake
 	}, nil)
 	conn := harness.conn
 
@@ -237,8 +234,8 @@ func TestConcurrentCallerCloses(t *testing.T) {
 }
 
 func TestRefreshFailureSealVsCloseRace(t *testing.T) {
-	harness := newRefreshFailureHarness(t, func() (TransactionResult, error) {
-		return TransactionResult{}, errFake
+	harness := newRefreshFailureHarness(t, func() (*stun.Message, error) {
+		return nil, errFake
 	}, nil)
 	conn := harness.conn
 
@@ -272,8 +269,8 @@ func TestRefreshFailureSealVsCloseRace(t *testing.T) {
 
 func TestSelfSealEmissionFailureJoinsCause(t *testing.T) {
 	emitErr := errors.New("lifetime-0 write failed") //nolint:err113 // test-local cause
-	harness := newRefreshFailureHarness(t, func() (TransactionResult, error) {
-		return TransactionResult{}, errFake
+	harness := newRefreshFailureHarness(t, func() (*stun.Message, error) {
+		return nil, errFake
 	}, emitErr)
 	conn := harness.conn
 

--- a/internal/client/transaction.go
+++ b/internal/client/transaction.go
@@ -18,10 +18,9 @@ const (
 	maxRtxCount                  = 7 // Initial request plus six retries.
 )
 
-// TransactionResult is a bag of result values of a transaction.
-type TransactionResult struct {
-	Msg *stun.Message
-	Err error
+type transactionResult struct {
+	msg *stun.Message
+	err error
 }
 
 type transactionRegistryEntry struct {
@@ -30,7 +29,7 @@ type transactionRegistryEntry struct {
 	interval time.Duration
 	nRtx     int
 	timer    *time.Timer
-	resultCh chan TransactionResult
+	resultCh chan transactionResult
 }
 
 // TransactionRegistry owns the live transaction set and its terminal claims.
@@ -51,10 +50,10 @@ func NewTransactionRegistry(send func([]byte) (int, error), rto time.Duration) *
 }
 
 // Perform registers, initially sends, and waits for one transaction.
-func (r *TransactionRegistry) Perform(msg *stun.Message) (TransactionResult, error) {
-	entry, err := r.begin(msg, false)
+func (r *TransactionRegistry) Perform(msg *stun.Message) (*stun.Message, error) {
+	entry, err := r.begin(msg, make(chan transactionResult, 1))
 	if err != nil {
-		return TransactionResult{}, err
+		return nil, err
 	}
 
 	return waitForTransaction(entry)
@@ -62,7 +61,7 @@ func (r *TransactionRegistry) Perform(msg *stun.Message) (TransactionResult, err
 
 // Start registers and initially sends one fire-and-forget transaction.
 func (r *TransactionRegistry) Start(msg *stun.Message) error {
-	_, err := r.begin(msg, true)
+	_, err := r.begin(msg, nil)
 
 	return err
 }
@@ -71,19 +70,19 @@ func (r *TransactionRegistry) Start(msg *stun.Message) error {
 func (r *TransactionRegistry) PerformWithContext(
 	ctx context.Context,
 	msg *stun.Message,
-) (TransactionResult, error) {
+) (*stun.Message, error) {
 	if err := ctx.Err(); err != nil {
-		return TransactionResult{}, context.Cause(ctx)
+		return nil, context.Cause(ctx)
 	}
 
-	entry, err := r.begin(msg, false)
+	entry, err := r.begin(msg, make(chan transactionResult, 1))
 	if err != nil {
-		return TransactionResult{}, err
+		return nil, err
 	}
 
 	select {
 	case result, ok := <-entry.resultCh:
-		return finishTransactionResult(result, ok)
+		return finishResult(result, ok)
 	case <-ctx.Done():
 	}
 
@@ -96,7 +95,7 @@ func (r *TransactionRegistry) PerformWithContext(
 		r.mutex.Unlock()
 		close(entry.resultCh)
 
-		return TransactionResult{}, context.Cause(ctx)
+		return nil, context.Cause(ctx)
 	}
 	r.mutex.Unlock()
 
@@ -105,15 +104,13 @@ func (r *TransactionRegistry) PerformWithContext(
 
 func (r *TransactionRegistry) begin(
 	msg *stun.Message,
-	ignoreResult bool,
+	resultCh chan transactionResult,
 ) (*transactionRegistryEntry, error) {
 	entry := &transactionRegistryEntry{
 		id:       msg.TransactionID,
 		raw:      append([]byte(nil), msg.Raw...),
 		interval: r.rto,
-	}
-	if !ignoreResult {
-		entry.resultCh = make(chan TransactionResult, 1)
+		resultCh: resultCh,
 	}
 
 	r.mutex.Lock()
@@ -166,8 +163,8 @@ func (r *TransactionRegistry) retry(entry *transactionRegistryEntry) {
 	if entry.nRtx == maxRtxCount {
 		delete(r.live, entry.id)
 		r.mutex.Unlock()
-		publishTransactionResult(entry, TransactionResult{
-			Err: fmt.Errorf("%w: transaction %s", ErrTransactionTimeout, transactionKey(entry.id)),
+		publishResult(entry, transactionResult{
+			err: fmt.Errorf("%w: transaction %s", ErrTransactionTimeout, transactionKey(entry.id)),
 		})
 
 		return
@@ -185,8 +182,8 @@ func (r *TransactionRegistry) retry(entry *transactionRegistryEntry) {
 	if err != nil {
 		delete(r.live, entry.id)
 		r.mutex.Unlock()
-		publishTransactionResult(entry, TransactionResult{
-			Err: fmt.Errorf("%w: transaction %s: %w", errFailedToRetransmitTransaction, transactionKey(entry.id), err),
+		publishResult(entry, transactionResult{
+			err: fmt.Errorf("%w: transaction %s: %w", errFailedToRetransmitTransaction, transactionKey(entry.id), err),
 		})
 
 		return
@@ -199,24 +196,24 @@ func transactionKey(id [stun.TransactionIDSize]byte) string {
 	return b64.StdEncoding.EncodeToString(id[:])
 }
 
-func publishTransactionResult(entry *transactionRegistryEntry, result TransactionResult) {
+func publishResult(entry *transactionRegistryEntry, result transactionResult) {
 	if entry.resultCh != nil {
 		entry.resultCh <- result
 	}
 }
 
-func waitForTransaction(entry *transactionRegistryEntry) (TransactionResult, error) {
+func waitForTransaction(entry *transactionRegistryEntry) (*stun.Message, error) {
 	result, ok := <-entry.resultCh
 
-	return finishTransactionResult(result, ok)
+	return finishResult(result, ok)
 }
 
-func finishTransactionResult(result TransactionResult, ok bool) (TransactionResult, error) {
+func finishResult(result transactionResult, ok bool) (*stun.Message, error) {
 	if !ok {
-		result.Err = errTransactionClosed
+		result.err = errTransactionClosed
 	}
 
-	return result, result.Err
+	return result.msg, result.err
 }
 
 // Complete claims a matching response and publishes it to a waiting caller.
@@ -231,7 +228,7 @@ func (r *TransactionRegistry) Complete(msg *stun.Message) {
 	}
 	r.mutex.Unlock()
 	if ok {
-		publishTransactionResult(entry, TransactionResult{Msg: msg})
+		publishResult(entry, transactionResult{msg: msg})
 	}
 }
 

--- a/internal/client/transaction_test.go
+++ b/internal/client/transaction_test.go
@@ -36,7 +36,7 @@ func TestTransactionRegistryInitialSendFailureRollsBack(t *testing.T) {
 	_, err := registry.Perform(request)
 	require.ErrorIs(t, err, sendErr)
 
-	resultCh := make(chan TransactionResult, 1)
+	resultCh := make(chan *stun.Message, 1)
 	go func() {
 		result, _ := registry.Perform(request)
 		resultCh <- result
@@ -46,7 +46,7 @@ func TestTransactionRegistryInitialSendFailureRollsBack(t *testing.T) {
 
 	select {
 	case result := <-resultCh:
-		assert.Same(t, response, result.Msg)
+		assert.Same(t, response, result)
 	case <-time.After(time.Second):
 		assert.Fail(t, "replacement transaction did not complete")
 	}
@@ -65,7 +65,7 @@ func TestTransactionRegistryRejectsDuplicateLiveID(t *testing.T) {
 		return len(raw), nil
 	}, time.Hour)
 
-	firstResult := make(chan TransactionResult, 1)
+	firstResult := make(chan *stun.Message, 1)
 	go func() {
 		result, _ := registry.Perform(request)
 		firstResult <- result
@@ -79,7 +79,7 @@ func TestTransactionRegistryRejectsDuplicateLiveID(t *testing.T) {
 	registry.Complete(response)
 	select {
 	case result := <-firstResult:
-		assert.Same(t, response, result.Msg, "the original owner must remain live")
+		assert.Same(t, response, result, "the original owner must remain live")
 	case <-time.After(time.Second):
 		assert.Fail(t, "original transaction did not complete")
 	}
@@ -194,7 +194,7 @@ func TestTransactionRegistryResponseWinsBlockedInitialSend(t *testing.T) {
 		return len(raw), nil
 	}, time.Millisecond)
 
-	resultCh := make(chan TransactionResult, 1)
+	resultCh := make(chan *stun.Message, 1)
 	go func() {
 		result, _ := registry.Perform(request)
 		resultCh <- result
@@ -205,7 +205,7 @@ func TestTransactionRegistryResponseWinsBlockedInitialSend(t *testing.T) {
 
 	select {
 	case result := <-resultCh:
-		assert.Same(t, response, result.Msg)
+		assert.Same(t, response, result)
 	case <-time.After(time.Second):
 		assert.Fail(t, "response winner did not wake the blocked begin caller")
 	}
@@ -246,17 +246,17 @@ func TestTransactionRegistryClaimDuringBlockedRetryPreventsRearm(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
 		claim  func(*TransactionRegistry, *stun.Message)
-		assert func(*testing.T, TransactionResult, error, *stun.Message)
+		assert func(*testing.T, *stun.Message, error, *stun.Message)
 	}{
 		{
 			name: "response",
 			claim: func(registry *TransactionRegistry, response *stun.Message) {
 				registry.Complete(response)
 			},
-			assert: func(t *testing.T, result TransactionResult, err error, response *stun.Message) {
+			assert: func(t *testing.T, result *stun.Message, err error, response *stun.Message) {
 				t.Helper()
 				assert.NoError(t, err)
-				assert.Same(t, response, result.Msg)
+				assert.Same(t, response, result)
 			},
 		},
 		{
@@ -264,7 +264,7 @@ func TestTransactionRegistryClaimDuringBlockedRetryPreventsRearm(t *testing.T) {
 			claim: func(registry *TransactionRegistry, _ *stun.Message) {
 				registry.AbortCurrent()
 			},
-			assert: func(t *testing.T, _ TransactionResult, err error, _ *stun.Message) {
+			assert: func(t *testing.T, _ *stun.Message, err error, _ *stun.Message) {
 				t.Helper()
 				assert.ErrorIs(t, err, net.ErrClosed)
 			},
@@ -289,7 +289,7 @@ func TestTransactionRegistryClaimDuringBlockedRetryPreventsRearm(t *testing.T) {
 			}, time.Millisecond)
 
 			type outcome struct {
-				result TransactionResult
+				result *stun.Message
 				err    error
 			}
 			outcomeCh := make(chan outcome, 1)
@@ -340,7 +340,7 @@ func TestTransactionRegistryWaitedRetryFailureRetires(t *testing.T) {
 	require.ErrorIs(t, err, retryErr)
 	assert.Equal(t, int32(2), sends.Load())
 
-	resultCh := make(chan TransactionResult, 1)
+	resultCh := make(chan *stun.Message, 1)
 	go func() {
 		result, _ := registry.Perform(request)
 		resultCh <- result
@@ -350,7 +350,7 @@ func TestTransactionRegistryWaitedRetryFailureRetires(t *testing.T) {
 	close(releaseReplacement)
 	select {
 	case result := <-resultCh:
-		assert.Same(t, response, result.Msg)
+		assert.Same(t, response, result)
 	case <-time.After(time.Second):
 		assert.Fail(t, "replacement after retry failure did not complete")
 	}

--- a/internal/client/udp_conn.go
+++ b/internal/client/udp_conn.go
@@ -56,7 +56,8 @@ type UDPConn struct {
 	// Package-crossing operations are immutable production/mock adapters. They
 	// do not own or mutate Allocation lifecycle state.
 	writeTo            func(data []byte) (int, error)
-	performTransaction func(msg *stun.Message, dontWait bool) (TransactionResult, error)
+	performTransaction func(msg *stun.Message) (*stun.Message, error)
+	startTransaction   func(msg *stun.Message) error
 	onDeallocated      func(relayedAddr net.Addr)
 	abortTransactions  func()
 
@@ -109,6 +110,7 @@ func newUDPConn(config *AllocationConfig, abortTransactions func()) *UDPConn {
 	conn := &UDPConn{
 		writeTo:                config.WriteTo,
 		performTransaction:     config.PerformTransaction,
+		startTransaction:       config.StartTransaction,
 		onDeallocated:          config.OnDeallocated,
 		abortTransactions:      abortTransactions,
 		relayedAddr:            config.RelayedAddr,
@@ -525,7 +527,7 @@ func (c *UDPConn) startCloseLocked(cause error) (bool, error) {
 
 	c.onDeallocated(c.relayedAddr)
 
-	emitErr := c.refreshAllocation(0, true /* dontWait=true */)
+	emitErr := c.emitRelease()
 	if cause != nil {
 		// Self-seal: record the terminal cause; a failed lifetime-0 emission
 		// is joined into it so the caller's Close can still observe it.
@@ -602,12 +604,10 @@ func (c *UDPConn) CreatePermissions(addrs ...netip.AddrPort) error {
 		return err
 	}
 
-	trRes, err := c.performTransaction(msg, false)
+	res, err := c.performTransaction(msg)
 	if err != nil {
 		return err
 	}
-
-	res := trRes.Msg
 
 	if res.Type.Class == stun.ClassErrorResponse {
 		var code stun.ErrorCodeAttribute
@@ -816,12 +816,10 @@ func (c *UDPConn) bind(bound *binding) error {
 		return err
 	}
 
-	trRes, err := c.performTransaction(msg, false)
+	res, err := c.performTransaction(msg)
 	if err != nil {
 		return fmt.Errorf("%w: %w", errChannelBindTransactionFailed, err)
 	}
-
-	res := trRes.Msg
 	if res.Type.Class == stun.ClassErrorResponse {
 		return c.handleChannelBindErrorResponse(res)
 	}

--- a/internal/client/udp_conn_test.go
+++ b/internal/client/udp_conn_test.go
@@ -63,12 +63,12 @@ func TestNewUDPConnRejectsMissingAbortBeforeStartingWork(t *testing.T) {
 func TestNewUDPConnBuildsUnstartedAndClosesOnce(t *testing.T) {
 	var releases atomic.Int32
 	mock := &testConnScript{
-		performTransaction: func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
-			if msg.Type.Method == stun.MethodRefresh && dontWait {
+		startTransaction: func(msg *stun.Message) error {
+			if msg.Type.Method == stun.MethodRefresh {
 				releases.Add(1)
 			}
 
-			return TransactionResult{}, nil
+			return nil
 		},
 	}
 	conn := newTestConn(t, mock)
@@ -85,8 +85,8 @@ func TestNewUDPConnBuildsUnstartedAndClosesOnce(t *testing.T) {
 
 func TestNewUDPConnStartsTimers(t *testing.T) {
 	mock := &testConnScript{
-		performTransaction: func(*stun.Message, bool) (TransactionResult, error) {
-			return TransactionResult{}, nil
+		performTransaction: func(*stun.Message) (*stun.Message, error) {
+			return new(stun.Message), nil
 		},
 	}
 	conn := NewUDPConn(testAllocationConfig(mock), func() {})
@@ -157,8 +157,8 @@ func newInboundDeliveryConn(t *testing.T) *UDPConn {
 	t.Helper()
 
 	return newTestConn(t, &testConnScript{
-		performTransaction: func(*stun.Message, bool) (TransactionResult, error) {
-			return TransactionResult{}, nil
+		performTransaction: func(*stun.Message) (*stun.Message, error) {
+			return nil, nil
 		},
 	})
 }
@@ -226,6 +226,42 @@ func assertRequestShape(
 	assert.Equal(t, expected.Raw, actual.Raw, "TURN request normalized to the generated transaction ID")
 }
 
+func TestUDPConnReleaseUsesStartTransactionAndPreservesRequest(t *testing.T) {
+	startCalls := 0
+	config := testAllocationConfig(&testConnScript{
+		performTransaction: func(*stun.Message) (*stun.Message, error) {
+			require.Fail(t, "release used the waited transaction crossing")
+
+			return nil, errFake
+		},
+	})
+	config.StartTransaction = func(msg *stun.Message) error {
+		startCalls++
+		assertRequestShape(t, msg, []stun.AttrType{
+			stun.AttrLifetime,
+			stun.AttrUsername,
+			stun.AttrRealm,
+			stun.AttrNonce,
+			stun.AttrMessageIntegrity,
+			stun.AttrFingerprint,
+		},
+			stun.NewType(stun.MethodRefresh, stun.ClassRequest),
+			proto.Lifetime{Duration: 0},
+			config.Username,
+			config.Realm,
+			config.Nonce,
+			config.Integrity,
+			stun.Fingerprint,
+		)
+
+		return nil
+	}
+	conn := newUDPConn(config, func() {})
+
+	require.NoError(t, conn.Close())
+	assert.Equal(t, 1, startCalls)
+}
+
 func TestRefreshAllocationPreservesRequestAndRetriesStaleNonce(t *testing.T) {
 	const lifetime = time.Hour
 	username := stun.NewUsername("user")
@@ -245,9 +281,8 @@ func TestRefreshAllocationPreservesRequestAndRetriesStaleNonce(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			calls := 0
 			script := &testConnScript{
-				performTransaction: func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
+				performTransaction: func(msg *stun.Message) (*stun.Message, error) {
 					calls++
-					assert.False(t, dontWait)
 					nonce := oldNonce
 					if calls > 1 {
 						nonce = freshNonce
@@ -269,17 +304,17 @@ func TestRefreshAllocationPreservesRequestAndRetriesStaleNonce(t *testing.T) {
 						stun.Fingerprint,
 					)
 					if tt.staleFirst && calls == 1 {
-						return TransactionResult{Msg: stun.MustBuild(
+						return stun.MustBuild(
 							stun.NewType(stun.MethodRefresh, stun.ClassErrorResponse),
 							stun.ErrorCodeAttribute{Code: stun.CodeStaleNonce, Reason: []byte("Stale Nonce")},
 							freshNonce,
-						)}, nil
+						), nil
 					}
 
-					return TransactionResult{Msg: stun.MustBuild(
+					return stun.MustBuild(
 						stun.NewType(stun.MethodRefresh, stun.ClassSuccessResponse),
 						proto.Lifetime{Duration: lifetime},
-					)}, nil
+					), nil
 				},
 			}
 			conn := newTestConn(t, script)
@@ -306,8 +341,7 @@ func TestPermissionAndBindingRequestShapes(t *testing.T) {
 	peerB := netip.MustParseAddrPort("192.0.2.2:6000")
 	var bound *binding
 	script := &testConnScript{
-		performTransaction: func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
-			assert.False(t, dontWait)
+		performTransaction: func(msg *stun.Message) (*stun.Message, error) {
 			switch msg.Type.Method {
 			case stun.MethodCreatePermission:
 				assertRequestShape(t, msg, []stun.AttrType{
@@ -329,9 +363,9 @@ func TestPermissionAndBindingRequestShapes(t *testing.T) {
 					stun.Fingerprint,
 				)
 
-				return TransactionResult{Msg: stun.MustBuild(
+				return stun.MustBuild(
 					stun.NewType(stun.MethodCreatePermission, stun.ClassSuccessResponse),
-				)}, nil
+				), nil
 			case stun.MethodChannelBind:
 				assertRequestShape(t, msg, []stun.AttrType{
 					stun.AttrXORPeerAddress,
@@ -352,11 +386,11 @@ func TestPermissionAndBindingRequestShapes(t *testing.T) {
 					stun.Fingerprint,
 				)
 
-				return TransactionResult{Msg: stun.MustBuild(
+				return stun.MustBuild(
 					stun.NewType(stun.MethodChannelBind, stun.ClassSuccessResponse),
-				)}, nil
+				), nil
 			default:
-				return TransactionResult{}, errFake
+				return nil, errFake
 			}
 		},
 	}
@@ -390,8 +424,8 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 	t.Run("maybeBind()", func(t *testing.T) {
 		t.Run("fresh success becomes preparable", func(t *testing.T) {
 			conn := makeConn(&testConnScript{
-				performTransaction: func(*stun.Message, bool) (TransactionResult, error) {
-					return TransactionResult{Msg: new(stun.Message)}, nil
+				performTransaction: func(*stun.Message) (*stun.Message, error) {
+					return new(stun.Message), nil
 				},
 			})
 			bound := requireBinding(t, conn.bindingMgr, netip.MustParseAddrPort("127.0.0.1:1234"))
@@ -411,10 +445,10 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		t.Run("recent confirmation does not refresh", func(t *testing.T) {
 			var attempts atomic.Int32
 			conn := makeConn(&testConnScript{
-				performTransaction: func(*stun.Message, bool) (TransactionResult, error) {
+				performTransaction: func(*stun.Message) (*stun.Message, error) {
 					attempts.Add(1)
 
-					return TransactionResult{Msg: new(stun.Message)}, nil
+					return new(stun.Message), nil
 				},
 			})
 			bound := requireBinding(t, conn.bindingMgr, netip.MustParseAddrPort("127.0.0.1:1234"))
@@ -427,10 +461,10 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		t.Run("stale confirmation refreshes", func(t *testing.T) {
 			var attempts atomic.Int32
 			conn := makeConn(&testConnScript{
-				performTransaction: func(*stun.Message, bool) (TransactionResult, error) {
+				performTransaction: func(*stun.Message) (*stun.Message, error) {
 					attempts.Add(1)
 
-					return TransactionResult{Msg: new(stun.Message)}, nil
+					return new(stun.Message), nil
 				},
 			})
 			bound := requireBinding(t, conn.bindingMgr, netip.MustParseAddrPort("127.0.0.1:1234"))
@@ -444,7 +478,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 	t.Run("bind()", func(t *testing.T) {
 		tests := []struct {
 			name                 string
-			transactionFn        func(*stun.Message, bool) (TransactionResult, error)
+			transactionFn        func(*stun.Message) (*stun.Message, error)
 			expectErr            error
 			expectErrContains    string
 			expectBadRequest     bool
@@ -454,29 +488,29 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		}{
 			{
 				name: "PerformTransaction returns error",
-				transactionFn: func(*stun.Message, bool) (TransactionResult, error) {
-					return TransactionResult{}, errFake
+				transactionFn: func(*stun.Message) (*stun.Message, error) {
+					return nil, errFake
 				},
 				expectErr:            errFake,
 				expectBindingDeleted: false,
 			},
 			{
 				name: "ErrorResponse with CodeStaleNonce triggers nonce update",
-				transactionFn: func(*stun.Message, bool) (TransactionResult, error) {
-					return TransactionResult{Msg: staleNonceMsg()}, nil
+				transactionFn: func(*stun.Message) (*stun.Message, error) {
+					return staleNonceMsg(), nil
 				},
 				expectErr:          errTryAgain,
 				expectNonceChanged: true,
 			},
 			{
 				name: "ErrorResponse with error code returns cannot bind channel error",
-				transactionFn: func(*stun.Message, bool) (TransactionResult, error) {
+				transactionFn: func(*stun.Message) (*stun.Message, error) {
 					res := stun.MustBuild(
 						stun.NewType(stun.MethodChannelBind, stun.ClassErrorResponse),
 						stun.ErrorCodeAttribute{Code: stun.CodeForbidden, Reason: []byte("Forbidden")},
 					)
 
-					return TransactionResult{Msg: res}, nil
+					return res, nil
 				},
 				expectErr:           errCannotBindChannel,
 				expectErrContains:   "received error",
@@ -484,13 +518,13 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 			},
 			{
 				name: "ErrorResponse with CodeBadRequest is detectable",
-				transactionFn: func(*stun.Message, bool) (TransactionResult, error) {
+				transactionFn: func(*stun.Message) (*stun.Message, error) {
 					res := stun.MustBuild(
 						stun.NewType(stun.MethodChannelBind, stun.ClassErrorResponse),
 						stun.ErrorCodeAttribute{Code: stun.CodeBadRequest, Reason: []byte("Bad Request")},
 					)
 
-					return TransactionResult{Msg: res}, nil
+					return res, nil
 				},
 				expectErr:           errCannotBindChannel,
 				expectErrContains:   "received error",
@@ -499,12 +533,12 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 			},
 			{
 				name: "ErrorResponse without error code returns unexpected response type error",
-				transactionFn: func(*stun.Message, bool) (TransactionResult, error) {
+				transactionFn: func(*stun.Message) (*stun.Message, error) {
 					res := stun.MustBuild(
 						stun.NewType(stun.MethodChannelBind, stun.ClassErrorResponse),
 					)
 
-					return TransactionResult{Msg: res}, nil
+					return res, nil
 				},
 				expectErr:         errCannotBindChannel,
 				expectErrContains: "unexpected response type",
@@ -563,10 +597,10 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 	t.Run("bindChannel exhausts stale nonce retries without a typed TURN error", func(t *testing.T) {
 		var attempts atomic.Int32
 		conn := makeConn(&testConnScript{
-			performTransaction: func(*stun.Message, bool) (TransactionResult, error) {
+			performTransaction: func(*stun.Message) (*stun.Message, error) {
 				attempts.Add(1)
 
-				return TransactionResult{Msg: staleNonceMsg()}, nil
+				return staleNonceMsg(), nil
 			},
 		})
 		bound := requireBinding(t, conn.bindingMgr, netip.MustParseAddrPort("127.0.0.1:1234"))
@@ -587,12 +621,12 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		var failed atomic.Bool
 
 		conn := makeConn(&testConnScript{
-			performTransaction: func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
+			performTransaction: func(msg *stun.Message) (*stun.Message, error) {
 				if failed.CompareAndSwap(false, true) {
-					return TransactionResult{}, errFake
+					return nil, errFake
 				}
 
-				return TransactionResult{Msg: new(stun.Message)}, nil
+				return new(stun.Message), nil
 			},
 		})
 		bound := requireBinding(t, conn.bindingMgr, netip.MustParseAddrPort("127.0.0.1:1234"))
@@ -626,32 +660,34 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		peerAddr := netip.MustParseAddrPort("127.0.0.1:50000")
 		deallocatedCh := make(chan net.Addr, 1)
 		refreshLifetimeCh := make(chan time.Duration, 1)
-		refreshDontWaitCh := make(chan bool, 1)
 		refreshErrCh := make(chan error, 1)
 
 		script := &testConnScript{
-			performTransaction: func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
+			performTransaction: func(msg *stun.Message) (*stun.Message, error) {
 				switch msg.Type.Method {
 				case stun.MethodChannelBind:
-					return TransactionResult{
-						Msg: stun.MustBuild(
+					return stun.MustBuild(
 							stun.NewType(stun.MethodChannelBind, stun.ClassErrorResponse),
 							stun.ErrorCodeAttribute{Code: stun.CodeBadRequest, Reason: []byte("Bad Request")},
 						),
-					}, nil
+						nil
 				case stun.MethodRefresh:
+					return nil, errFake
+				default:
+					return nil, errFake
+				}
+			},
+			startTransaction: func(msg *stun.Message) error {
+				if msg.Type.Method == stun.MethodRefresh {
 					var lifetime proto.Lifetime
 					if err := lifetime.GetFrom(msg); err != nil {
 						refreshErrCh <- err
 					} else {
 						refreshLifetimeCh <- lifetime.Duration
-						refreshDontWaitCh <- dontWait
 					}
-
-					return TransactionResult{}, nil
-				default:
-					return TransactionResult{}, errFake
 				}
+
+				return nil
 			},
 			onDeallocated: func(addr net.Addr) {
 				deallocatedCh <- addr
@@ -686,13 +722,6 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 			assert.Fail(t, "timed out waiting for refresh deallocation")
 		}
 
-		select {
-		case dontWait := <-refreshDontWaitCh:
-			assert.True(t, dontWait)
-		case <-time.After(5 * time.Second):
-			assert.Fail(t, "timed out waiting for refresh dontWait flag")
-		}
-
 		_, err := conn.WriteTo([]byte("still closed"), peerAddr)
 		assert.ErrorIs(t, err, net.ErrClosed)
 		var turnErr *stun.TurnError
@@ -711,18 +740,16 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		deallocatedCh := make(chan net.Addr, 1)
 
 		script := &testConnScript{
-			performTransaction: func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
+			performTransaction: func(msg *stun.Message) (*stun.Message, error) {
 				switch msg.Type.Method {
 				case stun.MethodChannelBind:
 					if channelBindAttempts.Add(1) == 1 {
-						return TransactionResult{}, errFake
+						return nil, errFake
 					}
 
-					return TransactionResult{Msg: badRequestMsg()}, nil
-				case stun.MethodRefresh:
-					return TransactionResult{}, nil
+					return badRequestMsg(), nil
 				default:
-					return TransactionResult{}, errFake
+					return nil, errFake
 				}
 			},
 			onDeallocated: func(addr net.Addr) {
@@ -765,18 +792,16 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		var channelBindAttempts atomic.Int32
 
 		script := &testConnScript{
-			performTransaction: func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
+			performTransaction: func(msg *stun.Message) (*stun.Message, error) {
 				switch msg.Type.Method {
 				case stun.MethodChannelBind:
 					if channelBindAttempts.Add(1) == 1 {
-						return TransactionResult{}, newTimeoutError("channel bind timeout")
+						return nil, newTimeoutError("channel bind timeout")
 					}
 
-					return TransactionResult{Msg: badRequestMsg()}, nil
-				case stun.MethodRefresh:
-					return TransactionResult{}, nil
+					return badRequestMsg(), nil
 				default:
-					return TransactionResult{}, errFake
+					return nil, errFake
 				}
 			},
 		}
@@ -814,10 +839,10 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		staleRefreshedAt := time.Now().Add(-(defaultBindingRefreshInterval + time.Minute))
 		var channelBindAttempts atomic.Int32
 		conn := makeConn(&testConnScript{
-			performTransaction: func(msg *stun.Message, dontWait bool) (TransactionResult, error) {
+			performTransaction: func(msg *stun.Message) (*stun.Message, error) {
 				channelBindAttempts.Add(1)
 
-				return TransactionResult{Msg: badRequestMsg()}, nil
+				return badRequestMsg(), nil
 			},
 		})
 		bound := requireBinding(t, conn.bindingMgr, netip.MustParseAddrPort("127.0.0.1:1234"))
@@ -837,8 +862,8 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 
 	t.Run("WriteTo()", func(t *testing.T) {
 		script := &testConnScript{
-			performTransaction: func(*stun.Message, bool) (TransactionResult, error) {
-				return TransactionResult{}, errFake
+			performTransaction: func(*stun.Message) (*stun.Message, error) {
+				return nil, errFake
 			},
 			writeTo: func(data []byte) (int, error) {
 				return len(data), nil
@@ -867,8 +892,8 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 	t.Run("ChannelBind transaction failure retains channel number", func(t *testing.T) {
 		addr := netip.MustParseAddrPort("127.0.0.1:9999")
 		script := &testConnScript{
-			performTransaction: func(*stun.Message, bool) (TransactionResult, error) {
-				return TransactionResult{}, errFake
+			performTransaction: func(*stun.Message) (*stun.Message, error) {
+				return nil, errFake
 			},
 			writeTo: func(data []byte) (int, error) {
 				return len(data), nil
@@ -963,13 +988,13 @@ func TestCreatePermissions(t *testing.T) {
 	t.Run("CreatePermissions success", func(t *testing.T) {
 		called := false
 		script := &testConnScript{
-			performTransaction: func(msg *stun.Message, _ bool) (TransactionResult, error) {
+			performTransaction: func(msg *stun.Message) (*stun.Message, error) {
 				called = true
 				// Simulate a successful response
 				res := stun.New()
 				res.Type = stun.NewType(stun.MethodCreatePermission, stun.ClassSuccessResponse)
 
-				return TransactionResult{Msg: res}, nil
+				return res, nil
 			},
 		}
 		conn := newTestConn(t, script)
@@ -981,7 +1006,7 @@ func TestCreatePermissions(t *testing.T) {
 
 	t.Run("CreatePermissions error", func(t *testing.T) {
 		script := &testConnScript{
-			performTransaction: func(msg *stun.Message, _ bool) (TransactionResult, error) {
+			performTransaction: func(msg *stun.Message) (*stun.Message, error) {
 				res := stun.New()
 				res.Type = stun.NewType(stun.MethodCreatePermission, stun.ClassErrorResponse)
 				code := stun.ErrorCodeAttribute{
@@ -990,7 +1015,7 @@ func TestCreatePermissions(t *testing.T) {
 				}
 				_ = code.AddTo(res)
 
-				return TransactionResult{Msg: res}, nil
+				return res, nil
 			},
 		}
 		conn := newTestConn(t, script)

--- a/scripted_allocation_test.go
+++ b/scripted_allocation_test.go
@@ -18,7 +18,8 @@ import (
 )
 
 type scriptedAllocationScript struct {
-	performTransaction func(msg *stun.Message, dontWait bool) (client.TransactionResult, error)
+	performTransaction func(msg *stun.Message) (*stun.Message, error)
+	startTransaction   func(msg *stun.Message) error
 	onDeallocated      func(relayedAddr net.Addr)
 	onChannelBind      func(msg *stun.Message)
 	permissionCount    atomic.Int32
@@ -39,31 +40,39 @@ func (s *scriptedAllocationScript) writeTo(data []byte) (int, error) {
 }
 
 func (s *scriptedAllocationScript) transact(
-	msg *stun.Message, dontWait bool,
-) (client.TransactionResult, error) {
+	msg *stun.Message,
+) (*stun.Message, error) {
 	if s.performTransaction != nil {
-		return s.performTransaction(msg, dontWait)
+		return s.performTransaction(msg)
 	}
 
 	switch msg.Type.Method {
 	case stun.MethodCreatePermission:
 		s.permissionCount.Add(1)
 
-		return client.TransactionResult{Msg: stun.MustBuild(
+		return stun.MustBuild(
 			stun.NewType(stun.MethodCreatePermission, stun.ClassSuccessResponse),
-		)}, nil
+		), nil
 	case stun.MethodChannelBind:
 		s.bindingCount.Add(1)
 		if s.onChannelBind != nil {
 			s.onChannelBind(msg)
 		}
 
-		return client.TransactionResult{Msg: stun.MustBuild(
+		return stun.MustBuild(
 			stun.NewType(stun.MethodChannelBind, stun.ClassSuccessResponse),
-		)}, nil
+		), nil
 	default:
-		return client.TransactionResult{}, nil
+		return new(stun.Message), nil
 	}
+}
+
+func (s *scriptedAllocationScript) start(msg *stun.Message) error {
+	if s.startTransaction != nil {
+		return s.startTransaction(msg)
+	}
+
+	return nil
 }
 
 func (s *scriptedAllocationScript) deallocated(relayedAddr net.Addr) {
@@ -92,6 +101,7 @@ func newScriptedAllocation(
 	conn := client.NewUDPConn(&client.AllocationConfig{
 		WriteTo:            script.writeTo,
 		PerformTransaction: script.transact,
+		StartTransaction:   script.start,
 		OnDeallocated:      script.deallocated,
 		RelayedAddr:        net.UDPAddrFromAddrPort(relayed),
 		Username:           stun.NewUsername("user"),


### PR DESCRIPTION
Closes #90
Parent: #85

Plan: `docs/adr/2026-08-19-udpconn-construction-crossing-plan.md`
Recorded plan commit: `dfee1df4bbd4d828f9185b1fa6afc94161b4139d`
Exact slice: `Slice T1.S2 — Two named transaction crossings`

## Outcome

- Replaces the mode-flag Allocation crossing with `PerformTransaction(*stun.Message) (*stun.Message, error)` and `StartTransaction(*stun.Message) error`.
- Wires root directly to `TransactionRegistry.Perform` and `TransactionRegistry.Start`, removes `Client.performTransaction`, and keeps the registry as the sole waited/fire-and-forget semantics owner.
- Gives lifetime-zero Release a named `UDPConn.emitRelease` path using the same Refresh builder as waited refreshes.
- Deletes the exported-internal `TransactionResult` bag and keeps only a private registry channel payload.

## Contract

Supported domain: the two transaction operations, their waited Refresh and lifetime-zero Release consumers, and Refresh requests for lifetime L and zero. The guarantee is universal over that finite set. `TransactionRegistry` owns transaction semantics; `UDPConn` owns operation selection and Release emission; `startCloseLocked` still owns abort → deallocation → Release ordering.

Artifacts: the crossing shape and Release emitter are shipped behavior; registry guards remain required safety enforcement; adapted tests are verification aids; this PR and plan status are process metadata. Contract closure remains not triggered because Release has one owner and one reachable path.

## Validation so far

- Focused Release byte-shape, waited Refresh, lifecycle, close-ordering, nonce, and registry tests
- `task check`
- `task race`

The PR remains draft through bounded RAS review and exact-head local certification. Completion/frontier status will be committed here before the first review.
