### PR TITLE
ci: rename release-check to release-gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           install-task: true
 
       - name: Run release validation
-        run: task release-check
+        run: task release-gate
 
   floor:
     runs-on: ubuntu-latest

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -120,8 +120,8 @@ tasks:
     cmds:
       - GITLEAKS_GO_RUN_VERSION={{.GITLEAKS_VERSION}} ./scripts/ci/check-secrets.sh
 
-  release-check:
-    desc: Complete validation required before creating or moving a release tag.
+  release-gate:
+    desc: Complete validation required before creating or moving a release tag; run by the tag-push release workflow.
     cmds:
       - task: check
       - task: docs-check


### PR DESCRIPTION
Closes the `WF-RELEASE-GATE` / `TASK-RELEASE-GATE-MISSING` audit deviations (portfolio CI standard, the-sarge/skills #15): every tag-push release workflow runs a literal `task release-gate`.

## Change

- Taskfile: `release-check` → `release-gate` (body unchanged: `check` + `docs-check` + `race` + `dependency-gate` + `platform-check` + `fuzz`).
- `release.yml`: the release-validation step runs `task release-gate`. Job names, the consumer-Go-floor job, and the secret-scan job are unchanged.
- No other callers exist (no contract tests, scripts, or current-procedure docs reference the old name).

The commands that run at the tagged commit are unchanged; this is an entry-point rename.

## Local evidence

- `task workflow-check` (actionlint) passed; `task --dry release-gate` resolves.
- `standardize-github-ci/scripts/audit-ci.sh .` and `CI_AUDIT_RULESET=live …`: `None. Repository conforms to the standard.` (was the two release-gate deviations on `main`).

## Hosted evidence

Recorded after the post-ready `ci` run on the live head (see checks).

## Review trail

- RAS review 20260820T070531-fdc754a5e47a5e18ed10405d (head `bae2a51`): no fix-now findings; one follow-up (evaluate a workflow-to-Taskfile token-resolution assertion or running the conformance auditor in required CI) deferred to a separate issue.
- Local `task ci` full `check` path exit 0 at `bae2a51` under the repository's pinned Go 1.26.6 (the machine's Go 1.27.0 cannot feed golangci-lint v2.8.0 — environment, not change, and hosted CI pins 1.26.6 via setup-validation).