### PR TITLE
Centralize the public error vocabulary

### DIFF
--- a/allocation.go
+++ b/allocation.go
@@ -37,6 +37,10 @@ func (a *Allocation) RelayedAddr() netip.AddrPort {
 // the same peer share one permission and one bind; canceling ctx wakes only
 // that caller and leaves the shared work running.
 func (a *Allocation) PreparePeer(ctx context.Context, peer netip.AddrPort) error {
+	if ctx == nil {
+		return errNilContext
+	}
+
 	canonical, ok := canonicalAddrPort(peer, canonicalUnmap)
 	if !ok {
 		return fmt.Errorf("%w: %s", ErrInvalidPeer, peer)

--- a/allocation_test.go
+++ b/allocation_test.go
@@ -32,6 +32,26 @@ func invalidPeers() map[string]netip.AddrPort {
 	}
 }
 
+func TestAllocationPreparePeerRejectsNilContextFirst(t *testing.T) {
+	script := &scriptedAllocationScript{}
+	allocation, _ := newScriptedAllocation(t, script)
+
+	//nolint:staticcheck // Nil is the programmer-error input under test.
+	err := allocation.PreparePeer(nil, netip.AddrPort{})
+
+	assert.ErrorIs(t, err, errNilContext)
+	assert.NotErrorIs(t, err, ErrInvalidPeer)
+	assert.Equal(t, int32(0), script.permissionCount.Load())
+	assert.Equal(t, int32(0), script.bindingCount.Load())
+}
+
+func TestAllocateRejectsNilContext(t *testing.T) {
+	allocation, err := (&Client{}).Allocate(nil) //nolint:staticcheck // Nil is the programmer-error input under test.
+
+	assert.Nil(t, allocation)
+	assert.ErrorIs(t, err, errNilContext)
+}
+
 func TestAllocationRejectsInvalidPeers(t *testing.T) {
 	script := &scriptedAllocationScript{}
 	allocation, _ := newScriptedAllocation(t, script)

--- a/client_test.go
+++ b/client_test.go
@@ -338,7 +338,7 @@ func TestHandleInboundLiveUnknownChannelReturnsExistingErrorWithoutDelivery(t *t
 	)
 
 	assert.ErrorIs(t, err, errChannelBindNotFound)
-	assert.EqualError(t, err, "no binding found for channel: 16384")
+	assert.EqualError(t, err, "turn: no binding found for channel: 16384")
 	require.NoError(t, turnClient.HandleInbound(
 		buildDataIndication(t, []byte("marker"), peer),
 		net.UDPAddrFromAddrPort(server),

--- a/docs/adr/2026-08-19-allocate-admission-errors-plan.md
+++ b/docs/adr/2026-08-19-allocate-admission-errors-plan.md
@@ -1,7 +1,7 @@
 # Allocate Admission and Public Error Vocabulary Implementation Plan
 
 **Date:** 2026-08-19
-**Status:** T2.S1 implemented by PR #100; T2.S2 pending
+**Status:** Complete via PRs #100 and #103
 **Track:** 2 of 4 in the 2026-08-19 seam deepening program
 **Depends on:** Nothing — parallel-safe; T1.S1 is recommended first to reduce test churn but is not a blocker
 **Related:** [Program index](2026-08-19-seam-deepening-program.md), [Allocation lifecycle plan](2026-08-17-allocation-lifecycle-plan.md), [Modernize kept API plan](2026-08-15-modernize-kept-api-plan.md), [Allocation construction timing validity plan](2026-08-19-allocation-construction-timing-validity-plan.md)
@@ -45,7 +45,7 @@ Error vocabulary is split across the seam: `errNilContext` exists in both packag
 | Slice | Status/disposition | Delivers | Blocked by | Removes temporary seam |
 |---|---|---|---|---|
 | T2.S1 | Complete via PR #100 | One admission rule and error for the single live Allocation; relayed address crosses the seam only as canonical `netip.AddrPort`; `TryLock`, `LocalAddr`, `RelayedAddr`, `OnDeallocated` parameter gone; publish-after-validate | None | Second guard; unvalidated relayed-address spelling |
-| T2.S2 | New | One owner for public error identity, prose, and prefix; nil-context checked once at the public ingress; `errFake` out of production vocabulary | None | Duplicate `errNilContext`; diverged prose |
+| T2.S2 | Complete via PR #103 | One owner for public error identity, prose, and prefix; nil-context checked once at the public ingress; `errFake` out of production vocabulary | None | Duplicate `errNilContext`; diverged prose |
 
 ## Implementation Slices
 
@@ -98,6 +98,8 @@ Error vocabulary is split across the seam: `errNilContext` exists in both packag
 
 **What it delivers:** One PR adding the nil-context check to `Allocation.PreparePeer` with root's sentinel, removing the internal check and sentinel, moving `errFake` to a test file, reducing internal sentinel comments to pointers at the root prose, and adding the `turn:` prefix to the remaining unprefixed root sentinels.
 
+**Implementation:** PR #103 is this slice's one product PR.
+
 **Existing-work disposition:** New slice.
 
 **Blocked by:** None. T2.S1 first is recommended (it deletes `errOneAllocateOnly`, one of the unprefixed sentinels) but not required: if T2.S2 lands first it prefixes a sentinel T2.S1 later deletes.
@@ -131,8 +133,8 @@ Error vocabulary is split across the seam: `errNilContext` exists in both packag
 - [x] A concurrent second Allocate, or an Allocate while an Allocation is live, returns `ErrAlreadyAllocated` with zero network output, and an Allocate after the live Allocation ends (caller Close or self-seal) succeeds. Domain: the T2.S1 matrix; owner: `Client.Allocate`; guarantee: universal over that finite set; evidence: the matrix plus one guard mutation.
 - [x] `TryLock`, `errOneAllocateOnly`, `errDoubleLock`, `UDPConn.LocalAddr`, `AllocationConfig.RelayedAddr`, and the `OnDeallocated` address parameter do not exist; the relayed address lives only on root `Allocation` as canonical `netip.AddrPort`.
 - [x] An invalid relayed address still yields exactly one lifetime-zero release and `ErrInvalidRelayedAddress`, and the doomed Allocation is never published to the inbound path.
-- [ ] `Allocate(nil, …)` and `Allocation.PreparePeer(nil, …)` return root's `errNilContext` (checked first); no internal `errNilContext` or production `errFake` exists; every sentinel defined in root `errors.go` has a message starting with `turn:` (the six re-exports keep their text); sentinel identities are unchanged. Domain: root-defined sentinels and the two public ingresses; owner: root `errors.go`; guarantee: universal over that finite set; evidence: two ingress tests and one grep.
-- [ ] Client close semantics, Allocation lifecycle ownership, wire bytes, and public API shape (beyond error text) are unchanged.
+- [x] `Allocate(nil, …)` and `Allocation.PreparePeer(nil, …)` return root's `errNilContext` (checked first); no internal `errNilContext` or production `errFake` exists; every sentinel defined in root `errors.go` has a message starting with `turn:` (the six re-exports keep their text); sentinel identities are unchanged. Domain: root-defined sentinels and the two public ingresses; owner: root `errors.go`; guarantee: universal over that finite set; evidence: two ingress tests and one grep.
+- [x] Client close semantics, Allocation lifecycle ownership, wire bytes, and public API shape (beyond error text) are unchanged.
 
 ## Validation Gates
 

--- a/docs/adr/2026-08-19-seam-deepening-program.md
+++ b/docs/adr/2026-08-19-seam-deepening-program.md
@@ -1,6 +1,6 @@
 # TURN Seam Deepening Program — 2026-08-19
 
-**Status:** Accepted; Track 1 implemented by PRs #96 and #98; T2.S1 implemented by PR #100; remaining slices pending
+**Status:** Accepted; Tracks 1 and 2 implemented by PRs #96, #98, #100, and #103; remaining slices pending
 
 ## What this is
 
@@ -24,11 +24,11 @@ Audit receipt: all six slices were independently slice-audited against `dad68d48
 | # | Track | Plan | Parent issue | Blocked by | Slices | Status |
 |---|---|---|---|---|---|---|
 | 1 | UDPConn construction and transaction crossing | [plan](2026-08-19-udpconn-construction-crossing-plan.md) | [#85](https://github.com/the-sarge/turn/issues/85) | None | 2 | Complete via PRs #96 and #98 |
-| 2 | Allocate admission and public error vocabulary | [plan](2026-08-19-allocate-admission-errors-plan.md) | [#86](https://github.com/the-sarge/turn/issues/86) | None | 2 | T2.S1 complete via PR #100; FRONTIER (T2.S2) |
+| 2 | Allocate admission and public error vocabulary | [plan](2026-08-19-allocate-admission-errors-plan.md) | [#86](https://github.com/the-sarge/turn/issues/86) | None | 2 | Complete via PRs #100 and #103 |
 | 3 | Permission readiness | [plan](2026-08-19-permission-readiness-plan.md) | pending | None | 1 | FRONTIER (T3.S1) |
 | 4 | Allocate exchange | [plan](2026-08-19-allocate-exchange-plan.md) | pending | None | 1 | FRONTIER (T4.S1) |
 
-There are no genuine blocking edges; every remaining slice is independently green. T1.S1, T1.S2, and T2.S1 landed in the strongly recommended order, and the recommended remaining dispatch order to minimize rebases — advice, not a blocker — is T2.S2 → T3.S1 → T4.S1. Known file overlaps: T1 and T3 both touch `internal/client/prepare_test.go`; T1.S2 and T2.S1 both touch `AllocationConfig`; T4.S1 is root-only but shares `client.go` (`sendAllocateRequest`, `Allocate`) with T1.S2 and T2.S1. Text conflicts between independently implemented slices require rebasing, not artificial blockers. T3.S1 and T4.S1 share no files with each other. Recommended next slice: T2.S2.
+There are no genuine blocking edges; every remaining slice is independently green. T1.S1, T1.S2, T2.S1, and T2.S2 landed in the strongly recommended order, and the recommended remaining dispatch order to minimize rebases — advice, not a blocker — is T3.S1 → T4.S1. Known file overlaps: T1 and T3 both touch `internal/client/prepare_test.go`; T1.S2 and T2.S1 both touch `AllocationConfig`; T4.S1 is root-only but shares `client.go` (`sendAllocateRequest`, `Allocate`) with T1.S2 and T2.S1. Text conflicts between independently implemented slices require rebasing, not artificial blockers. T3.S1 and T4.S1 share no files with each other. Recommended next slice: T3.S1.
 
 ## Rules that bind every track
 

--- a/errors.go
+++ b/errors.go
@@ -65,8 +65,8 @@ var (
 	errInvalidPermissionRefreshInterval = errors.New(
 		"turn: PermissionRefreshInterval must be zero or a positive duration less than 5 minutes")
 	errNilContext                   = errors.New("turn: context must not be nil")
-	errChannelBindNotFound          = errors.New("no binding found for channel")
+	errChannelBindNotFound          = errors.New("turn: no binding found for channel")
 	errUnexpectedServerDatagram     = errors.New("turn: datagram from server is neither STUN nor ChannelData")
-	errFailedToDecodeSTUN           = errors.New("failed to decode STUN message")
-	errUnexpectedSTUNRequestMessage = errors.New("unexpected STUN request message")
+	errFailedToDecodeSTUN           = errors.New("turn: failed to decode STUN message")
+	errUnexpectedSTUNRequestMessage = errors.New("turn: unexpected STUN request message")
 )

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -4,12 +4,15 @@
 package client
 
 import (
+	"errors"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/pion/stun/v3"
 )
+
+var errFake = errors.New("fake error") //nolint:err113 // Shared test-local failure sentinel.
 
 // testConnScript is the single internal test adapter for UDPConn's package
 // crossings. Method values read these fields at call time, so tests may

--- a/internal/client/errors.go
+++ b/internal/client/errors.go
@@ -12,31 +12,21 @@ import (
 // Exported sentinels: the failure classes a consumer can act on. The root
 // package re-exports them.
 var (
-	// ErrTransactionTimeout reports a STUN transaction whose retransmissions
-	// were all exhausted without a server response.
+	// ErrTransactionTimeout is re-exported by the root package, which owns its public prose.
 	ErrTransactionTimeout = errors.New("transaction timeout: all retransmissions failed")
-	// ErrAllocationRefreshFailed reports a permanent allocation-refresh
-	// failure. The allocation seals itself with this cause: pending waiters
-	// wake, and every subsequent operation returns net.ErrClosed wrapped with
-	// it.
+	// ErrAllocationRefreshFailed is re-exported by the root package, which owns its public prose.
 	ErrAllocationRefreshFailed = errors.New("allocation refresh failed")
-	// ErrPermissionRefreshFailed reports a permission refresh that kept
-	// failing after retries; prepared bindings for the allocation terminalize
-	// with it.
+	// ErrPermissionRefreshFailed is re-exported by the root package, which owns its public prose.
 	ErrPermissionRefreshFailed = errors.New("permission refresh failed")
-	// ErrChannelBindFailed reports a channel binding that could not be
-	// established or has failed.
+	// ErrChannelBindFailed is re-exported by the root package, which owns its public prose.
 	ErrChannelBindFailed = errors.New("channel bind failed")
-	// ErrChannelBindingExpired reports a confirmed channel binding whose
-	// server-side lifetime has expired.
+	// ErrChannelBindingExpired is re-exported by the root package, which owns its public prose.
 	ErrChannelBindingExpired = errors.New("confirmed channel binding expired")
-	// ErrNotPrepared reports a write to a peer that has no prepared,
-	// confirmed channel binding: nothing was sent.
+	// ErrNotPrepared is re-exported by the root package, which owns its public prose.
 	ErrNotPrepared = errors.New("peer not prepared: no confirmed channel binding")
 )
 
 var (
-	errFake                          = errors.New("fake error")
 	errTryAgain                      = errors.New("try again")
 	errTransactionClosed             = fmt.Errorf("transaction closed: %w", net.ErrClosed)
 	errTransactionAlreadyExists      = errors.New("transaction ID is already live")
@@ -47,5 +37,4 @@ var (
 	errCannotBindChannel             = errors.New("cannot bind channel")
 	errChannelBindBadRequest         = errors.New("channel bind bad request")
 	errChannelBindTransactionFailed  = errors.New("channel bind transaction failed")
-	errNilContext                    = errors.New("context must not be nil")
 )

--- a/internal/client/udp_conn.go
+++ b/internal/client/udp_conn.go
@@ -211,9 +211,6 @@ func (c *UDPConn) createPermission(perm *permission, addr netip.AddrPort) error 
 // share one permission and one bind attempt; canceling ctx wakes only that
 // caller (with its cause) and leaves the shared work running.
 func (c *UDPConn) PreparePeer(ctx context.Context, peer netip.AddrPort) error {
-	if ctx == nil {
-		return errNilContext
-	}
 	if err := ctx.Err(); err != nil {
 		return context.Cause(ctx)
 	}


### PR DESCRIPTION
Closes #92

Parent: #86

Normative plan: `docs/adr/2026-08-19-allocate-admission-errors-plan.md`

Plan commit: `dfee1df4bbd4d828f9185b1fa6afc94161b4139d`

Slice: `Slice T2.S2 — One owner for the public error vocabulary`

## Summary

- enforce nil context once at each public ingress
- keep public error identity, prose, and prefixes at the root package
- move the shared fake failure sentinel into test code

## Validation

- `go test ./...`
- `go test -race ./...`
- `task verify`