### PR TITLE
client: let permissions own readiness attempts

### DIFF
--- a/docs/adr/2026-08-19-permission-readiness-plan.md
+++ b/docs/adr/2026-08-19-permission-readiness-plan.md
@@ -94,10 +94,10 @@ Tests probe readiness by `permMap.find(peer).state() == permStatePermitted` (`pr
 
 ## Acceptance Criteria
 
-- [ ] Every permission state and attempt transition in the supported finite domain has one owner in `permission`; `UDPConn` drives no permission lock or raw field. Domain: the matrix; owner: `permission`; guarantee: universal over the finite matrix; evidence: table, preserved PreparePeer tests, one guard mutation.
-- [ ] Concurrent PreparePeer callers for one peer IP share one CreatePermission attempt; a failed fresh attempt wakes waiters with that exact attempt generation's error even if a stale caller starts or completes a replacement first; the next caller starts fresh; a closing Allocation wakes joined waiters with the terminal cause.
-- [ ] `permState`, `setState`, the raw `state()` accessor, `perm.mutex`, `attemptMutex`, `permissionMap.insert`, `permissionMap.find`, and the dead `pm.insert` test setup do not exist; no shared helper with channel binding exists.
-- [ ] Permission identity, CreatePermission bytes, retry count, refresh cadence and membership rule, prepared-binding terminalization, seal precedence, waiter-local cancellation, and public API are unchanged; the only behavior change is that a permission succeeding after an intermediate 438 remains in `permMap`.
+- [x] Every permission state and attempt transition in the supported finite domain has one owner in `permission`; `UDPConn` drives no permission lock or raw field. Domain: the matrix; owner: `permission`; guarantee: universal over the finite matrix; evidence: table, preserved PreparePeer tests, one guard mutation.
+- [x] Concurrent PreparePeer callers for one peer IP share one CreatePermission attempt; a failed fresh attempt wakes waiters with that exact attempt generation's error even if a stale caller starts or completes a replacement first; the next caller starts fresh; a closing Allocation wakes joined waiters with the terminal cause.
+- [x] `permState`, `setState`, the raw `state()` accessor, `perm.mutex`, `attemptMutex`, `permissionMap.insert`, `permissionMap.find`, and the dead `pm.insert` test setup do not exist; no shared helper with channel binding exists.
+- [x] Permission identity, CreatePermission bytes, retry count, refresh cadence and membership rule, prepared-binding terminalization, seal precedence, waiter-local cancellation, and public API are unchanged; the only behavior change is that a permission succeeding after an intermediate 438 remains in `permMap`.
 
 ## Validation Gates
 

--- a/docs/adr/2026-08-19-permission-readiness-plan.md
+++ b/docs/adr/2026-08-19-permission-readiness-plan.md
@@ -1,7 +1,7 @@
 # Permission Readiness Implementation Plan
 
 **Date:** 2026-08-19
-**Status:** Accepted; not yet implemented
+**Status:** Complete via PR #105
 **Track:** 3 of 4 in the 2026-08-19 seam deepening program
 **Depends on:** Nothing — parallel-safe; T1.S1 first is recommended to avoid `prepare_test.go` conflicts but is not a blocker
 **Related:** [Program index](2026-08-19-seam-deepening-program.md), [Channel-binding readiness plan](2026-08-19-channel-binding-readiness-plan.md), [Prepared-only writes ADR](2026-08-15-prepared-only-writes.md), [Permission owns its attempt ADR](2026-08-19-permission-owns-its-attempt.md), [Allocation lifecycle plan](2026-08-17-allocation-lifecycle-plan.md)
@@ -40,13 +40,15 @@ Tests probe readiness by `permMap.find(peer).state() == permStatePermitted` (`pr
 
 | Slice | Status/disposition | Delivers | Blocked by | Removes temporary seam |
 |---|---|---|---|---|
-| T3.S1 | New | `permission` owns begin/join/resolve and the permitted fact behind three operations; `UDPConn` drives no permission lock or raw field; vestigial lock, enum, atomics, `insert`/`find` gone | None | Raw permission state protocol in `UDPConn` |
+| T3.S1 | Complete via PR #105 | `permission` owns begin/join/resolve and the permitted fact behind three operations; `UDPConn` drives no permission lock or raw field; vestigial lock, enum, atomics, `insert`/`find` gone | None | Raw permission state protocol in `UDPConn` |
 
 ## Implementation Slices
 
 ### Slice T3.S1 — Permission owns its attempt and readiness
 
 **What it delivers:** One PR introducing the three permission operations, migrating `awaitPermission`/`ensurePermissionAttempt`/`createPermission` to them, deleting the raw accessors, enum, atomics, `perm.mutex`, `insert`, `find`, and the dead `pm.insert` test setup, and replacing accessor/CRUD tests with a table over begin/join/resolve plus preserved PreparePeer behavior.
+
+**Implementation:** PR #105 is this slice's one product PR.
 
 **Existing-work disposition:** New slice.
 

--- a/docs/adr/2026-08-19-seam-deepening-program.md
+++ b/docs/adr/2026-08-19-seam-deepening-program.md
@@ -1,6 +1,6 @@
 # TURN Seam Deepening Program — 2026-08-19
 
-**Status:** Accepted; Tracks 1 and 2 implemented by PRs #96, #98, #100, and #103; remaining slices pending
+**Status:** Accepted; Tracks 1, 2, and 3 implemented by PRs #96, #98, #100, #103, and #105; Track 4 pending
 
 ## What this is
 
@@ -25,10 +25,10 @@ Audit receipt: all six slices were independently slice-audited against `dad68d48
 |---|---|---|---|---|---|---|
 | 1 | UDPConn construction and transaction crossing | [plan](2026-08-19-udpconn-construction-crossing-plan.md) | [#85](https://github.com/the-sarge/turn/issues/85) | None | 2 | Complete via PRs #96 and #98 |
 | 2 | Allocate admission and public error vocabulary | [plan](2026-08-19-allocate-admission-errors-plan.md) | [#86](https://github.com/the-sarge/turn/issues/86) | None | 2 | Complete via PRs #100 and #103 |
-| 3 | Permission readiness | [plan](2026-08-19-permission-readiness-plan.md) | pending | None | 1 | FRONTIER (T3.S1) |
+| 3 | Permission readiness | [plan](2026-08-19-permission-readiness-plan.md) | [#87](https://github.com/the-sarge/turn/issues/87) | None | 1 | Complete via PR #105 |
 | 4 | Allocate exchange | [plan](2026-08-19-allocate-exchange-plan.md) | pending | None | 1 | FRONTIER (T4.S1) |
 
-There are no genuine blocking edges; every remaining slice is independently green. T1.S1, T1.S2, T2.S1, and T2.S2 landed in the strongly recommended order, and the recommended remaining dispatch order to minimize rebases — advice, not a blocker — is T3.S1 → T4.S1. Known file overlaps: T1 and T3 both touch `internal/client/prepare_test.go`; T1.S2 and T2.S1 both touch `AllocationConfig`; T4.S1 is root-only but shares `client.go` (`sendAllocateRequest`, `Allocate`) with T1.S2 and T2.S1. Text conflicts between independently implemented slices require rebasing, not artificial blockers. T3.S1 and T4.S1 share no files with each other. Recommended next slice: T3.S1.
+There are no genuine blocking edges; T3.S1 has now landed after T1.S1, T1.S2, T2.S1, and T2.S2, leaving T4.S1 as the independently green frontier. Known file overlaps: T1 and T3 both touch `internal/client/prepare_test.go`; T1.S2 and T2.S1 both touch `AllocationConfig`; T4.S1 is root-only but shares `client.go` (`sendAllocateRequest`, `Allocate`) with T1.S2 and T2.S1. Text conflicts between independently implemented slices require rebasing, not artificial blockers. Recommended next slice: T4.S1.
 
 ## Rules that bind every track
 

--- a/internal/client/permission.go
+++ b/internal/client/permission.go
@@ -12,14 +12,25 @@ type permission struct {
 	addr      netip.AddrPort
 	mu        sync.Mutex
 	permitted bool
-	attempt   chan struct{}
+	attempt   *permissionAttempt
 	result    error
 }
 
-// beginOrJoin returns the current attempt's completion signal. The caller that
-// receives fresh=true owns running and resolving the attempt. A nil signal
-// means the permission became ready before this caller could start work.
-func (p *permission) beginOrJoin() (done chan struct{}, fresh bool) {
+// permissionAttempt owns one generation's immutable completion result. A read
+// after done closes observes the result published by resolve.
+type permissionAttempt struct {
+	done chan struct{}
+	err  error
+}
+
+func (a *permissionAttempt) result() error {
+	return a.err
+}
+
+// beginOrJoin returns the current attempt handle. The caller that receives
+// fresh=true owns running and resolving the attempt. A nil handle means the
+// permission became ready before this caller could start work.
+func (p *permission) beginOrJoin() (attempt *permissionAttempt, fresh bool) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
@@ -30,7 +41,7 @@ func (p *permission) beginOrJoin() (done chan struct{}, fresh bool) {
 		return p.attempt, false
 	}
 
-	p.attempt = make(chan struct{})
+	p.attempt = &permissionAttempt{done: make(chan struct{})}
 	p.result = nil
 
 	return p.attempt, true
@@ -44,11 +55,12 @@ func (p *permission) resolve(err error) {
 	if p.attempt == nil {
 		return
 	}
-	done := p.attempt
+	attempt := p.attempt
 	p.attempt = nil
 	p.result = err
 	p.permitted = err == nil
-	close(done)
+	attempt.err = err
+	close(attempt.done)
 }
 
 // readiness reports the durable permitted fact and the last attempt result.

--- a/internal/client/permission.go
+++ b/internal/client/permission.go
@@ -6,36 +6,57 @@ package client
 import (
 	"net/netip"
 	"sync"
-	"sync/atomic"
-)
-
-type permState int32
-
-const (
-	permStateIdle permState = iota
-	permStatePermitted
 )
 
 type permission struct {
-	addr        netip.AddrPort
-	st          permState     // Thread-safe (atomic op)
-	attemptDone chan struct{} // Protected by attemptMutex; non-nil while a create attempt is in flight
-	attemptErr  error         // Protected by attemptMutex; result of the last create attempt
-
-	// attemptMutex guards the attempt bookkeeping only. It is never held
-	// across a transaction, unlike mutex, which createPermission holds for
-	// the duration of the CreatePermission transaction; waiters joining an
-	// attempt must not block behind that transaction.
-	attemptMutex sync.Mutex   // Thread-safe
-	mutex        sync.RWMutex // Thread-safe
+	addr      netip.AddrPort
+	mu        sync.Mutex
+	permitted bool
+	attempt   chan struct{}
+	result    error
 }
 
-func (p *permission) setState(state permState) {
-	atomic.StoreInt32((*int32)(&p.st), int32(state))
+// beginOrJoin returns the current attempt's completion signal. The caller that
+// receives fresh=true owns running and resolving the attempt. A nil signal
+// means the permission became ready before this caller could start work.
+func (p *permission) beginOrJoin() (done chan struct{}, fresh bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.permitted {
+		return nil, false
+	}
+	if p.attempt != nil {
+		return p.attempt, false
+	}
+
+	p.attempt = make(chan struct{})
+	p.result = nil
+
+	return p.attempt, true
 }
 
-func (p *permission) state() permState {
-	return permState(atomic.LoadInt32((*int32)(&p.st)))
+// resolve publishes one attempt result before waking every joined caller.
+func (p *permission) resolve(err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.attempt == nil {
+		return
+	}
+	done := p.attempt
+	p.attempt = nil
+	p.result = err
+	p.permitted = err == nil
+	close(done)
+}
+
+// readiness reports the durable permitted fact and the last attempt result.
+func (p *permission) readiness() (permitted bool, err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.permitted, p.result
 }
 
 // Thread-safe permission map. TURN permissions are per peer IP, so the map is
@@ -44,15 +65,6 @@ func (p *permission) state() permState {
 type permissionMap struct {
 	permMap map[netip.Addr]*permission
 	mutex   sync.RWMutex
-}
-
-func (m *permissionMap) insert(addr netip.AddrPort, p *permission) bool {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-	p.addr = addr
-	m.permMap[addr.Addr()] = p
-
-	return true
 }
 
 // getOrCreate returns the existing permission for addr, or creates one, so
@@ -70,14 +82,6 @@ func (m *permissionMap) getOrCreate(addr netip.AddrPort) *permission {
 	m.permMap[key] = p
 
 	return p
-}
-
-func (m *permissionMap) find(addr netip.AddrPort) (*permission, bool) {
-	m.mutex.RLock()
-	defer m.mutex.RUnlock()
-	p, ok := m.permMap[addr.Addr()]
-
-	return p, ok
 }
 
 func (m *permissionMap) delete(addr netip.AddrPort) {

--- a/internal/client/permission_test.go
+++ b/internal/client/permission_test.go
@@ -85,7 +85,7 @@ func TestPermissionAttemptLifecycle(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("joined attempt result remains stable when a stale caller starts another attempt", func(t *testing.T) {
+	t.Run("joined failure wins when a stale replacement attempt succeeds", func(t *testing.T) {
 		perm := &permission{}
 		attemptA, fresh := perm.beginOrJoin()
 		require.True(t, fresh)
@@ -96,10 +96,12 @@ func TestPermissionAttemptLifecycle(t *testing.T) {
 		perm.resolve(errFake)
 		attemptB, fresh := perm.beginOrJoin()
 		require.True(t, fresh)
-		assert.ErrorIs(t, joinedA.result(), errFake)
-
 		perm.resolve(nil)
 		<-attemptB.done
+
+		permitted, err := new(UDPConn).permissionAttemptResult(perm, joinedA)
+		assert.False(t, permitted)
+		assert.ErrorIs(t, err, errFake)
 	})
 }
 

--- a/internal/client/permission_test.go
+++ b/internal/client/permission_test.go
@@ -17,12 +17,12 @@ func TestPermissionAttemptLifecycle(t *testing.T) {
 	t.Run("first caller starts and second caller joins one attempt", func(t *testing.T) {
 		perm := &permission{}
 
-		done, fresh := perm.beginOrJoin()
-		require.NotNil(t, done)
+		attempt, fresh := perm.beginOrJoin()
+		require.NotNil(t, attempt)
 		assert.True(t, fresh)
 
 		joined, fresh := perm.beginOrJoin()
-		assert.Equal(t, done, joined)
+		assert.Equal(t, attempt, joined)
 		assert.False(t, fresh)
 	})
 
@@ -45,12 +45,12 @@ func TestPermissionAttemptLifecycle(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			perm := &permission{}
-			done, fresh := perm.beginOrJoin()
+			attempt, fresh := perm.beginOrJoin()
 			require.True(t, fresh)
 
 			perm.resolve(tt.result)
 			select {
-			case <-done:
+			case <-attempt.done:
 			default:
 				assert.Fail(t, "resolve did not wake attempt waiters")
 			}
@@ -59,8 +59,8 @@ func TestPermissionAttemptLifecycle(t *testing.T) {
 			assert.Equal(t, tt.wantPermitted, permitted)
 			assert.ErrorIs(t, err, tt.wantErr)
 			if tt.wantPermitted {
-				done, fresh = perm.beginOrJoin()
-				assert.Nil(t, done, "a permitted permission does not start another attempt")
+				attempt, fresh = perm.beginOrJoin()
+				assert.Nil(t, attempt, "a permitted permission does not start another attempt")
 				assert.False(t, fresh)
 			}
 		})
@@ -72,17 +72,34 @@ func TestPermissionAttemptLifecycle(t *testing.T) {
 		require.True(t, fresh)
 		perm.resolve(errFake)
 
-		done, fresh := perm.beginOrJoin()
+		attempt, fresh := perm.beginOrJoin()
 		require.True(t, fresh)
 		permitted, err := perm.readiness()
 		assert.False(t, permitted)
 		assert.NoError(t, err)
 
 		perm.resolve(nil)
-		<-done
+		<-attempt.done
 		permitted, err = perm.readiness()
 		assert.True(t, permitted)
 		assert.NoError(t, err)
+	})
+
+	t.Run("joined attempt result remains stable when a stale caller starts another attempt", func(t *testing.T) {
+		perm := &permission{}
+		attemptA, fresh := perm.beginOrJoin()
+		require.True(t, fresh)
+		joinedA, fresh := perm.beginOrJoin()
+		assert.Equal(t, attemptA, joinedA)
+		assert.False(t, fresh)
+
+		perm.resolve(errFake)
+		attemptB, fresh := perm.beginOrJoin()
+		require.True(t, fresh)
+		assert.ErrorIs(t, joinedA.result(), errFake)
+
+		perm.resolve(nil)
+		<-attemptB.done
 	})
 }
 
@@ -125,12 +142,12 @@ func TestPermissionMap(t *testing.T) {
 		pm := newPermissionMap()
 		addr := netip.MustParseAddrPort("1.2.3.4:5000")
 		perm := pm.getOrCreate(addr)
-		done, fresh := perm.beginOrJoin()
+		attempt, fresh := perm.beginOrJoin()
 		require.True(t, fresh)
 
 		pm.delete(addr)
 		perm.resolve(errFake)
-		<-done
+		<-attempt.done
 
 		assert.Empty(t, pm.addrs())
 		assert.NotSame(t, perm, pm.getOrCreate(addr))

--- a/internal/client/permission_test.go
+++ b/internal/client/permission_test.go
@@ -10,45 +10,96 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestPermission(t *testing.T) {
-	t.Run("Getter and setter", func(t *testing.T) {
+func TestPermissionAttemptLifecycle(t *testing.T) {
+	t.Run("first caller starts and second caller joins one attempt", func(t *testing.T) {
 		perm := &permission{}
 
-		assert.Equal(t, permStateIdle, perm.state())
-		perm.setState(permStatePermitted)
-		assert.Equal(t, permStatePermitted, perm.state())
+		done, fresh := perm.beginOrJoin()
+		require.NotNil(t, done)
+		assert.True(t, fresh)
+
+		joined, fresh := perm.beginOrJoin()
+		assert.Equal(t, done, joined)
+		assert.False(t, fresh)
+	})
+
+	tests := []struct {
+		name          string
+		result        error
+		wantPermitted bool
+		wantErr       error
+	}{
+		{
+			name:          "success marks the permission permitted",
+			wantPermitted: true,
+		},
+		{
+			name:    "failure records the attempt error",
+			result:  errFake,
+			wantErr: errFake,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			perm := &permission{}
+			done, fresh := perm.beginOrJoin()
+			require.True(t, fresh)
+
+			perm.resolve(tt.result)
+			select {
+			case <-done:
+			default:
+				assert.Fail(t, "resolve did not wake attempt waiters")
+			}
+
+			permitted, err := perm.readiness()
+			assert.Equal(t, tt.wantPermitted, permitted)
+			assert.ErrorIs(t, err, tt.wantErr)
+			if tt.wantPermitted {
+				done, fresh = perm.beginOrJoin()
+				assert.Nil(t, done, "a permitted permission does not start another attempt")
+				assert.False(t, fresh)
+			}
+		})
+	}
+
+	t.Run("a new attempt clears a previously resolved failure", func(t *testing.T) {
+		perm := &permission{}
+		_, fresh := perm.beginOrJoin()
+		require.True(t, fresh)
+		perm.resolve(errFake)
+
+		done, fresh := perm.beginOrJoin()
+		require.True(t, fresh)
+		permitted, err := perm.readiness()
+		assert.False(t, permitted)
+		assert.NoError(t, err)
+
+		perm.resolve(nil)
+		<-done
+		permitted, err = perm.readiness()
+		assert.True(t, permitted)
+		assert.NoError(t, err)
 	})
 }
 
 func TestPermissionMap(t *testing.T) {
-	t.Run("Basic operations", func(t *testing.T) {
+	t.Run("Identity, membership, and deletion", func(t *testing.T) {
 		pm := newPermissionMap()
 		assert.NotNil(t, pm)
 		assert.NotNil(t, pm.permMap)
 
-		perm1 := &permission{st: permStateIdle}
-		perm2 := &permission{st: permStatePermitted}
 		addr1 := netip.MustParseAddrPort("1.2.3.4:5000")
 		addr2 := netip.MustParseAddrPort("5.6.7.8:8888")
-		assert.True(t, pm.insert(addr1, perm1))
-		assert.Equal(t, 1, len(pm.permMap))
-		assert.True(t, pm.insert(addr2, perm2))
-		assert.Equal(t, 2, len(pm.permMap))
-
-		perms, ok := pm.find(addr1)
-		assert.True(t, ok)
-		assert.Equal(t, perm1, perms)
-		assert.Equal(t, permStateIdle, perms.st)
-
-		perms, ok = pm.find(addr2)
-		assert.True(t, ok)
-		assert.Equal(t, perm2, perms)
-		assert.Equal(t, permStatePermitted, perms.st)
+		perm1 := pm.getOrCreate(addr1)
+		perm2 := pm.getOrCreate(addr2)
+		assert.NotSame(t, perm1, perm2)
 
 		addrs := pm.addrs()
-		assert.Equal(t, 2, len(addrs))
+		assert.Len(t, addrs, 2)
 		sort.Slice(addrs, func(i, j int) bool {
 			return strings.Compare(addrs[i].String(), addrs[j].String()) < 0
 		})
@@ -56,9 +107,9 @@ func TestPermissionMap(t *testing.T) {
 		assert.Equal(t, addr2, addrs[1])
 
 		pm.delete(addr1)
-		assert.Equal(t, 1, len(pm.permMap))
+		assert.Equal(t, []netip.AddrPort{addr2}, pm.addrs())
 		pm.delete(addr2)
-		assert.Equal(t, 0, len(pm.permMap))
+		assert.Empty(t, pm.addrs())
 	})
 
 	t.Run("Permissions are per peer IP", func(t *testing.T) {
@@ -67,10 +118,21 @@ func TestPermissionMap(t *testing.T) {
 		perm := pm.getOrCreate(netip.MustParseAddrPort("1.2.3.4:5000"))
 		samePeerOtherPort := pm.getOrCreate(netip.MustParseAddrPort("1.2.3.4:6000"))
 		assert.Equal(t, perm, samePeerOtherPort, "peers differing only by port share one permission")
-		assert.Equal(t, 1, len(pm.permMap))
+		assert.Equal(t, []netip.AddrPort{netip.MustParseAddrPort("1.2.3.4:5000")}, pm.addrs())
+	})
 
-		found, ok := pm.find(netip.MustParseAddrPort("1.2.3.4:7000"))
-		assert.True(t, ok)
-		assert.Equal(t, perm, found)
+	t.Run("failed permission is absent before waiters wake", func(t *testing.T) {
+		pm := newPermissionMap()
+		addr := netip.MustParseAddrPort("1.2.3.4:5000")
+		perm := pm.getOrCreate(addr)
+		done, fresh := perm.beginOrJoin()
+		require.True(t, fresh)
+
+		pm.delete(addr)
+		perm.resolve(errFake)
+		<-done
+
+		assert.Empty(t, pm.addrs())
+		assert.NotSame(t, perm, pm.getOrCreate(addr))
 	})
 }

--- a/internal/client/prepare_test.go
+++ b/internal/client/prepare_test.go
@@ -168,6 +168,7 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 		require.Eventually(t, func() bool {
 			return harness.permCount.Load() == 1
 		}, 5*time.Second, 10*time.Millisecond)
+		failedPerm := harness.conn.permMap.getOrCreate(harness.peer)
 		go func() { results <- harness.conn.PreparePeer(context.Background(), harness.peer) }()
 		time.Sleep(100 * time.Millisecond)
 		close(harness.permGate)
@@ -178,6 +179,9 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 			assert.Equal(t, stun.CodeForbidden, turnErr.ErrorCodeAttr.Code)
 		}
 		assert.Equal(t, int32(1), harness.permCount.Load(), "failed attempt is shared")
+		assert.Empty(t, harness.conn.permMap.addrs(), "final failure deletes membership before waking waiters")
+		nextPerm := harness.conn.permMap.getOrCreate(harness.peer)
+		assert.NotSame(t, failedPerm, nextPerm, "the next attempt has fresh permission identity")
 
 		harness.failPerms.Store(false)
 		require.NoError(t, harness.conn.PreparePeer(context.Background(), harness.peer))
@@ -187,17 +191,16 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 	t.Run("closing before worker registration resolves joined waiters", func(t *testing.T) {
 		harness := newPrepareHarness(t, false)
 		perm := harness.conn.permMap.getOrCreate(harness.peer)
-		done, fresh := perm.beginOrJoin()
+		attempt, fresh := perm.beginOrJoin()
 		require.True(t, fresh)
 		joined, fresh := perm.beginOrJoin()
-		assert.Equal(t, done, joined)
+		assert.Equal(t, attempt, joined)
 		assert.False(t, fresh)
 
 		require.NoError(t, harness.conn.Close())
-		assert.False(t, harness.conn.startPermissionAttempt(perm, harness.peer))
-		perm.resolve(harness.conn.closedErr())
+		harness.conn.runPermissionAttempt(perm, harness.peer)
 		select {
-		case <-done:
+		case <-attempt.done:
 		case <-time.After(2 * time.Second):
 			assert.Fail(t, "joined permission waiters did not wake after registration failed")
 		}
@@ -662,7 +665,7 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 		// joined the attempt must carry the recorded terminal cause, not bare
 		// net.ErrClosed.
 		perm := harness.conn.permMap.getOrCreate(harness.peer)
-		done, fresh := perm.beginOrJoin()
+		attempt, fresh := perm.beginOrJoin()
 		require.True(t, fresh)
 		require.True(t, harness.conn.startPermissionAttempt(perm, harness.peer))
 		assert.Eventually(t, func() bool {
@@ -672,7 +675,7 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 		harness.conn.startClose(errFake)
 		close(harness.permGate)
 		select {
-		case <-done:
+		case <-attempt.done:
 		case <-time.After(5 * time.Second):
 			assert.Fail(t, "permission attempt did not finish after the seal")
 		}
@@ -682,6 +685,8 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 		assert.ErrorIs(t, err, net.ErrClosed)
 		assert.ErrorIs(t, err, errFake,
 			"an in-flight attempt finishing after the seal must record the terminal cause")
+		assert.Equal(t, []netip.AddrPort{harness.peer}, harness.conn.permMap.addrs(),
+			"seal precedence retains permission membership")
 	})
 
 	t.Run("re-entry after binding expiry is terminal", func(t *testing.T) {

--- a/internal/client/prepare_test.go
+++ b/internal/client/prepare_test.go
@@ -56,7 +56,7 @@ func newPrepareHarness(t *testing.T, gateBinds bool) *prepareHarness {
 						stun.ErrorCodeAttribute{Code: stun.CodeForbidden, Reason: []byte("Forbidden")},
 					), nil
 				}
-				if harness.staleNonce.Load() {
+				if harness.staleNonce.Swap(false) {
 					return stun.MustBuild(
 						stun.NewType(stun.MethodCreatePermission, stun.ClassErrorResponse),
 						stun.ErrorCodeAttribute{Code: stun.CodeStaleNonce, Reason: []byte("Stale Nonce")},
@@ -123,6 +123,89 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 			"write after successful PreparePeer must be ChannelData, not Send indication")
 	})
 
+	t.Run("stale nonce retry retains successful permission membership", func(t *testing.T) {
+		harness := newPrepareHarness(t, false)
+		harness.staleNonce.Store(true)
+		var rejectUnexpectedAttempt atomic.Bool
+		var unexpectedAttempts atomic.Int32
+		rejectUnexpectedAttempt.Store(true)
+		performTransaction := harness.script.performTransaction
+		harness.script.performTransaction = func(msg *stun.Message) (*stun.Message, error) {
+			if msg.Type.Method == stun.MethodCreatePermission &&
+				rejectUnexpectedAttempt.Load() && harness.permCount.Load() >= 2 {
+				unexpectedAttempts.Add(1)
+
+				return stun.MustBuild(
+					stun.NewType(stun.MethodCreatePermission, stun.ClassErrorResponse),
+					stun.ErrorCodeAttribute{Code: stun.CodeForbidden, Reason: []byte("Unexpected retry")},
+				), nil
+			}
+
+			return performTransaction(msg)
+		}
+
+		assert.NoError(t, harness.conn.PreparePeer(context.Background(), harness.peer))
+		assert.Zero(t, unexpectedAttempts.Load(), "successful resolution must prevent another permission attempt")
+		rejectUnexpectedAttempt.Store(false)
+		assert.Equal(t, int32(2), harness.permCount.Load(), "CreatePermission retries once after stale nonce")
+
+		harness.failPerms.Store(true)
+		require.NoError(t, harness.conn.PreparePeer(context.Background(), harness.peer))
+		assert.Equal(t, int32(2), harness.permCount.Load(), "later preparation reuses the retained permission")
+
+		harness.failPerms.Store(false)
+		harness.conn.onRefreshTimers(timerIDRefreshPerms)
+		assert.Equal(t, int32(3), harness.permCount.Load(), "retained permission remains a refresh member")
+	})
+
+	t.Run("failed shared attempt wakes waiters and the next caller starts fresh", func(t *testing.T) {
+		harness := newPrepareHarness(t, false)
+		harness.permGate = make(chan struct{})
+		harness.failPerms.Store(true)
+
+		results := make(chan error, 2)
+		go func() { results <- harness.conn.PreparePeer(context.Background(), harness.peer) }()
+		require.Eventually(t, func() bool {
+			return harness.permCount.Load() == 1
+		}, 5*time.Second, 10*time.Millisecond)
+		go func() { results <- harness.conn.PreparePeer(context.Background(), harness.peer) }()
+		time.Sleep(100 * time.Millisecond)
+		close(harness.permGate)
+
+		for range 2 {
+			var turnErr *stun.TurnError
+			require.ErrorAs(t, <-results, &turnErr)
+			assert.Equal(t, stun.CodeForbidden, turnErr.ErrorCodeAttr.Code)
+		}
+		assert.Equal(t, int32(1), harness.permCount.Load(), "failed attempt is shared")
+
+		harness.failPerms.Store(false)
+		require.NoError(t, harness.conn.PreparePeer(context.Background(), harness.peer))
+		assert.Equal(t, int32(2), harness.permCount.Load(), "the next caller starts a fresh permission")
+	})
+
+	t.Run("closing before worker registration resolves joined waiters", func(t *testing.T) {
+		harness := newPrepareHarness(t, false)
+		perm := harness.conn.permMap.getOrCreate(harness.peer)
+		done, fresh := perm.beginOrJoin()
+		require.True(t, fresh)
+		joined, fresh := perm.beginOrJoin()
+		assert.Equal(t, done, joined)
+		assert.False(t, fresh)
+
+		require.NoError(t, harness.conn.Close())
+		assert.False(t, harness.conn.startPermissionAttempt(perm, harness.peer))
+		perm.resolve(harness.conn.closedErr())
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			assert.Fail(t, "joined permission waiters did not wake after registration failed")
+		}
+		permitted, err := perm.readiness()
+		assert.False(t, permitted)
+		assert.ErrorIs(t, err, net.ErrClosed)
+	})
+
 	t.Run("capacity exhaustion follows permission and starts no ChannelBind", func(t *testing.T) {
 		harness := newPrepareHarness(t, false)
 		fillBindingManager(t, harness.conn.bindingMgr)
@@ -135,9 +218,8 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 		assert.Len(t, harness.conn.bindingMgr.all(), len(bindingsBefore))
 		_, found := harness.conn.bindingMgr.findByAddr(harness.peer)
 		assert.False(t, found)
-		perm, found := harness.conn.permMap.find(harness.peer)
-		require.True(t, found)
-		assert.Equal(t, permStatePermitted, perm.state())
+		assert.ErrorIs(t, harness.conn.PreparePeer(context.Background(), harness.peer), ErrChannelBindFailed)
+		assert.Equal(t, int32(1), harness.permCount.Load(), "confirmed permission is reused after capacity exhaustion")
 
 		harness.failPerms.Store(true)
 		rejectedPeer := netip.MustParseAddrPort("192.0.2.2:1234")
@@ -169,9 +251,7 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 		go func() { result <- harness.conn.PreparePeer(ctx, harness.peer) }()
 
 		require.Eventually(t, func() bool {
-			perm, found := harness.conn.permMap.find(harness.peer)
-
-			return found && perm.state() == permStatePermitted
+			return harness.permCount.Load() == 1
 		}, 5*time.Second, 10*time.Millisecond)
 		cancel(cause)
 		harness.conn.bindingMgr.mutex.Unlock()
@@ -200,9 +280,7 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 		go func() { result <- harness.conn.PreparePeer(context.Background(), harness.peer) }()
 
 		require.Eventually(t, func() bool {
-			perm, found := harness.conn.permMap.find(harness.peer)
-
-			return found && perm.state() == permStatePermitted
+			return harness.permCount.Load() == 1
 		}, 5*time.Second, 10*time.Millisecond)
 		require.NoError(t, harness.conn.Close())
 		harness.conn.bindingMgr.mutex.Unlock()
@@ -584,8 +662,9 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 		// joined the attempt must carry the recorded terminal cause, not bare
 		// net.ErrClosed.
 		perm := harness.conn.permMap.getOrCreate(harness.peer)
-		done := harness.conn.ensurePermissionAttempt(perm, harness.peer)
-		assert.NotNil(t, done)
+		done, fresh := perm.beginOrJoin()
+		require.True(t, fresh)
+		require.True(t, harness.conn.startPermissionAttempt(perm, harness.peer))
 		assert.Eventually(t, func() bool {
 			return harness.permCount.Load() == 1
 		}, 5*time.Second, 10*time.Millisecond)
@@ -598,9 +677,8 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 			assert.Fail(t, "permission attempt did not finish after the seal")
 		}
 
-		perm.attemptMutex.Lock()
-		err := perm.attemptErr
-		perm.attemptMutex.Unlock()
+		permitted, err := perm.readiness()
+		assert.False(t, permitted)
 		assert.ErrorIs(t, err, net.ErrClosed)
 		assert.ErrorIs(t, err, errFake,
 			"an in-flight attempt finishing after the seal must record the terminal cause")

--- a/internal/client/udp_conn.go
+++ b/internal/client/udp_conn.go
@@ -234,8 +234,8 @@ func (c *UDPConn) awaitPermission(ctx context.Context, peer netip.AddrPort) erro
 			return nil
 		}
 
-		done, fresh := perm.beginOrJoin()
-		if done == nil {
+		attempt, fresh := perm.beginOrJoin()
+		if attempt == nil {
 			continue
 		}
 		if fresh {
@@ -243,17 +243,18 @@ func (c *UDPConn) awaitPermission(ctx context.Context, peer netip.AddrPort) erro
 		}
 
 		select {
-		case <-done:
+		case <-attempt.done:
 		case <-ctx.Done():
 			return context.Cause(ctx)
 		case <-c.closeCh:
 			return c.closedErr()
 		}
 
-		permitted, err := perm.readiness()
+		permitted, _ = perm.readiness()
 		if permitted {
 			return nil
 		}
+		err := attempt.result()
 		if err != nil {
 			return err
 		}

--- a/internal/client/udp_conn.go
+++ b/internal/client/udp_conn.go
@@ -250,16 +250,28 @@ func (c *UDPConn) awaitPermission(ctx context.Context, peer netip.AddrPort) erro
 			return c.closedErr()
 		}
 
-		permitted, _ = perm.readiness()
-		if permitted {
-			return nil
-		}
-		err := attempt.result()
+		permitted, err := c.permissionAttemptResult(perm, attempt)
 		if err != nil {
 			return err
 		}
+		if permitted {
+			return nil
+		}
 		// The attempt we joined predates our loop iteration; re-evaluate.
 	}
+}
+
+// permissionAttemptResult preserves the exact attempt generation a caller
+// joined before consulting readiness established by any later attempt.
+func (*UDPConn) permissionAttemptResult(
+	perm *permission,
+	attempt *permissionAttempt,
+) (permitted bool, err error) {
+	if err = attempt.result(); err != nil {
+		return false, err
+	}
+
+	return perm.readiness()
 }
 
 func (c *UDPConn) runPermissionAttempt(perm *permission, peer netip.AddrPort) {

--- a/internal/client/udp_conn.go
+++ b/internal/client/udp_conn.go
@@ -187,21 +187,8 @@ func (c *UDPConn) ReadFrom(p []byte) (int, netip.AddrPort, error) {
 	}
 }
 
-func (c *UDPConn) createPermission(perm *permission, addr netip.AddrPort) error {
-	perm.mutex.Lock()
-	defer perm.mutex.Unlock()
-
-	if perm.state() == permStateIdle {
-		// Punch a hole! (this would block a bit..)
-		if err := c.CreatePermissions(addr); err != nil {
-			c.permMap.delete(addr)
-
-			return err
-		}
-		perm.setState(permStatePermitted)
-	}
-
-	return nil
+func (c *UDPConn) createPermission(addr netip.AddrPort) error {
+	return c.CreatePermissions(addr)
 }
 
 // PreparePeer creates a permission for the canonical peer and waits until the
@@ -242,13 +229,17 @@ func (c *UDPConn) PreparePeer(ctx context.Context, peer netip.AddrPort) error {
 func (c *UDPConn) awaitPermission(ctx context.Context, peer netip.AddrPort) error {
 	for {
 		perm := c.permMap.getOrCreate(peer)
-		if perm.state() == permStatePermitted {
+		permitted, _ := perm.readiness()
+		if permitted {
 			return nil
 		}
 
-		done := c.ensurePermissionAttempt(perm, peer)
+		done, fresh := perm.beginOrJoin()
 		if done == nil {
-			return c.closedErr()
+			continue
+		}
+		if fresh {
+			c.runPermissionAttempt(perm, peer)
 		}
 
 		select {
@@ -259,12 +250,10 @@ func (c *UDPConn) awaitPermission(ctx context.Context, peer netip.AddrPort) erro
 			return c.closedErr()
 		}
 
-		if perm.state() == permStatePermitted {
+		permitted, err := perm.readiness()
+		if permitted {
 			return nil
 		}
-		perm.attemptMutex.Lock()
-		err := perm.attemptErr
-		perm.attemptMutex.Unlock()
 		if err != nil {
 			return err
 		}
@@ -272,46 +261,47 @@ func (c *UDPConn) awaitPermission(ctx context.Context, peer netip.AddrPort) erro
 	}
 }
 
-// ensurePermissionAttempt returns a channel that closes when the in-flight
-// CreatePermission attempt (existing or newly started) completes. It returns
-// nil once the allocation is closing.
-func (c *UDPConn) ensurePermissionAttempt(perm *permission, peer netip.AddrPort) chan struct{} {
-	perm.attemptMutex.Lock()
-	defer perm.attemptMutex.Unlock()
-
-	if perm.attemptDone != nil {
-		return perm.attemptDone
+func (c *UDPConn) runPermissionAttempt(perm *permission, peer netip.AddrPort) {
+	if !c.startPermissionAttempt(perm, peer) {
+		perm.resolve(c.closedErr())
 	}
+}
+
+// startPermissionAttempt registers and starts the CreatePermission worker for
+// a fresh permission-owned attempt. It returns false once the allocation is
+// closing; the caller must resolve the attempt so joined waiters wake.
+func (c *UDPConn) startPermissionAttempt(perm *permission, peer netip.AddrPort) bool {
 	if !c.addWorker() {
-		return nil
+		return false
 	}
 
-	done := make(chan struct{})
-	perm.attemptDone = done
 	go func() {
 		defer c.workerWG.Done()
 		var err error
+		deleteOnFailure := false
 		for range maxRetryAttempts {
 			if c.isClosed() {
 				// Seal precedence: a waiter that joins this attempt gets the
 				// recorded terminal cause, exactly like an operation started
 				// after the seal.
 				err = c.closedErr()
+				deleteOnFailure = false
 
 				break
 			}
-			if err = c.createPermission(perm, peer); !errors.Is(err, errTryAgain) {
+			err = c.createPermission(peer)
+			deleteOnFailure = err != nil
+			if !errors.Is(err, errTryAgain) {
 				break
 			}
 		}
-		perm.attemptMutex.Lock()
-		perm.attemptDone = nil
-		perm.attemptErr = err
-		perm.attemptMutex.Unlock()
-		close(done)
+		if deleteOnFailure {
+			c.permMap.delete(peer)
+		}
+		perm.resolve(err)
 	}()
 
-	return done
+	return true
 }
 
 // awaitBinding blocks until the server confirms the channel binding, the

--- a/internal/client/udp_conn_test.go
+++ b/internal/client/udp_conn_test.go
@@ -869,9 +869,6 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		addr := netip.MustParseAddrPort("127.0.0.1:1234")
 
 		conn := newTestConn(t, script)
-		assert.True(t, conn.permMap.insert(addr, &permission{
-			st: permStatePermitted,
-		}))
 
 		binding := requireBinding(t, conn.bindingMgr, addr)
 		confirmBindingAt(t, binding, time.Now())
@@ -896,7 +893,6 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 			},
 		}
 		conn := newTestConn(t, script)
-		assert.True(t, conn.permMap.insert(addr, &permission{st: permStatePermitted}))
 		bound := requireBinding(t, conn.bindingMgr, addr)
 		originalCh := bound.number
 


### PR DESCRIPTION
Parent: #87
Plan: `docs/adr/2026-08-19-permission-readiness-plan.md` at `dfee1df4bbd4d828f9185b1fa6afc94161b4139d`, heading `Slice T3.S1 — Permission owns its attempt and readiness`.

Closes #93

## Summary

- make `permission` the single owner of its attempt lifecycle and permitted fact behind one private lock
- keep worker registration, CreatePermission retry, seal precedence, final-failure deletion, and refresh policy in `UDPConn`
- retain a successful permission after an intermediate 438 and remove raw permission state/accessor seams

## Validation

- permission transition table and focused PreparePeer lifecycle regressions
- required permitted-transition guard mutation produced an unexpected third CreatePermission attempt
- `task check`
- `go test -race ./...`