### PR TITLE
client: integrity-protect requested address family

### DIFF
--- a/allocate_ctx_test.go
+++ b/allocate_ctx_test.go
@@ -377,7 +377,6 @@ func TestAllocateRequestWireShape(t *testing.T) {
 				stun.AttrUsername,
 				stun.AttrRealm,
 				stun.AttrNonce,
-				stun.AttrMessageIntegrity,
 			}
 			authenticatedSetters := []stun.Setter{
 				stun.NewType(stun.MethodAllocate, stun.ClassRequest),
@@ -385,12 +384,13 @@ func TestAllocateRequestWireShape(t *testing.T) {
 				&username,
 				&realm,
 				&nonce,
-				&integrity,
 			}
 			if tt.requestIPv6 {
 				authenticatedAttrs = append(authenticatedAttrs, stun.AttrRequestedAddressFamily)
 				authenticatedSetters = append(authenticatedSetters, proto.RequestedFamilyIPv6)
 			}
+			authenticatedAttrs = append(authenticatedAttrs, stun.AttrMessageIntegrity)
+			authenticatedSetters = append(authenticatedSetters, &integrity)
 			authenticatedAttrs = append(authenticatedAttrs, stun.AttrFingerprint)
 			authenticatedSetters = append(authenticatedSetters, stun.Fingerprint)
 			assertAllocateRequestShape(t, authenticated, authenticatedAttrs, authenticatedSetters...)

--- a/client.go
+++ b/client.go
@@ -167,12 +167,14 @@ func (c *Client) buildAllocateRequest(
 			&c.username,
 			&credentials.realm,
 			&credentials.nonce,
-			&credentials.integrity,
 		)
 	}
 
 	if c.requestedAddressFamily == proto.RequestedFamilyIPv6 {
 		allocationSetters = append(allocationSetters, c.requestedAddressFamily)
+	}
+	if credentials != nil {
+		allocationSetters = append(allocationSetters, &credentials.integrity)
 	}
 
 	// FINGERPRINT must be the last attribute per RFC 5389


### PR DESCRIPTION
Closes #83

## Outcome

Move `REQUESTED-ADDRESS-FAMILY` before `MESSAGE-INTEGRITY` in authenticated IPv6 Allocate requests so the family request is integrity-protected. All anonymous requests and authenticated IPv4/fallback requests retain their previous byte shape.

## Review contract

- Supported domain: anonymous/authenticated Allocate forms across IPv4 UDP, IPv6 UDP, and non-UDP local-address fallback.
- Representation owner: `buildAllocateRequest`; pion/stun owns STUN encoding and HMAC construction.
- Guarantee: universal over the existing six wire-shape cells; example-level for the IPv6 `turntest` exchange.
- Preservation: family inference, response handling, allocation state, cancellation, concurrency, public APIs, dependencies, and all non-IPv6-authenticated wire bytes remain unchanged.
- Non-goals: changing anonymous requests, family inference, `turntest` protocol enforcement, or generalizing authenticated exchanges.
- Artifact classes: builder ordering is shipped behavior and required safety enforcement; wire/E2E tests are approved maintained verification aids; PR and tracking records are process metadata.
- Terminating evidence: focused wire test, IPv6 E2E, `task verify`, race suite, bounded review, exact-head `task preflight`, and same-head hosted CI.
- Review budget: one initial review plus at most one replacement review.

## Validation

- `go test . -run '^TestAllocateRequestWireShape$' -count=1`
- `go test ./turntest -run '^TestIPv6$' -count=1`
- `task verify`
- `go test -race ./...`

Local validation used the repository-pinned Go 1.26.6 toolchain. Exact-head preflight remains pending until review is complete.
