### PR TITLE
Adopt portfolio Go lint standard v1.0.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,159 +1,106 @@
-# SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
-# SPDX-License-Identifier: MIT
-
+# Portfolio Go lint standard v1.0.0 — byte-identical in every portfolio repo.
+# Canonical copy: the-sarge/infra config/golangci/.golangci.yml (see STANDARD.md).
+# Do not edit in consuming repos; exceptions use `//nolint:<linter> // reason`.
 version: "2"
+
+run:
+  timeout: 5m
+  tests: true
+
 linters:
+  default: none
   enable:
-    - asciicheck       # Simple linter to check that your code does not contain non-ASCII identifiers
-    - bidichk          # Checks for dangerous unicode character sequences
-    - bodyclose        # checks whether HTTP response body is closed successfully
-    - containedctx     # containedctx is a linter that detects struct contained context.Context field
-    - contextcheck     # check the function whether use a non-inherited context
-    - cyclop           # checks function and package cyclomatic complexity
-    - decorder         # check declaration order and count of types, constants, variables and functions
-    - dogsled          # Checks assignments with too many blank identifiers (e.g. x, _, _, _, := f())
-    - dupl             # Tool for code clone detection
-    - durationcheck    # check for two durations multiplied together
-    - err113           # Golang linter to check the errors handling expressions
-    - errcheck         # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases
-    - errchkjson       # Checks types passed to the json encoding functions. Reports unsupported types and optionally reports occations, where the check for the returned error can be omitted.
-    - errname          # Checks that sentinel errors are prefixed with the `Err` and error types are suffixed with the `Error`.
-    - errorlint        # errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
-    - exhaustive       # check exhaustiveness of enum switch statements
-    - forbidigo        # Forbids identifiers
-    - forcetypeassert  # finds forced type assertions
-    - gochecknoglobals # Checks that no globals are present in Go code
-    - gocognit         # Computes and checks the cognitive complexity of functions
-    - goconst          # Finds repeated strings that could be replaced by a constant
-    - gocritic         # The most opinionated Go source code linter
-    - gocyclo          # Computes and checks the cyclomatic complexity of functions
-    - godot            # Check if comments end in a period
-    - godox            # Tool for detection of FIXME, TODO and other comment keywords
-    - goheader         # Checks is file header matches to pattern
-    - gomoddirectives  # Manage the use of 'replace', 'retract', and 'excludes' directives in go.mod.
-    - goprintffuncname # Checks that printf-like functions are named with `f` at the end
-    - gosec            # Inspects source code for security problems
-    - govet            # Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
-    - grouper          # An analyzer to analyze expression groups.
-    - importas         # Enforces consistent import aliases
-    - ineffassign      # Detects when assignments to existing variables are not used
-    - lll              # Reports long lines
-    - maintidx         # maintidx measures the maintainability index of each function.
-    - makezero         # Finds slice declarations with non-zero initial length
-    - misspell         # Finds commonly misspelled English words in comments
-    - modernize        # Replace and suggests simplifications to code
-    - nakedret         # Finds naked returns in functions greater than a specified function length
-    - nestif           # Reports deeply nested if statements
-    - nilerr           # Finds the code that returns nil even if it checks that the error is not nil.
-    - nilnil           # Checks that there is no simultaneous return of `nil` error and an invalid value.
-    - nlreturn         # nlreturn checks for a new line before return and branch statements to increase code clarity
-    - noctx            # noctx finds sending http request without context.Context
-    - predeclared      # find code that shadows one of Go's predeclared identifiers
-    - revive           # golint replacement, finds style mistakes
-    - staticcheck      # Staticcheck is a go vet on steroids, applying a ton of static analysis checks
-    - tagliatelle      # Checks the struct tags.
-    - thelper          # thelper detects golang test helpers without t.Helper() call and checks the consistency of test helpers
-    - unconvert        # Remove unnecessary type conversions
-    - unparam          # Reports unused function parameters
-    - unused           # Checks Go code for unused constants, variables, functions and types
-    - varnamelen       # checks that the length of a variable's name matches its scope
-    - wastedassign     # wastedassign finds wasted assignment statements
-    - whitespace       # Tool for detection of leading and trailing whitespace
-  disable:
-    - depguard         # Go linter that checks if package imports are in a list of acceptable packages
-    - funlen           # Tool for detection of long functions
-    - gochecknoinits   # Checks that no init functions are present in Go code
-    - gomodguard       # Allow and block list linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations.
-    - interfacebloat   # A linter that checks length of interface.
-    - ireturn          # Accept Interfaces, Return Concrete Types
-    - mnd              # An analyzer to detect magic numbers
-    - nolintlint       # Reports ill-formed or insufficient nolint directives
-    - paralleltest     # paralleltest detects missing usage of t.Parallel() method in your Go test
-    - prealloc         # Finds slice declarations that could potentially be preallocated
-    - promlinter       # Check Prometheus metrics naming via promlint
-    - rowserrcheck     # checks whether Err of rows is checked successfully
-    - sqlclosecheck    # Checks that sql.Rows and sql.Stmt are closed.
-    - testpackage      # linter that makes you use a separate _test package
-    - tparallel        # tparallel detects inappropriate usage of t.Parallel() method in your Go test codes
-    - wrapcheck        # Checks that errors returned from external packages are wrapped
-    - wsl              # Whitespace Linter - Forces you to use empty lines!
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - copyloopvar
+    - durationcheck
+    - errcheck
+    - errchkjson
+    - errname
+    - errorlint
+    - exhaustive
+    - fatcontext
+    - forcetypeassert
+    - gocheckcompilerdirectives
+    - gocritic
+    - gosec
+    - govet
+    - ineffassign
+    - intrange
+    - makezero
+    - mirror
+    - misspell
+    - nilerr
+    - nilnesserr
+    - nilnil
+    - noctx
+    - nolintlint
+    - nosprintfhostport
+    - predeclared
+    - reassign
+    - recvcheck
+    - rowserrcheck
+    - sloglint
+    - spancheck
+    - sqlclosecheck
+    - staticcheck
+    - testifylint
+    - unconvert
+    - unused
+    - usestdlibvars
+    - usetesting
+    - wastedassign
   settings:
+    errcheck:
+      exclude-functions:
+        - (net.Conn).Close
+        - (net.Listener).Close
+        - (io.Closer).Close
+    exhaustive:
+      default-signifies-exhaustive: true
+    misspell:
+      locale: US
+    nolintlint:
+      require-explanation: true
+      require-specific: true
     staticcheck:
       checks:
         - all
-        - -QF1008 # "could remove embedded field", to keep it explicit!
-        - -QF1003 # "could use tagged switch on enum", Cases conflicts with exhaustive!
-    exhaustive:
-      default-signifies-exhaustive: true
-    forbidigo:
-      forbid:
-        - pattern: ^fmt.Print(f|ln)?$
-        - pattern: ^log.(Panic|Fatal|Print)(f|ln)?$
-        - pattern: ^os.Exit$
-        - pattern: ^panic$
-        - pattern: ^print(ln)?$
-        - pattern: ^testing.T.(Error|Errorf|Fatal|Fatalf|Fail|FailNow)$
-          pkg: ^testing$
-          msg: use testify/assert instead
-      analyze-types: true
-    gomodguard:
-      blocked:
-        modules:
-          - github.com/pkg/errors:
-              recommendations:
-                - errors
-    govet:
-      enable:
-        - shadow
-    revive:
-      rules:
-        # Prefer 'any' type alias over 'interface{}' for Go 1.18+ compatibility
-        - name: use-any
-          severity: warning
-          disabled: false
-        # Keep package documentation consistent and avoid duplicate package comments.
-        - name: package-comments
-          severity: warning
-          disabled: false
-    misspell:
-      locale: US
-    varnamelen:
-      max-distance: 12
-      min-name-length: 2
-      ignore-type-assert-ok: true
-      ignore-map-index-ok: true
-      ignore-chan-recv-ok: true
-      ignore-decls:
-        - i int
-        - n int
-        - w io.Writer
-        - r io.Reader
-        - b []byte
+        - -QF1011
+        - -ST1000
   exclusions:
     generated: lax
+    presets:
+      - common-false-positives
+      - std-error-handling
     rules:
-      - linters:
-          - forbidigo
-          - gocognit
-        path: (examples|main\.go)
-      - linters:
-          - gocognit
-        path: _test\.go
-      - linters:
-          - modernize
-        path: internal/proto/chandata_test\.go
-        text: b\.N can be modernized using b\.Loop\(\)
-      - linters:
-          - forbidigo
-        path: cmd
+      # Tests may use direct type assertions and context-free requests; a
+      # panic or leaked request in a test is a test failure, not a prod bug.
+      - path: _test\.go
+        linters:
+          - forcetypeassert
+          - noctx
+      # File/dir permission findings are meaningless on test fixtures. All
+      # other gosec rules (secrets, crypto, injection) still cover tests.
+      - path: _test\.go
+        linters:
+          - gosec
+        text: "^G30[126]"
+
 formatters:
   enable:
-    - gci              # Gci control golang package import order and make it always deterministic.
-    - gofmt            # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
-    - gofumpt          # Gofumpt checks whether code was gofumpt-ed.
-    - goimports        # Goimports does everything that gofmt does. Additionally it checks unused imports
+    - gofumpt
+    - gci
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - localmodule
   exclusions:
     generated: lax
+
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -8,6 +8,9 @@ dotenv: ['scripts/tool-versions.env']
 vars:
   GO: GOTOOLCHAIN=local go
   GOLANGCI_LINT_PKG: github.com/golangci/golangci-lint/v2/cmd/golangci-lint
+  # Portfolio Go lint standard v1.0.0. .golangci.yml is a byte-identical copy of
+  # the canonical file; bump this digest and the config together, never alone.
+  LINT_STANDARD_SHA256: a18cfc4fcdbc03b2c2e40c658f3b1cf27066b8ff62816786283663226d910dc8
   GOVULNCHECK_PKG: golang.org/x/vuln/cmd/govulncheck
   GITLEAKS_PKG: github.com/zricethezav/gitleaks/v8
   ACTIONLINT_PKG: github.com/rhysd/actionlint/cmd/actionlint
@@ -83,8 +86,21 @@ tasks:
     cmds:
       - '{{.GO}} test -race ./...'
 
+  lint-config-check:
+    desc: Verify .golangci.yml matches the portfolio lint standard.
+    run: once
+    cmds:
+      - |
+        got="$(shasum -a 256 .golangci.yml | awk '{print $1}')"
+        if [ "$got" != "{{.LINT_STANDARD_SHA256}}" ]; then
+          echo "lint config drift: .golangci.yml sha256 $got does not match portfolio standard {{.LINT_STANDARD_SHA256}}" >&2
+          echo "canonical copy: the-sarge/infra config/golangci/.golangci.yml" >&2
+          exit 1
+        fi
+
   lint:
     desc: Run the pinned golangci-lint.
+    deps: [lint-config-check]
     cmds:
       - '{{.GO}} run {{.GOLANGCI_LINT_PKG}}@{{.GOLANGCI_LINT_VERSION}} run --timeout 5m'
 

--- a/allocate_ctx_test.go
+++ b/allocate_ctx_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pion/stun/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/the-sarge/turn/v5/internal/proto"
 )
 
@@ -474,7 +475,7 @@ func TestAllocateRejectsConcurrentCallerWithoutNetworkOutput(t *testing.T) {
 	select {
 	case outcome := <-firstResult:
 		assert.Nil(t, outcome.alloc)
-		assert.ErrorIs(t, outcome.err, cause)
+		require.ErrorIs(t, outcome.err, cause)
 	case <-time.After(2 * time.Second):
 		require.Fail(t, "first Allocate did not return after cancellation")
 	}
@@ -552,7 +553,7 @@ func TestAllocateContext(t *testing.T) {
 
 		alloc, err := cl.Allocate(ctx)
 		assert.Nil(t, alloc)
-		assert.ErrorIs(t, err, cause)
+		require.ErrorIs(t, err, cause)
 		assert.Equal(t, int32(0), conn.writeCount.Load(), "canceled-before-send Allocate must not write")
 		assert.Equal(t, int32(0), conn.deadlineCalls.Load(), "the fork must never deadline the caller's socket")
 		assert.Equal(t, int32(0), conn.closeCalls.Load(), "the fork must never close the caller's socket")
@@ -577,7 +578,7 @@ func TestAllocateContext(t *testing.T) {
 
 		select {
 		case err := <-result:
-			assert.ErrorIs(t, err, cause)
+			require.ErrorIs(t, err, cause)
 			assert.Less(t, time.Since(start), 500*time.Millisecond,
 				"cancellation must return well inside the retransmission budget")
 		case <-time.After(2 * time.Second):
@@ -606,7 +607,7 @@ func TestAllocateContext(t *testing.T) {
 
 		select {
 		case err := <-result:
-			assert.ErrorIs(t, err, cause)
+			require.ErrorIs(t, err, cause)
 			assert.Less(t, time.Since(start), 500*time.Millisecond,
 				"cancellation must return well inside the retransmission budget")
 		case <-time.After(2 * time.Second):
@@ -641,11 +642,11 @@ func TestAllocateContext(t *testing.T) {
 
 		select {
 		case res := <-result:
-			assert.NoError(t, res.err, "a published success must win over cancellation")
+			require.NoError(t, res.err, "a published success must win over cancellation")
 			assert.NotNil(t, res.alloc)
 			if res.alloc != nil {
 				assert.Equal(t, netip.MustParseAddrPort("127.0.0.1:40000"), res.alloc.RelayedAddr())
-				assert.NoError(t, res.alloc.Close(), "the raced Allocation must be closable")
+				require.NoError(t, res.alloc.Close(), "the raced Allocation must be closable")
 			}
 		case <-time.After(2 * time.Second):
 			assert.Fail(t, "Allocate did not return after the success response")
@@ -678,7 +679,7 @@ func TestAllocateCancelDuringBlockedRetransmit(t *testing.T) {
 	cancel(cause)
 	select {
 	case err := <-result:
-		assert.ErrorIs(t, err, cause)
+		require.ErrorIs(t, err, cause)
 		assert.Less(t, time.Since(start), 500*time.Millisecond,
 			"cancellation must not wait behind caller-socket I/O")
 	case <-time.After(2 * time.Second):
@@ -719,7 +720,7 @@ func TestAllocateCancelProducerRace(t *testing.T) {
 	cancel(cause)
 	select {
 	case err := <-result:
-		assert.ErrorIs(t, err, cause)
+		require.ErrorIs(t, err, cause)
 	case <-time.After(2 * time.Second):
 		assert.Fail(t, "canceled Allocate did not return")
 	}
@@ -753,7 +754,7 @@ func TestAllocateCancelProducerRace(t *testing.T) {
 	}()
 	select {
 	case err := <-handled:
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	case <-time.After(2 * time.Second):
 		assert.Fail(t, "HandleInbound blocked behind an in-flight retransmit write")
 	}
@@ -783,8 +784,8 @@ func TestAllocateCancelVsClientClose(t *testing.T) {
 
 	select {
 	case err := <-result:
-		assert.ErrorIs(t, err, net.ErrClosed, "a closed client must surface net.ErrClosed")
-		assert.NotErrorIs(t, err, cause, "closure must take precedence over the cancellation cause")
+		require.ErrorIs(t, err, net.ErrClosed, "a closed client must surface net.ErrClosed")
+		require.NotErrorIs(t, err, cause, "closure must take precedence over the cancellation cause")
 	case <-time.After(2 * time.Second):
 		assert.Fail(t, "Allocate did not return after Client.Close")
 	}
@@ -812,18 +813,21 @@ func TestAllocateLateSuccessDiscarded(t *testing.T) {
 	cancel(cause)
 	select {
 	case err := <-result:
-		assert.ErrorIs(t, err, cause)
+		require.ErrorIs(t, err, cause)
 	case <-time.After(2 * time.Second):
 		assert.Fail(t, "canceled Allocate did not return")
 	}
 
 	// The delayed authenticated success arrives after Allocate returned: it
 	// must be discarded without blocking and without error.
+	// Build the response on the test goroutine: allocateSuccessResponse asserts
+	// with require, which may only fail the test from the test goroutine.
+	lateSuccess := allocateSuccessResponse(t, authReq)
 	done := make(chan error, 1)
-	go func() { done <- cl.HandleInbound(allocateSuccessResponse(t, authReq), testServerNetAddr()) }()
+	go func() { done <- cl.HandleInbound(lateSuccess, testServerNetAddr()) }()
 	select {
 	case err := <-done:
-		assert.NoError(t, err, "a late success for a departed waiter is silently discarded")
+		require.NoError(t, err, "a late success for a departed waiter is silently discarded")
 	case <-time.After(2 * time.Second):
 		assert.Fail(t, "HandleInbound blocked delivering a late success")
 	}
@@ -846,7 +850,7 @@ func TestAllocateLateSuccessDiscarded(t *testing.T) {
 	select {
 	case err := <-retryResult:
 		var turnErr *stun.TurnError
-		assert.ErrorAs(t, err, &turnErr, "the 437 must surface as a typed value")
+		require.ErrorAs(t, err, &turnErr, "the 437 must surface as a typed value")
 		if turnErr != nil {
 			assert.Equal(t, codeAllocMismatch, turnErr.ErrorCodeAttr.Code)
 		}

--- a/allocation_test.go
+++ b/allocation_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pion/stun/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/the-sarge/turn/v5/internal/client"
 	"github.com/the-sarge/turn/v5/internal/proto"
 )
@@ -41,8 +42,8 @@ func TestAllocationPreparePeerRejectsNilContextFirst(t *testing.T) {
 	//nolint:staticcheck // Nil is the programmer-error input under test.
 	err := allocation.PreparePeer(nil, netip.AddrPort{})
 
-	assert.ErrorIs(t, err, errNilContext)
-	assert.NotErrorIs(t, err, ErrInvalidPeer)
+	require.ErrorIs(t, err, errNilContext)
+	require.NotErrorIs(t, err, ErrInvalidPeer)
 	assert.Equal(t, int32(0), script.permissionCount.Load())
 	assert.Equal(t, int32(0), script.bindingCount.Load())
 }
@@ -83,12 +84,12 @@ func TestAllocationPeerAliasCanonicalizes(t *testing.T) {
 		netip.AddrFrom16([16]byte{10: 0xff, 11: 0xff, 12: 127, 13: 0, 14: 0, 15: 1}), 1234)
 	require.True(t, mapped.Addr().Is4In6(), "test input must be the mapped spelling")
 
-	assert.NoError(t, allocation.PreparePeer(context.Background(), mapped))
+	require.NoError(t, allocation.PreparePeer(context.Background(), mapped))
 	assert.Equal(t, int32(1), script.permissionCount.Load())
 	assert.Equal(t, int32(1), script.bindingCount.Load())
 
 	n, err := allocation.WriteTo([]byte("hello"), netip.MustParseAddrPort("127.0.0.1:1234"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 5, n)
 	assert.True(t, proto.IsChannelData(script.lastWrite()),
 		"write to the unmapped spelling of a prepared mapped peer must be ChannelData")
@@ -146,12 +147,12 @@ func scriptInvalidRelayedServer(serverSock net.PacketConn, refreshLifetime chan<
 // the server-side allocation with a lifetime-0 Refresh, clear the client's
 // allocation pointer, and return ErrInvalidRelayedAddress.
 func TestAllocateRejectsInvalidRelayedAddress(t *testing.T) {
-	serverSock, err := net.ListenPacket("udp4", "127.0.0.1:0") // nolint: noctx
+	serverSock, err := net.ListenPacket("udp4", "127.0.0.1:0")
 	require.NoError(t, err)
-	defer serverSock.Close()                                   //nolint:errcheck
-	clientSock, err := net.ListenPacket("udp4", "127.0.0.1:0") // nolint: noctx
+	defer serverSock.Close()
+	clientSock, err := net.ListenPacket("udp4", "127.0.0.1:0")
 	require.NoError(t, err)
-	defer clientSock.Close() //nolint:errcheck
+	defer clientSock.Close()
 
 	refreshLifetime := make(chan time.Duration, 4)
 
@@ -168,7 +169,7 @@ func TestAllocateRejectsInvalidRelayedAddress(t *testing.T) {
 	defer turnClient.Close()
 
 	alloc, err := turnClient.Allocate(context.Background())
-	assert.ErrorIs(t, err, ErrInvalidRelayedAddress)
+	require.ErrorIs(t, err, ErrInvalidRelayedAddress)
 	assert.Nil(t, alloc)
 
 	select {

--- a/allocation_zero_lifetime_characterization_test.go
+++ b/allocation_zero_lifetime_characterization_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pion/stun/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/the-sarge/turn/v5/internal/proto"
 )
 
@@ -69,7 +70,7 @@ func awaitNewRefresh(
 
 	var raw []byte
 	require.Eventually(t, func() bool {
-		for i := int32(0); i < conn.writeCount.Load(); i++ {
+		for i := range conn.writeCount.Load() {
 			candidate := conn.write(int(i))
 			if candidate == nil {
 				continue
@@ -100,7 +101,7 @@ func scanMethodTransactions(
 ) (map[[stun.TransactionIDSize]byte]struct{}, bool) {
 	transactions := make(map[[stun.TransactionIDSize]byte]struct{})
 	malformed := false
-	for i := int32(0); i < conn.writeCount.Load(); i++ {
+	for i := range conn.writeCount.Load() {
 		raw := conn.write(int(i))
 		if raw == nil {
 			continue
@@ -304,9 +305,9 @@ func TestZeroLifetimeRefreshSuccessTerminalizesPublishedAllocation(t *testing.T)
 	requireRefreshLifetime(t, release, 0)
 
 	_, err = allocation.WriteTo([]byte("data"), netip.MustParseAddrPort("127.0.0.1:5000"))
-	assert.ErrorIs(t, err, net.ErrClosed)
-	assert.ErrorIs(t, err, ErrAllocationRefreshFailed)
-	assert.ErrorIs(t, allocation.Close(), ErrAllocationRefreshFailed)
+	require.ErrorIs(t, err, net.ErrClosed)
+	require.ErrorIs(t, err, ErrAllocationRefreshFailed)
+	require.ErrorIs(t, allocation.Close(), ErrAllocationRefreshFailed)
 
 	requireLaterAllocateReachesWire(t, cl, conn)
 
@@ -370,7 +371,7 @@ func TestFirstRefreshFailureObservesPublishedAllocation(t *testing.T) {
 		transactionID(t, firstRefresh): {},
 	})
 	requireRefreshLifetime(t, release, 0)
-	assert.ErrorIs(t, allocation.Close(), ErrAllocationRefreshFailed)
+	require.ErrorIs(t, allocation.Close(), ErrAllocationRefreshFailed)
 	requireLaterAllocateReachesWire(t, cl, conn.observerConn)
 
 	cl.Close()

--- a/client.go
+++ b/client.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/pion/stun/v3"
+
 	"github.com/the-sarge/turn/v5/internal/client"
 	"github.com/the-sarge/turn/v5/internal/proto"
 )
@@ -41,7 +42,7 @@ type ClientConfig struct {
 	// performs no name resolution.
 	Server   netip.AddrPort
 	Username string
-	Password string //nolint:gosec // runtime credential, not hardcoded.
+	Password string
 	RTO      time.Duration
 	Conn     net.PacketConn // Caller-owned socket; the caller runs the read pump.
 
@@ -183,7 +184,7 @@ func (c *Client) buildAllocateRequest(
 	return stun.Build(allocationSetters...)
 }
 
-func (c *Client) sendAllocateRequest(ctx context.Context, protocol proto.Protocol) ( //nolint:cyclop
+func (c *Client) sendAllocateRequest(ctx context.Context, protocol proto.Protocol) (
 	exchange allocateExchange,
 	err error,
 ) {
@@ -231,7 +232,7 @@ func (c *Client) sendAllocateRequest(ctx context.Context, protocol proto.Protoco
 			return exchange, turnError
 		}
 
-		return exchange, fmt.Errorf("%s", res.Type) //nolint:err113
+		return exchange, fmt.Errorf("%s", res.Type)
 	}
 
 	// Getting relayed addresses from response.
@@ -368,7 +369,7 @@ func (c *Client) HandleInbound(data []byte, from net.Addr) error {
 	}
 }
 
-func (c *Client) handleSTUNMessage(data []byte) error { //nolint:cyclop
+func (c *Client) handleSTUNMessage(data []byte) error {
 	raw := make([]byte, len(data))
 	copy(raw, data)
 
@@ -381,7 +382,7 @@ func (c *Client) handleSTUNMessage(data []byte) error { //nolint:cyclop
 		return fmt.Errorf("%w : %s", errUnexpectedSTUNRequestMessage, msg.String())
 	}
 
-	if msg.Type.Class == stun.ClassIndication { // nolint:nestif
+	if msg.Type.Class == stun.ClassIndication {
 		switch msg.Type.Method {
 		case stun.MethodData:
 			var peerAddr proto.PeerAddress

--- a/client_test.go
+++ b/client_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pion/stun/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/the-sarge/turn/v5/internal/proto"
 	"github.com/the-sarge/turn/v5/turntest"
 )
@@ -28,9 +29,9 @@ func TestNewClientRejectsNilConn(t *testing.T) {
 }
 
 func TestNewClientRejectsNonCanonicalServer(t *testing.T) {
-	conn, err := net.ListenPacket("udp4", "127.0.0.1:0") // nolint: noctx
+	conn, err := net.ListenPacket("udp4", "127.0.0.1:0")
 	require.NoError(t, err)
-	defer conn.Close() //nolint:errcheck
+	defer conn.Close()
 
 	mapped := netip.AddrPortFrom(netip.AddrFrom16([16]byte{10: 0xff, 11: 0xff, 12: 192, 13: 0, 14: 2, 15: 1}), 3478)
 	for name, server := range map[string]netip.AddrPort{
@@ -54,9 +55,9 @@ func TestNewClientRejectsNonCanonicalServer(t *testing.T) {
 }
 
 func TestNewClientValidatesPermissionRefreshInterval(t *testing.T) {
-	conn, err := net.ListenPacket("udp4", "127.0.0.1:0") // nolint: noctx
+	conn, err := net.ListenPacket("udp4", "127.0.0.1:0")
 	require.NoError(t, err)
-	defer conn.Close() //nolint:errcheck
+	defer conn.Close()
 
 	server := netip.MustParseAddrPort("192.0.2.1:3478")
 
@@ -108,13 +109,13 @@ func TestNewClientValidatesPermissionRefreshInterval(t *testing.T) {
 				PermissionRefreshInterval: tt.interval,
 			})
 			if tt.wantErr != nil {
-				assert.ErrorIs(t, newErr, tt.wantErr)
+				require.ErrorIs(t, newErr, tt.wantErr)
 				assert.Nil(t, client)
 
 				return
 			}
 			if tt.wantText != "" {
-				assert.EqualError(t, newErr, tt.wantText)
+				require.EqualError(t, newErr, tt.wantText)
 				assert.Nil(t, client)
 
 				return
@@ -188,7 +189,7 @@ func TestHandleInboundAdmitsOnlyServer(t *testing.T) {
 	t.Run("server source is delivered", func(t *testing.T) {
 		c, conn := newClient(t)
 		raw, waited := pendingResponse(t, c, conn)
-		assert.NoError(t, c.HandleInbound(raw, net.UDPAddrFromAddrPort(server)))
+		require.NoError(t, c.HandleInbound(raw, net.UDPAddrFromAddrPort(server)))
 		expectDelivered(t, waited)
 	})
 
@@ -197,7 +198,7 @@ func TestHandleInboundAdmitsOnlyServer(t *testing.T) {
 		raw, waited := pendingResponse(t, c, conn)
 		from := &net.UDPAddr{IP: net.IPv4(192, 0, 2, 1), Port: 3478} // 16-byte mapped form, as a dual-stack socket reports it
 		require.Len(t, from.IP, net.IPv6len)
-		assert.NoError(t, c.HandleInbound(raw, from))
+		require.NoError(t, c.HandleInbound(raw, from))
 		expectDelivered(t, waited)
 	})
 
@@ -220,7 +221,7 @@ func TestHandleInboundAdmitsOnlyServer(t *testing.T) {
 	t.Run("non-protocol datagram: error from server, ignored from others", func(t *testing.T) {
 		c, _ := newClient(t)
 		junk := []byte("not stun, not channeldata")
-		assert.ErrorIs(t, c.HandleInbound(junk, net.UDPAddrFromAddrPort(server)), errUnexpectedServerDatagram)
+		require.ErrorIs(t, c.HandleInbound(junk, net.UDPAddrFromAddrPort(server)), errUnexpectedServerDatagram)
 		assert.NoError(t, c.HandleInbound(junk, &net.UDPAddr{IP: net.IPv4(192, 0, 2, 2), Port: 3478}))
 	})
 }
@@ -342,8 +343,8 @@ func TestHandleInboundLiveUnknownChannelReturnsExistingErrorWithoutDelivery(t *t
 		net.UDPAddrFromAddrPort(server),
 	)
 
-	assert.ErrorIs(t, err, errChannelBindNotFound)
-	assert.EqualError(t, err, "turn: no binding found for channel: 16384")
+	require.ErrorIs(t, err, errChannelBindNotFound)
+	require.EqualError(t, err, "turn: no binding found for channel: 16384")
 	require.NoError(t, turnClient.HandleInbound(
 		buildDataIndication(t, []byte("marker"), peer),
 		net.UDPAddrFromAddrPort(server),
@@ -421,7 +422,7 @@ func TestClientCloseIsAnAbortCutNotATerminalState(t *testing.T) {
 
 	select {
 	case got := <-resultCh:
-		assert.NoError(t, got.err)
+		require.NoError(t, got.err)
 		assert.NotNil(t, got.result)
 	case <-time.After(time.Second):
 		assert.Fail(t, "transaction begun after Client.Close did not complete")
@@ -449,7 +450,7 @@ func TestClientCloseWinsBlockedInitialSendWithoutRearm(t *testing.T) {
 
 	select {
 	case err := <-resultCh:
-		assert.ErrorIs(t, err, net.ErrClosed)
+		require.ErrorIs(t, err, net.ErrClosed)
 	case <-time.After(time.Second):
 		assert.Fail(t, "Client.Close did not wake the blocked begin caller")
 	}
@@ -469,8 +470,8 @@ func TestClientNonceExpiration(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	conn, err := net.ListenPacket("udp4", "0.0.0.0:0") // nolint: noctx
-	assert.NoError(t, err)
+	conn, err := net.ListenPacket("udp4", "0.0.0.0:0")
+	require.NoError(t, err)
 
 	client, err := NewClient(&ClientConfig{
 		Conn:     conn,
@@ -478,16 +479,16 @@ func TestClientNonceExpiration(t *testing.T) {
 		Username: testUsername,
 		Password: testPassword,
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	startTestPump(t, client, conn)
 
 	allocation, err := client.Allocate(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	server.InjectStaleNonce()
 
 	peer := netip.MustParseAddrPort("127.0.0.1:8080")
-	assert.NoError(t, allocation.PreparePeer(context.Background(), peer))
+	require.NoError(t, allocation.PreparePeer(context.Background(), peer))
 	_, err = allocation.WriteTo([]byte{0x00}, peer)
 	assert.NoError(t, err)
 
@@ -512,8 +513,8 @@ func TestClientE2E(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	stunClientConn, err := net.ListenPacket("udp4", "0.0.0.0:0") // nolint: noctx
-	assert.NoError(t, err)
+	stunClientConn, err := net.ListenPacket("udp4", "0.0.0.0:0")
+	require.NoError(t, err)
 
 	client, err := NewClient(&ClientConfig{
 		Conn:                      stunClientConn,
@@ -524,14 +525,14 @@ func TestClientE2E(t *testing.T) {
 		bindingRefreshInterval:    time.Millisecond * 50,
 		bindingCheckInterval:      time.Millisecond * 50,
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	startTestPump(t, client, stunClientConn)
 
 	allocation, err := client.Allocate(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	remotePeerConn, err := net.ListenPacket("udp4", "0.0.0.0:0") // nolint: noctx
-	assert.NoError(t, err)
+	remotePeerConn, err := net.ListenPacket("udp4", "0.0.0.0:0")
+	require.NoError(t, err)
 
 	remotePeerAddr, ok := remotePeerConn.LocalAddr().(*net.UDPAddr)
 	assert.True(t, ok)
@@ -554,7 +555,7 @@ func TestClientE2E(t *testing.T) {
 			}
 		}()
 		for pktCount.Load() < expectedPktCount {
-			assert.NoError(t, write(expectedPacket))
+			require.NoError(t, write(expectedPacket))
 
 			time.Sleep(time.Millisecond * 25)
 		}

--- a/close_latency_test.go
+++ b/close_latency_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pion/stun/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/the-sarge/turn/v5/internal/client"
 )
 
@@ -99,7 +100,7 @@ func TestCloseInterruptsTransactionWaits(t *testing.T) {
 		cancelB(cause)
 		select {
 		case err := <-resultB:
-			assert.ErrorIs(t, err, cause)
+			require.ErrorIs(t, err, cause)
 		case <-time.After(time.Second):
 			assert.Fail(t, "canceled waiter did not wake promptly")
 		}
@@ -110,7 +111,7 @@ func TestCloseInterruptsTransactionWaits(t *testing.T) {
 		}
 
 		start := time.Now()
-		assert.NoError(t, conn.Close())
+		require.NoError(t, conn.Close())
 		elapsed := time.Since(start)
 		t.Logf("Close took %v with abort", elapsed)
 		assert.Less(t, elapsed, time.Second,
@@ -121,7 +122,7 @@ func TestCloseInterruptsTransactionWaits(t *testing.T) {
 
 		select {
 		case err := <-resultA:
-			assert.Error(t, err)
+			require.Error(t, err)
 		case <-time.After(5 * time.Second):
 			assert.Fail(t, "surviving waiter did not unblock on close")
 		}

--- a/internal/client/allocation.go
+++ b/internal/client/allocation.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/pion/stun/v3"
+
 	"github.com/the-sarge/turn/v5/internal/proto"
 )
 
@@ -88,7 +89,7 @@ func (c *UDPConn) refreshAllocation(lifetime time.Duration) error {
 			}
 		}
 
-		return fmt.Errorf("%s", res.Type) //nolint:err113
+		return fmt.Errorf("%s", res.Type)
 	}
 
 	// Getting lifetime from response

--- a/internal/client/binding_test.go
+++ b/internal/client/binding_test.go
@@ -23,8 +23,8 @@ func TestBindingReadinessBeginsAndRetriesFreshAttempt(t *testing.T) {
 	assert.Equal(t, bindingAttemptFresh, class)
 	final, err := bound.preparationAccess(t0)
 	assert.False(t, final)
-	assert.NoError(t, err)
-	assert.ErrorIs(t, bound.writeAccess(t0), ErrNotPrepared)
+	require.NoError(t, err)
+	require.ErrorIs(t, bound.writeAccess(t0), ErrNotPrepared)
 
 	_, _, started = bound.beginAttempt(t0, defaultBindingRefreshInterval)
 	assert.False(t, started, "one readiness generation may be active at a time")
@@ -92,11 +92,11 @@ func TestBindingReadinessPreparationAndWriteAccess(t *testing.T) {
 	t0 := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
 	bound := &binding{}
 
-	assert.ErrorIs(t, bound.writeAccess(t0), ErrNotPrepared)
+	require.ErrorIs(t, bound.writeAccess(t0), ErrNotPrepared)
 	token, _, started := bound.beginAttempt(t0, defaultBindingRefreshInterval)
 	require.True(t, started)
 	require.True(t, bound.resolveAttempt(token, bindingAttemptConfirmed, nil, t0))
-	assert.ErrorIs(t, bound.writeAccess(t0), ErrNotPrepared,
+	require.ErrorIs(t, bound.writeAccess(t0), ErrNotPrepared,
 		"server confirmation alone must not establish prepared history")
 
 	final, err := bound.preparationAccess(t0.Add(channelBindingLifetime - time.Nanosecond))
@@ -104,8 +104,8 @@ func TestBindingReadinessPreparationAndWriteAccess(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, bound.writeAccess(t0.Add(channelBindingLifetime-time.Nanosecond)))
 
-	assert.ErrorIs(t, bound.writeAccess(t0.Add(channelBindingLifetime)), ErrChannelBindingExpired)
-	assert.ErrorIs(t, bound.writeAccess(t0.Add(channelBindingLifetime+time.Second)), ErrChannelBindingExpired,
+	require.ErrorIs(t, bound.writeAccess(t0.Add(channelBindingLifetime)), ErrChannelBindingExpired)
+	require.ErrorIs(t, bound.writeAccess(t0.Add(channelBindingLifetime+time.Second)), ErrChannelBindingExpired,
 		"expiry must retain its first durable cause")
 	assert.False(t, bound.resolveAttempt(token, bindingAttemptConfirmed, nil, t0.Add(time.Hour)),
 		"late completion must not resurrect terminal readiness")
@@ -132,7 +132,7 @@ func TestBindingReadinessPreparedPermissionLossOrdering(t *testing.T) {
 
 		assert.True(t, bound.failPrepared(permissionCause))
 		assert.False(t, bound.failPrepared(otherCause))
-		assert.ErrorIs(t, bound.writeAccess(t0), permissionCause)
+		require.ErrorIs(t, bound.writeAccess(t0), permissionCause)
 		assert.NotErrorIs(t, bound.writeAccess(t0), otherCause)
 	})
 }
@@ -171,7 +171,7 @@ func TestBindingReadinessPermanentFailureIsDurable(t *testing.T) {
 	require.True(t, bound.resolveAttempt(token, bindingAttemptPermanentFailure, cause, t0))
 	final, err := bound.preparationAccess(t0)
 	assert.True(t, final)
-	assert.ErrorIs(t, err, cause)
+	require.ErrorIs(t, err, cause)
 	_, _, started = bound.beginAttempt(t0.Add(time.Minute), defaultBindingRefreshInterval)
 	assert.False(t, started)
 	assert.False(t, bound.resolveAttempt(token, bindingAttemptConfirmed, nil, t0.Add(time.Minute)))
@@ -210,7 +210,7 @@ func TestBindingReadinessExpiryRejectsInFlightCompletion(t *testing.T) {
 	)
 	require.True(t, started)
 	assert.Equal(t, bindingAttemptPreviouslyConfirmed, class)
-	assert.ErrorIs(t, bound.writeAccess(t0.Add(channelBindingLifetime)), ErrChannelBindingExpired)
+	require.ErrorIs(t, bound.writeAccess(t0.Add(channelBindingLifetime)), ErrChannelBindingExpired)
 	assert.False(t, bound.resolveAttempt(token, bindingAttemptConfirmed, nil, t0.Add(channelBindingLifetime)),
 		"an in-flight success must not resurrect terminal expiry")
 	assert.ErrorIs(t, bound.writeAccess(t0.Add(channelBindingLifetime)), ErrChannelBindingExpired)
@@ -243,7 +243,7 @@ func TestBindingManagerCapacity(t *testing.T) {
 	bindingsByNumber := make(map[uint16]*binding, wantCapacity)
 	peerAddr := netip.MustParseAddr("192.0.2.1")
 	for i := range wantCapacity {
-		peer := netip.AddrPortFrom(peerAddr, uint16(i+1)) //nolint:gosec // Bounded by channel capacity.
+		peer := netip.AddrPortFrom(peerAddr, uint16(i+1))
 		peers[i] = peer
 
 		bound, ok := bm.getOrCreate(peer)
@@ -286,7 +286,7 @@ func TestBindingManagerConcurrentFinalSlot(t *testing.T) {
 	bm := newBindingManager()
 	peerAddr := netip.MustParseAddr("192.0.2.1")
 	for i := range maxChannelBindings - 1 {
-		peer := netip.AddrPortFrom(peerAddr, uint16(i+1)) //nolint:gosec // Bounded by channel capacity.
+		peer := netip.AddrPortFrom(peerAddr, uint16(i+1))
 		_, ok := bm.getOrCreate(peer)
 		require.True(t, ok)
 	}
@@ -367,7 +367,7 @@ func TestBindingManager(t *testing.T) {
 			assert.True(t, ok, "should exist")
 			assert.Equal(t, b, found, "should match")
 		}
-		assert.Equal(t, count, len(all), "should match")
+		assert.Len(t, all, count, "should match")
 	})
 
 	t.Run("missing lookup", func(t *testing.T) {

--- a/internal/client/permission_test.go
+++ b/internal/client/permission_test.go
@@ -57,7 +57,7 @@ func TestPermissionAttemptLifecycle(t *testing.T) {
 
 			permitted, err := perm.readiness()
 			assert.Equal(t, tt.wantPermitted, permitted)
-			assert.ErrorIs(t, err, tt.wantErr)
+			require.ErrorIs(t, err, tt.wantErr)
 			if tt.wantPermitted {
 				attempt, fresh = perm.beginOrJoin()
 				assert.Nil(t, attempt, "a permitted permission does not start another attempt")
@@ -76,7 +76,7 @@ func TestPermissionAttemptLifecycle(t *testing.T) {
 		require.True(t, fresh)
 		permitted, err := perm.readiness()
 		assert.False(t, permitted)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		perm.resolve(nil)
 		<-attempt.done

--- a/internal/client/prepare_test.go
+++ b/internal/client/prepare_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pion/stun/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/the-sarge/turn/v5/internal/proto"
 )
 
@@ -102,22 +103,22 @@ func fillBindingManager(t *testing.T, mgr *bindingManager) {
 
 	peerAddr := netip.MustParseAddr("192.0.2.1")
 	for i := range maxChannelBindings {
-		peer := netip.AddrPortFrom(peerAddr, uint16(i+1)) //nolint:gosec // Bounded by channel capacity.
+		peer := netip.AddrPortFrom(peerAddr, uint16(i+1))
 		_, ok := mgr.getOrCreate(peer)
 		require.True(t, ok)
 	}
 }
 
-func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
+func TestPreparePeer(t *testing.T) {
 	t.Run("readiness success then ChannelData writes", func(t *testing.T) {
 		harness := newPrepareHarness(t, false)
 
-		assert.NoError(t, harness.conn.PreparePeer(context.Background(), harness.peer))
+		require.NoError(t, harness.conn.PreparePeer(context.Background(), harness.peer))
 		assert.Equal(t, int32(1), harness.permCount.Load())
 		assert.Equal(t, int32(1), harness.bindCount.Load())
 
 		n, err := harness.conn.WriteTo([]byte("hello"), harness.peer)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, 5, n)
 		assert.True(t, proto.IsChannelData(harness.lastWrite()),
 			"write after successful PreparePeer must be ChannelData, not Send indication")
@@ -144,7 +145,7 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 			return performTransaction(msg)
 		}
 
-		assert.NoError(t, harness.conn.PreparePeer(context.Background(), harness.peer))
+		require.NoError(t, harness.conn.PreparePeer(context.Background(), harness.peer))
 		assert.Zero(t, unexpectedAttempts.Load(), "successful resolution must prevent another permission attempt")
 		rejectUnexpectedAttempt.Store(false)
 		assert.Equal(t, int32(2), harness.permCount.Load(), "CreatePermission retries once after stale nonce")
@@ -215,13 +216,13 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 
 		bindingsBefore := harness.conn.bindingMgr.all()
 		err := harness.conn.PreparePeer(context.Background(), harness.peer)
-		assert.ErrorIs(t, err, ErrChannelBindFailed)
+		require.ErrorIs(t, err, ErrChannelBindFailed)
 		assert.Equal(t, int32(1), harness.permCount.Load(), "permission phase remains first")
 		assert.Equal(t, int32(0), harness.bindCount.Load(), "exhaustion must not start ChannelBind")
 		assert.Len(t, harness.conn.bindingMgr.all(), len(bindingsBefore))
 		_, found := harness.conn.bindingMgr.findByAddr(harness.peer)
 		assert.False(t, found)
-		assert.ErrorIs(t, harness.conn.PreparePeer(context.Background(), harness.peer), ErrChannelBindFailed)
+		require.ErrorIs(t, harness.conn.PreparePeer(context.Background(), harness.peer), ErrChannelBindFailed)
 		assert.Equal(t, int32(1), harness.permCount.Load(), "confirmed permission is reused after capacity exhaustion")
 
 		harness.failPerms.Store(true)
@@ -230,7 +231,7 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 		var turnErr *stun.TurnError
 		require.ErrorAs(t, err, &turnErr)
 		assert.Equal(t, stun.CodeForbidden, turnErr.ErrorCodeAttr.Code)
-		assert.NotErrorIs(t, err, ErrChannelBindFailed, "permission rejection retains its earlier outcome")
+		require.NotErrorIs(t, err, ErrChannelBindFailed, "permission rejection retains its earlier outcome")
 		assert.Equal(t, int32(0), harness.bindCount.Load(), "permission rejection must stop before binding")
 		_, found = harness.conn.bindingMgr.findByAddr(rejectedPeer)
 		assert.False(t, found)
@@ -260,7 +261,7 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 		harness.conn.bindingMgr.mutex.Unlock()
 		managerLocked = false
 
-		assert.ErrorIs(t, <-result, cause)
+		require.ErrorIs(t, <-result, cause)
 		assert.Equal(t, int32(0), harness.bindCount.Load())
 		assert.Len(t, harness.conn.bindingMgr.all(), maxChannelBindings)
 		_, found := harness.conn.bindingMgr.findByAddr(harness.peer)
@@ -289,7 +290,7 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 		harness.conn.bindingMgr.mutex.Unlock()
 		managerLocked = false
 
-		assert.ErrorIs(t, <-result, net.ErrClosed)
+		require.ErrorIs(t, <-result, net.ErrClosed)
 		assert.Equal(t, int32(0), harness.bindCount.Load())
 		assert.Len(t, harness.conn.bindingMgr.all(), maxChannelBindings)
 		_, found := harness.conn.bindingMgr.findByAddr(harness.peer)
@@ -304,7 +305,7 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 			cancel(cause)
 
 			err := harness.conn.PreparePeer(ctx, harness.peer)
-			assert.ErrorIs(t, err, cause)
+			require.ErrorIs(t, err, cause)
 			assert.Equal(t, int32(0), harness.permCount.Load())
 			assert.Equal(t, int32(0), harness.bindCount.Load())
 		})
@@ -314,7 +315,7 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 			require.NoError(t, harness.conn.Close())
 
 			err := harness.conn.PreparePeer(context.Background(), harness.peer)
-			assert.ErrorIs(t, err, net.ErrClosed)
+			require.ErrorIs(t, err, net.ErrClosed)
 			assert.Equal(t, int32(0), harness.permCount.Load())
 			assert.Equal(t, int32(0), harness.bindCount.Load())
 		})
@@ -373,7 +374,7 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 		for range waiters {
 			select {
 			case err := <-results:
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			case <-time.After(5 * time.Second):
 				assert.Fail(t, "timed out waiting for PreparePeer")
 			}
@@ -401,7 +402,7 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 		cancelA(causeA)
 		select {
 		case err := <-resultA:
-			assert.ErrorIs(t, err, causeA, "canceled waiter must observe its cause")
+			require.ErrorIs(t, err, causeA, "canceled waiter must observe its cause")
 		case <-time.After(2 * time.Second):
 			assert.Fail(t, "canceled waiter did not wake promptly")
 		}
@@ -416,7 +417,7 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 		close(harness.bindGate)
 		select {
 		case err := <-resultB:
-			assert.NoError(t, err, "surviving waiter should complete via the shared bind")
+			require.NoError(t, err, "surviving waiter should complete via the shared bind")
 		case <-time.After(5 * time.Second):
 			assert.Fail(t, "timed out waiting for surviving waiter")
 		}
@@ -434,7 +435,7 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 			return harness.bindCount.Load() == 1
 		}, 5*time.Second, 10*time.Millisecond)
 		cancel(cause)
-		assert.ErrorIs(t, <-result, cause)
+		require.ErrorIs(t, <-result, cause)
 
 		close(harness.bindGate)
 		bound, ok := harness.conn.bindingMgr.findByAddr(harness.peer)
@@ -447,8 +448,8 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 		}, 5*time.Second, 10*time.Millisecond)
 
 		_, err := harness.conn.WriteTo([]byte("still unprepared"), harness.peer)
-		assert.ErrorIs(t, err, ErrNotPrepared)
-		assert.NoError(t, harness.conn.PreparePeer(context.Background(), harness.peer))
+		require.ErrorIs(t, err, ErrNotPrepared)
+		require.NoError(t, harness.conn.PreparePeer(context.Background(), harness.peer))
 		assert.Equal(t, int32(1), harness.bindCount.Load(), "the second waiter observes existing readiness")
 	})
 
@@ -476,7 +477,7 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 		cancelB(cause)
 		select {
 		case err := <-resultB:
-			assert.ErrorIs(t, err, cause,
+			require.ErrorIs(t, err, cause,
 				"waiter must be cancelable while the permission transaction is in flight")
 		case <-time.After(2 * time.Second):
 			assert.Fail(t, "canceled waiter did not wake during in-flight permission transaction")
@@ -485,7 +486,7 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 		close(harness.permGate)
 		select {
 		case err := <-resultA:
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		case <-time.After(5 * time.Second):
 			assert.Fail(t, "timed out waiting for first caller")
 		}
@@ -495,7 +496,7 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 	t.Run("permission refresh failure fails writes, never Send indication", func(t *testing.T) {
 		harness := newPrepareHarness(t, false)
 
-		assert.NoError(t, harness.conn.PreparePeer(context.Background(), harness.peer))
+		require.NoError(t, harness.conn.PreparePeer(context.Background(), harness.peer))
 
 		// Simulate the permission-refresh timer firing against a server that
 		// now rejects the refresh.
@@ -504,7 +505,7 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 
 		writesBefore := harness.writeCount()
 		_, err := harness.conn.WriteTo([]byte("data"), harness.peer)
-		assert.ErrorIs(t, err, ErrPermissionRefreshFailed)
+		require.ErrorIs(t, err, ErrPermissionRefreshFailed)
 		assert.Equal(t, writesBefore, harness.writeCount(),
 			"failed write for a prepared peer must not emit anything (no Send indication fallback)")
 
@@ -515,7 +516,7 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 	t.Run("permission refresh success keeps prepared binding usable", func(t *testing.T) {
 		harness := newPrepareHarness(t, false)
 
-		assert.NoError(t, harness.conn.PreparePeer(context.Background(), harness.peer))
+		require.NoError(t, harness.conn.PreparePeer(context.Background(), harness.peer))
 		assert.Equal(t, int32(1), harness.permCount.Load())
 
 		harness.conn.onRefreshTimers(timerIDRefreshPerms)
@@ -523,7 +524,7 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 			"the consolidated receiver must refresh the existing permission")
 
 		n, err := harness.conn.WriteTo([]byte("still ready"), harness.peer)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, len("still ready"), n)
 		assert.True(t, proto.IsChannelData(harness.lastWrite()))
 	})
@@ -545,11 +546,11 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 		}
 
 		err := harness.conn.PreparePeer(context.Background(), harness.peer)
-		assert.ErrorIs(t, err, errChannelBindTransactionFailed)
+		require.ErrorIs(t, err, errChannelBindTransactionFailed)
 		assert.False(t, harness.conn.isClosed())
 
 		mock.performTransaction = inner
-		assert.NoError(t, harness.conn.PreparePeer(context.Background(), harness.peer),
+		require.NoError(t, harness.conn.PreparePeer(context.Background(), harness.peer),
 			"a fresh transaction failure is attempt-local and a later caller may retry")
 		assert.Equal(t, int32(2), harness.bindCount.Load())
 	})
@@ -578,12 +579,12 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 		close(gate)
 
 		for range 2 {
-			assert.ErrorIs(t, <-results, errChannelBindTransactionFailed)
+			require.ErrorIs(t, <-results, errChannelBindTransactionFailed)
 		}
 		assert.Equal(t, int32(1), harness.bindCount.Load())
 
 		mock.performTransaction = inner
-		assert.NoError(t, harness.conn.PreparePeer(context.Background(), harness.peer))
+		require.NoError(t, harness.conn.PreparePeer(context.Background(), harness.peer))
 		assert.Equal(t, int32(2), harness.bindCount.Load())
 	})
 
@@ -610,7 +611,7 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 		if assert.ErrorAs(t, err, &turnErr) {
 			assert.Equal(t, stun.CodeForbidden, turnErr.ErrorCodeAttr.Code)
 		}
-		assert.ErrorIs(t, err, errCannotBindChannel)
+		require.ErrorIs(t, err, errCannotBindChannel)
 		assert.False(t, harness.conn.isClosed())
 	})
 
@@ -630,7 +631,7 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 		// The waiter unblocks promptly; Close must keep waiting for the worker.
 		select {
 		case err := <-prepareResult:
-			assert.ErrorIs(t, err, net.ErrClosed)
+			require.ErrorIs(t, err, net.ErrClosed)
 		case <-time.After(2 * time.Second):
 			assert.Fail(t, "PreparePeer waiter did not unblock on close")
 		}
@@ -643,7 +644,7 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 		close(harness.bindGate)
 		select {
 		case err := <-closeResult:
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		case <-time.After(5 * time.Second):
 			assert.Fail(t, "Close did not return after the bind worker finished")
 		}
@@ -682,8 +683,8 @@ func TestPreparePeer(t *testing.T) { //nolint:maintidx,cyclop,gocyclo
 
 		permitted, err := perm.readiness()
 		assert.False(t, permitted)
-		assert.ErrorIs(t, err, net.ErrClosed)
-		assert.ErrorIs(t, err, errFake,
+		require.ErrorIs(t, err, net.ErrClosed)
+		require.ErrorIs(t, err, errFake,
 			"an in-flight attempt finishing after the seal must record the terminal cause")
 		assert.Equal(t, []netip.AddrPort{harness.peer}, harness.conn.permMap.addrs(),
 			"seal precedence retains permission membership")
@@ -739,7 +740,7 @@ func TestWriteToPreparedOnly(t *testing.T) {
 			name: "prepared then terminal",
 			arrange: func(t *testing.T, harness *prepareHarness) {
 				t.Helper()
-				assert.NoError(t, harness.conn.PreparePeer(context.Background(), harness.peer))
+				require.NoError(t, harness.conn.PreparePeer(context.Background(), harness.peer))
 				harness.failPerms.Store(true)
 				harness.conn.onRefreshTimers(timerIDRefreshPerms)
 			},
@@ -783,10 +784,10 @@ func TestWriteToPreparedOnly(t *testing.T) {
 			writes := harness.writeCount() - writesBefore
 
 			if tt.wantErr == nil {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, len("payload"), n)
 			} else {
-				assert.ErrorIs(t, err, tt.wantErr)
+				require.ErrorIs(t, err, tt.wantErr)
 				assert.Equal(t, 0, n, "a failed write reports zero bytes")
 			}
 			assert.Equal(t, tt.wantWrites, writes, "network output count")

--- a/internal/client/refresh_failure_test.go
+++ b/internal/client/refresh_failure_test.go
@@ -153,38 +153,38 @@ func TestRefreshFailureTerminalizes(t *testing.T) {
 
 			select {
 			case err := <-readResult:
-				assert.ErrorIs(t, err, net.ErrClosed, "post-seal ReadFrom must wrap net.ErrClosed")
-				assert.ErrorIs(t, err, ErrAllocationRefreshFailed, "post-seal ReadFrom must carry the terminal cause")
+				require.ErrorIs(t, err, net.ErrClosed, "post-seal ReadFrom must wrap net.ErrClosed")
+				require.ErrorIs(t, err, ErrAllocationRefreshFailed, "post-seal ReadFrom must carry the terminal cause")
 			case <-time.After(2 * time.Second):
 				assert.Fail(t, "blocked ReadFrom did not wake on the refresh-failure seal")
 			}
 
 			_, err := conn.WriteTo([]byte("data"), peer)
-			assert.ErrorIs(t, err, net.ErrClosed)
-			assert.ErrorIs(t, err, ErrAllocationRefreshFailed)
+			require.ErrorIs(t, err, net.ErrClosed)
+			require.ErrorIs(t, err, ErrAllocationRefreshFailed)
 
 			err = conn.PreparePeer(context.Background(), peer)
-			assert.ErrorIs(t, err, net.ErrClosed)
-			assert.ErrorIs(t, err, ErrAllocationRefreshFailed)
+			require.ErrorIs(t, err, net.ErrClosed)
+			require.ErrorIs(t, err, ErrAllocationRefreshFailed)
 
 			// The caller's Close joins and returns the recorded terminal cause,
 			// wrapping only the underlying failure — never a synthetic
 			// net.ErrClosed.
 			closeErr := conn.Close()
 			require.Error(t, closeErr)
-			assert.ErrorIs(t, closeErr, ErrAllocationRefreshFailed)
-			assert.NotErrorIs(t, closeErr, net.ErrClosed,
+			require.ErrorIs(t, closeErr, ErrAllocationRefreshFailed)
+			require.NotErrorIs(t, closeErr, net.ErrClosed,
 				"the terminal cause must wrap the underlying failure, not a synthetic net.ErrClosed")
 			if tt.underlying != nil {
-				assert.ErrorIs(t, closeErr, tt.underlying)
+				require.ErrorIs(t, closeErr, tt.underlying)
 			}
 			if tt.wantTurnError {
 				var turnErr *stun.TurnError
-				assert.ErrorAs(t, closeErr, &turnErr,
+				require.ErrorAs(t, closeErr, &turnErr,
 					"a well-formed error response must surface as a typed *stun.TurnError")
 			}
 
-			assert.ErrorIs(t, conn.Close(), net.ErrClosed,
+			require.ErrorIs(t, conn.Close(), net.ErrClosed,
 				"a repeated caller Close returns net.ErrClosed")
 
 			assert.Equal(t, int32(1), harness.emitCount.Load(),
@@ -278,7 +278,7 @@ func TestSelfSealEmissionFailureJoinsCause(t *testing.T) {
 
 	closeErr := conn.Close()
 	require.Error(t, closeErr)
-	assert.ErrorIs(t, closeErr, ErrAllocationRefreshFailed,
+	require.ErrorIs(t, closeErr, ErrAllocationRefreshFailed,
 		"the caller's Close must observe the refresh-failure cause")
 	assert.ErrorIs(t, closeErr, emitErr,
 		"a failed self-seal emission must be joined into the terminal cause")

--- a/internal/client/transaction_test.go
+++ b/internal/client/transaction_test.go
@@ -107,7 +107,7 @@ func TestTransactionRegistryAbortWinsBlockedInitialSend(t *testing.T) {
 
 	select {
 	case err := <-resultCh:
-		assert.ErrorIs(t, err, net.ErrClosed)
+		require.ErrorIs(t, err, net.ErrClosed)
 	case <-time.After(time.Second):
 		assert.Fail(t, "aborted transaction did not wake")
 	}
@@ -138,7 +138,7 @@ func TestTransactionRegistryCancellationClaimsLiveWait(t *testing.T) {
 
 	select {
 	case err := <-resultCh:
-		assert.ErrorIs(t, err, cause)
+		require.ErrorIs(t, err, cause)
 	case <-time.After(time.Second):
 		assert.Fail(t, "canceled transaction did not wake")
 	}
@@ -170,7 +170,7 @@ func TestTransactionRegistryExhaustionSendsSevenByteIdenticalRequests(t *testing
 
 	select {
 	case err := <-resultCh:
-		assert.ErrorIs(t, err, ErrTransactionTimeout)
+		require.ErrorIs(t, err, ErrTransactionTimeout)
 	case <-time.After(2 * time.Second):
 		assert.Fail(t, "transaction did not exhaust its retry budget")
 	}
@@ -236,7 +236,7 @@ func TestTransactionRegistryInitialSendErrorSurvivesAbort(t *testing.T) {
 
 	select {
 	case err := <-resultCh:
-		assert.ErrorIs(t, err, sendErr)
+		require.ErrorIs(t, err, sendErr)
 	case <-time.After(time.Second):
 		assert.Fail(t, "blocked send failure did not return")
 	}
@@ -255,7 +255,7 @@ func TestTransactionRegistryClaimDuringBlockedRetryPreventsRearm(t *testing.T) {
 			},
 			assert: func(t *testing.T, result *stun.Message, err error, response *stun.Message) {
 				t.Helper()
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Same(t, response, result)
 			},
 		},

--- a/internal/client/udp_conn.go
+++ b/internal/client/udp_conn.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/pion/stun/v3"
+
 	"github.com/the-sarge/turn/v5/internal/proto"
 )
 
@@ -346,7 +347,7 @@ func (c *UDPConn) startPermissionAttempt(perm *permission, peer netip.AddrPort) 
 
 // awaitBinding blocks until the server confirms the channel binding, the
 // binding fails, or ctx is canceled.
-func (c *UDPConn) awaitBinding(ctx context.Context, bound *binding) error { //nolint:cyclop
+func (c *UDPConn) awaitBinding(ctx context.Context, bound *binding) error {
 	for {
 		if final, err := bound.preparationAccess(time.Now()); final {
 			return err
@@ -646,7 +647,7 @@ func (c *UDPConn) CreatePermissions(addrs ...netip.AddrPort) error {
 			return turnError
 		}
 
-		return fmt.Errorf("%s", res.Type) //nolint // dynamic errors
+		return fmt.Errorf("%s", res.Type)
 	}
 
 	return nil
@@ -851,7 +852,7 @@ func (c *UDPConn) bind(bound *binding) error {
 func (c *UDPConn) handleChannelBindErrorResponse(res *stun.Message) error {
 	var code stun.ErrorCodeAttribute
 	if err := code.GetFrom(res); err != nil {
-		return fmt.Errorf("%w: unexpected response type %s", errCannotBindChannel, res.Type) // nolint:err113
+		return fmt.Errorf("%w: unexpected response type %s", errCannotBindChannel, res.Type)
 	}
 
 	if code.Code == stun.CodeStaleNonce {
@@ -875,7 +876,7 @@ func (c *UDPConn) handleChannelBindErrorResponse(res *stun.Message) error {
 		)
 	}
 
-	return fmt.Errorf("%w: received error %d: %w", errCannotBindChannel, code.Code, turnError) // nolint:err113
+	return fmt.Errorf("%w: received error %d: %w", errCannotBindChannel, code.Code, turnError)
 }
 
 func (c *UDPConn) sendChannelData(data []byte, chNum uint16) (int, error) {

--- a/internal/client/udp_conn_test.go
+++ b/internal/client/udp_conn_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pion/stun/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/the-sarge/turn/v5/internal/proto"
 )
 
@@ -156,7 +157,7 @@ func TestUDPConnZeroLifetimeActivationTerminalizesOnce(t *testing.T) {
 	}))
 	assert.Zero(t, callbackCount.Load())
 	assert.Equal(t, int32(1), releases.Load())
-	assert.ErrorIs(t, conn.Close(), ErrAllocationRefreshFailed)
+	require.ErrorIs(t, conn.Close(), ErrAllocationRefreshFailed)
 	assert.Equal(t, int32(1), releases.Load())
 }
 
@@ -264,7 +265,7 @@ func TestUDPConnHandleChannelDataDeliversAssignedUnpreparedBinding(t *testing.T)
 	payload[0] = 'x'
 
 	assert.True(t, handled)
-	assert.ErrorIs(t, bound.writeAccess(time.Now()), ErrNotPrepared,
+	require.ErrorIs(t, bound.writeAccess(time.Now()), ErrNotPrepared,
 		"inbound ChannelData must not establish prepared write access")
 	buf := make([]byte, len(payload))
 	n, from, err := conn.ReadFrom(buf)
@@ -321,7 +322,7 @@ func TestUDPConnDecodedDeliveryPreservesShortBufferError(t *testing.T) {
 
 	n, from, err := conn.ReadFrom(make([]byte, 3))
 
-	assert.ErrorIs(t, err, io.ErrShortBuffer)
+	require.ErrorIs(t, err, io.ErrShortBuffer)
 	assert.Zero(t, n)
 	assert.Equal(t, netip.AddrPort{}, from)
 }
@@ -522,7 +523,7 @@ func TestPermissionAndBindingRequestShapes(t *testing.T) {
 	require.NoError(t, conn.bind(bound))
 }
 
-func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
+func TestUDPConn(t *testing.T) {
 	makeConn := func(script *testConnScript) *UDPConn {
 		return newTestConn(t, script)
 	}
@@ -675,12 +676,12 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 
 				err := conn.bind(bound)
 				if tt.expectErr == nil {
-					assert.NoError(t, err)
+					require.NoError(t, err)
 				} else {
-					assert.ErrorIs(t, err, tt.expectErr)
+					require.ErrorIs(t, err, tt.expectErr)
 				}
 				if tt.expectErrContains != "" {
-					assert.ErrorContains(t, err, tt.expectErrContains)
+					require.ErrorContains(t, err, tt.expectErrContains)
 				}
 				assert.Equal(t, tt.expectBadRequest, errors.Is(err, errChannelBindBadRequest))
 				var turnErr *stun.TurnError
@@ -688,7 +689,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 					require.ErrorAs(t, err, &turnErr)
 					assert.Equal(t, tt.expectTurnErrorCode, turnErr.ErrorCodeAttr.Code)
 				} else {
-					assert.False(t, errors.As(err, &turnErr), "response class must remain untyped")
+					assert.NotErrorAs(t, err, &turnErr, "response class must remain untyped")
 				}
 
 				if tt.expectBindingDeleted {
@@ -729,13 +730,13 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		token, class, started := bound.beginAttempt(time.Now(), defaultBindingRefreshInterval)
 		require.True(t, started)
 		err := conn.bindChannel(bound, token, class)
-		assert.NoError(t, err, "the permanent exhausted-retry cause lives only in readiness")
+		require.NoError(t, err, "the permanent exhausted-retry cause lives only in readiness")
 		assert.Equal(t, int32(maxRetryAttempts), attempts.Load())
 		final, readinessErr := bound.preparationAccess(time.Now())
 		assert.True(t, final)
-		assert.ErrorIs(t, readinessErr, errTryAgain)
+		require.ErrorIs(t, readinessErr, errTryAgain)
 		var turnErr *stun.TurnError
-		assert.False(t, errors.As(err, &turnErr), "438 retry exhaustion must not become a typed TURN error")
+		assert.NotErrorAs(t, err, &turnErr, "438 retry exhaustion must not become a typed TURN error")
 	})
 
 	t.Run("maybeBind() retries unknown binding after transaction failure", func(t *testing.T) {
@@ -762,7 +763,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		}, 5*time.Second, 10*time.Millisecond)
 		final, err := bound.preparationAccess(time.Now())
 		assert.False(t, final)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		conn.maybeBind(bound)
 		assert.Eventually(t, func() bool {
@@ -825,7 +826,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 
 		select {
 		case err := <-refreshErrCh:
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		default:
 		}
 		select {
@@ -842,7 +843,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		}
 
 		_, err := conn.WriteTo([]byte("still closed"), peerAddr)
-		assert.ErrorIs(t, err, net.ErrClosed)
+		require.ErrorIs(t, err, net.ErrClosed)
 		var turnErr *stun.TurnError
 		require.ErrorAs(t, err, &turnErr)
 		assert.Equal(t, stun.CodeBadRequest, turnErr.ErrorCodeAttr.Code)
@@ -947,7 +948,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 			return channelBindAttempts.Load() == 2 && bound.attempt == nil
 		}, 5*time.Second, 10*time.Millisecond)
 		_, err = bound.preparationAccess(staleRefreshedAt.Add(channelBindingLifetime))
-		assert.ErrorIs(t, err, ErrChannelBindingExpired,
+		require.ErrorIs(t, err, ErrChannelBindingExpired,
 			"recovered 400 must not advance confirmation time")
 		assert.False(t, conn.isClosed())
 	})
@@ -999,7 +1000,7 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 
 		buf := []byte("Hello")
 		n, err := conn.WriteTo(buf, addr)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, len(buf), n, "WriteTo reports the payload length, not the ChannelData frame length")
 	})
 
@@ -1021,10 +1022,10 @@ func TestUDPConn(t *testing.T) { // nolint:maintidx,cyclop,gocyclo
 		// its channel number, and a write (which fails, unprepared) does not
 		// disturb it.
 		err := conn.bind(bound)
-		assert.ErrorIs(t, err, errFake)
+		require.ErrorIs(t, err, errFake)
 
 		_, err = conn.WriteTo([]byte("hi"), addr)
-		assert.ErrorIs(t, err, ErrNotPrepared)
+		require.ErrorIs(t, err, ErrNotPrepared)
 
 		b2, ok := conn.bindingMgr.findByAddr(addr)
 		assert.True(t, ok)
@@ -1058,8 +1059,8 @@ func TestUDPConnBindingCompletionOrdersWithClose(t *testing.T) {
 
 	got := <-result
 	assert.False(t, got.applied)
-	assert.ErrorIs(t, got.err, net.ErrClosed)
-	assert.ErrorIs(t, got.err, sealCause)
+	require.ErrorIs(t, got.err, net.ErrClosed)
+	require.ErrorIs(t, got.err, sealCause)
 	final, err := bound.preparationAccess(t0)
 	assert.False(t, final, "close-winning completion must not create readiness")
 	assert.NoError(t, err)
@@ -1076,7 +1077,7 @@ func TestUDPConnBindingAttemptResultOwnership(t *testing.T) {
 		cause := fmt.Errorf("permanent: %w", errCannotBindChannel)
 
 		attemptResult := conn.resolveBindError(bound, token, class, cause)
-		assert.NoError(t, attemptResult, "attempt coordination must not duplicate a durable cause")
+		require.NoError(t, attemptResult, "attempt coordination must not duplicate a durable cause")
 		final, readinessErr := bound.preparationAccess(t0)
 		assert.True(t, final)
 		assert.ErrorIs(t, readinessErr, cause)
@@ -1090,7 +1091,7 @@ func TestUDPConnBindingAttemptResultOwnership(t *testing.T) {
 		cause := fmt.Errorf("%w: %w", errChannelBindTransactionFailed, errFake)
 
 		attemptResult := conn.resolveBindError(bound, token, class, cause)
-		assert.ErrorIs(t, attemptResult, cause)
+		require.ErrorIs(t, attemptResult, cause)
 		final, readinessErr := bound.preparationAccess(t0)
 		assert.False(t, final)
 		assert.NoError(t, readinessErr, "transient attempt results must not become durable readiness causes")
@@ -1113,7 +1114,7 @@ func TestCreatePermissions(t *testing.T) {
 		conn := newTestConn(t, script)
 		addr := netip.MustParseAddrPort("5.6.7.8:12345")
 		err := conn.CreatePermissions(addr)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, called)
 	})
 
@@ -1135,8 +1136,8 @@ func TestCreatePermissions(t *testing.T) {
 		addr := netip.MustParseAddrPort("5.6.7.8:12345")
 		err := conn.CreatePermissions(addr)
 		var turnErr *stun.TurnError
-		assert.Error(t, err)
-		assert.True(t, errors.As(err, &turnErr), "should return a TurnError")
+		require.Error(t, err)
+		require.ErrorAs(t, err, &turnErr, "should return a TurnError")
 		assert.Equal(t, stun.CodeForbidden, turnErr.ErrorCodeAttr.Code)
 	})
 }

--- a/internal/proto/addr.go
+++ b/internal/proto/addr.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Addr is ip:port.
-type Addr struct {
+type Addr struct { //nolint:recvcheck // Addr is passed around as a net.Addr value; only FromUDPAddr mutates and takes a pointer.
 	IP   net.IP
 	Port int
 }

--- a/internal/proto/chandata.go
+++ b/internal/proto/chandata.go
@@ -92,7 +92,7 @@ func (c *ChannelData) WriteHeader() {
 	_ = c.Raw[:channelDataHeaderSize]
 	binary.BigEndian.PutUint16(c.Raw[:channelDataNumberSize], uint16(c.Number))
 	binary.BigEndian.PutUint16(c.Raw[channelDataNumberSize:channelDataHeaderSize],
-		uint16(len(c.Data)), // nolint:gosec // G115
+		uint16(len(c.Data)), //nolint:gosec // G115
 	)
 }
 

--- a/internal/proto/chandata_test.go
+++ b/internal/proto/chandata_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestChannelData_Encode(t *testing.T) {
@@ -21,7 +22,7 @@ func TestChannelData_Encode(t *testing.T) {
 	chanData.Encode()
 	b := &ChannelData{}
 	b.Raw = append(b.Raw, chanData.Raw...)
-	assert.NoError(t, b.Decode())
+	require.NoError(t, b.Decode())
 	assert.True(t, b.Equal(chanData))
 	assert.True(t, IsChannelData(b.Raw) && IsChannelData(chanData.Raw))
 }
@@ -168,7 +169,7 @@ func BenchmarkIsChannelData(b *testing.B) {
 	buf := []byte{64, 0, 0, 0, 0, 4, 0, 0, 1, 2, 3}
 	b.ReportAllocs()
 	b.SetBytes(int64(len(buf)))
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		IsChannelData(buf)
 	}
 }
@@ -180,7 +181,7 @@ func BenchmarkChannelData_Encode(b *testing.B) {
 	}
 	b.ReportAllocs()
 	b.SetBytes(4 + channelDataHeaderSize)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		d.Encode()
 	}
 }
@@ -195,7 +196,7 @@ func BenchmarkChannelData_Decode(b *testing.B) {
 	copy(buf, d.Raw)
 	b.ReportAllocs()
 	b.SetBytes(4 + channelDataHeaderSize)
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		d.Reset()
 		d.Raw = buf
 		assert.NoError(b, d.Decode())
@@ -213,7 +214,7 @@ func TestChromeChannelData(t *testing.T) {
 	// Decoding hex data into binary.
 	for s.Scan() {
 		b, err := hex.DecodeString(s.Text())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		data = append(data, b)
 	}
 	// All hex streams decoded to raw binary format and stored in data slice.
@@ -221,7 +222,7 @@ func TestChromeChannelData(t *testing.T) {
 	for i, packet := range data {
 		chanData := new(ChannelData)
 		chanData.Raw = packet
-		assert.NoError(t, chanData.Decode(), "Packet %d errored", i)
+		require.NoError(t, chanData.Decode(), "Packet %d errored", i)
 
 		encoded := &ChannelData{
 			Data:   chanData.Data,
@@ -230,10 +231,10 @@ func TestChromeChannelData(t *testing.T) {
 		encoded.Encode()
 		decoded := new(ChannelData)
 		decoded.Raw = encoded.Raw
-		assert.NoError(t, decoded.Decode())
+		require.NoError(t, decoded.Decode())
 		assert.True(t, decoded.Equal(chanData))
 
 		messages = append(messages, chanData)
 	}
-	assert.Equal(t, 2, len(messages), "unexpected number of messages")
+	assert.Len(t, messages, 2, "unexpected number of messages")
 }

--- a/internal/proto/chann.go
+++ b/internal/proto/chann.go
@@ -16,7 +16,9 @@ import (
 // The CHANNEL-NUMBER attribute contains the number of the channel.
 //
 // RFC 5766 Section 14.1.
-type ChannelNumber uint16 // Encoded as uint16
+//
+// Encoded as uint16.
+type ChannelNumber uint16 //nolint:recvcheck // pion/stun contract: AddTo needs a value receiver so unaddressable values satisfy stun.Setter, GetFrom needs a pointer receiver to decode into.
 
 func (n ChannelNumber) String() string { return strconv.Itoa(int(n)) }
 

--- a/internal/proto/chann_test.go
+++ b/internal/proto/chann_test.go
@@ -8,22 +8,23 @@ import (
 
 	"github.com/pion/stun/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func BenchmarkChannelNumber(b *testing.B) {
 	b.Run("AddTo", func(b *testing.B) {
 		b.ReportAllocs()
 		m := new(stun.Message)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			n := ChannelNumber(12)
-			assert.NoError(b, n.AddTo(m))
+			require.NoError(b, n.AddTo(m))
 			m.Reset()
 		}
 	})
 	b.Run("GetFrom", func(b *testing.B) {
 		m := new(stun.Message)
-		assert.NoError(b, ChannelNumber(12).AddTo(m))
-		for i := 0; i < b.N; i++ {
+		require.NoError(b, ChannelNumber(12).AddTo(m))
+		for range b.N {
 			var n ChannelNumber
 			assert.NoError(b, n.GetFrom(m))
 		}
@@ -40,7 +41,7 @@ func TestChannelNumber(t *testing.T) {
 		allocated := wasAllocs(func() {
 			// Case with ChannelNumber on stack.
 			n := ChannelNumber(6)
-			assert.NoError(t, n.AddTo(stunMsg))
+			require.NoError(t, n.AddTo(stunMsg))
 			stunMsg.Reset()
 		})
 		assert.False(t, allocated)
@@ -49,7 +50,7 @@ func TestChannelNumber(t *testing.T) {
 		nP := &n
 		allocated = wasAllocs(func() {
 			// On heap.
-			assert.NoError(t, nP.AddTo(stunMsg))
+			require.NoError(t, nP.AddTo(stunMsg))
 			stunMsg.Reset()
 		})
 		assert.False(t, allocated)
@@ -57,17 +58,17 @@ func TestChannelNumber(t *testing.T) {
 	t.Run("AddTo", func(t *testing.T) {
 		stunMsg := new(stun.Message)
 		chanNumber := ChannelNumber(6)
-		assert.NoError(t, chanNumber.AddTo(stunMsg))
+		require.NoError(t, chanNumber.AddTo(stunMsg))
 
 		stunMsg.WriteHeader()
 		t.Run("GetFrom", func(t *testing.T) {
 			decoded := new(stun.Message)
 			_, err := decoded.Write(stunMsg.Raw)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			var numDecoded ChannelNumber
 			err = numDecoded.GetFrom(decoded)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, chanNumber, numDecoded)
 
 			allocated := wasAllocs(func() {
@@ -79,7 +80,7 @@ func TestChannelNumber(t *testing.T) {
 			t.Run("HandleErr", func(t *testing.T) {
 				m := new(stun.Message)
 				nHandle := new(ChannelNumber)
-				assert.ErrorIs(t, nHandle.GetFrom(m), stun.ErrAttributeNotFound)
+				require.ErrorIs(t, nHandle.GetFrom(m), stun.ErrAttributeNotFound)
 
 				m.Add(stun.AttrChannelNumber, []byte{1, 2, 3})
 				assert.True(t, stun.IsAttrSizeInvalid(nHandle.GetFrom(m)))

--- a/internal/proto/chrome_test.go
+++ b/internal/proto/chrome_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/pion/stun/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestChromeAllocRequest(t *testing.T) {
@@ -24,7 +25,7 @@ func TestChromeAllocRequest(t *testing.T) {
 	// Decoding hex data into binary.
 	for s.Scan() {
 		b, err := hex.DecodeString(s.Text())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		data = append(data, b)
 	}
 	// All hex streams decoded to raw binary format and stored in data slice.
@@ -32,8 +33,8 @@ func TestChromeAllocRequest(t *testing.T) {
 	for i, packet := range data {
 		m := new(stun.Message)
 		_, err := m.Write(packet)
-		assert.NoErrorf(t, err, "Packet %d: %v", i, err)
+		require.NoErrorf(t, err, "Packet %d: %v", i, err)
 		messages = append(messages, m)
 	}
-	assert.Equal(t, 4, len(messages), "unexpected number of messages")
+	assert.Len(t, messages, 4, "unexpected number of messages")
 }

--- a/internal/proto/connection_id.go
+++ b/internal/proto/connection_id.go
@@ -15,7 +15,7 @@ import (
 // connection.  It is a 32-bit unsigned integral value.
 //
 // RFC 6062 Section 6.2.1.
-type ConnectionID uint32
+type ConnectionID uint32 //nolint:recvcheck // pion/stun contract: AddTo needs a value receiver so unaddressable values satisfy stun.Setter, GetFrom needs a pointer receiver to decode into.
 
 const connectionIDSize = 4 // uint32: 4 bytes, 32 bits
 

--- a/internal/proto/data.go
+++ b/internal/proto/data.go
@@ -14,7 +14,7 @@ import "github.com/pion/stun/v3"
 // and the peer).
 //
 // RFC 5766 Section 14.4.
-type Data []byte
+type Data []byte //nolint:recvcheck // pion/stun contract: AddTo needs a value receiver so unaddressable values satisfy stun.Setter, GetFrom needs a pointer receiver to decode into.
 
 // AddTo adds DATA to message.
 func (d Data) AddTo(m *stun.Message) error {

--- a/internal/proto/data_test.go
+++ b/internal/proto/data_test.go
@@ -8,14 +8,15 @@ import (
 
 	"github.com/pion/stun/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func BenchmarkData(b *testing.B) {
 	b.Run("AddTo", func(b *testing.B) {
 		m := new(stun.Message)
 		d := make(Data, 10)
-		for i := 0; i < b.N; i++ {
-			assert.NoError(b, d.AddTo(m))
+		for range b.N {
+			require.NoError(b, d.AddTo(m))
 			m.Reset()
 		}
 	})
@@ -23,7 +24,7 @@ func BenchmarkData(b *testing.B) {
 		m := new(stun.Message)
 		d := make([]byte, 10)
 		// Overhead should be low.
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			m.Add(stun.AttrData, d)
 			m.Reset()
 		}
@@ -37,7 +38,7 @@ func TestData(t *testing.T) {
 		allocated := wasAllocs(func() {
 			// On stack.
 			d := Data(v)
-			assert.NoError(t, d.AddTo(stunMsg))
+			require.NoError(t, d.AddTo(stunMsg))
 			stunMsg.Reset()
 		})
 		assert.False(t, allocated)
@@ -45,7 +46,7 @@ func TestData(t *testing.T) {
 		d := &Data{1, 2, 3, 4}
 		allocated = wasAllocs(func() {
 			// On heap.
-			assert.NoError(t, d.AddTo(stunMsg))
+			require.NoError(t, d.AddTo(stunMsg))
 			stunMsg.Reset()
 		})
 		assert.False(t, allocated)
@@ -53,7 +54,7 @@ func TestData(t *testing.T) {
 	t.Run("AddTo", func(t *testing.T) {
 		m := new(stun.Message)
 		data := Data{1, 2, 33, 44, 0x13, 0xaf}
-		assert.NoError(t, data.AddTo(m))
+		require.NoError(t, data.AddTo(m))
 
 		m.WriteHeader()
 		t.Run("GetFrom", func(t *testing.T) {

--- a/internal/proto/dontfrag.go
+++ b/internal/proto/dontfrag.go
@@ -20,7 +20,7 @@ type DontFragmentAttr = DontFragment
 // part and thus the attribute length field is 0.
 //
 // RFC 5766 Section 14.8.
-type DontFragment struct{}
+type DontFragment struct{} //nolint:recvcheck // pion/stun contract: AddTo needs a value receiver so unaddressable values satisfy stun.Setter, GetFrom needs a pointer receiver to decode into.
 
 const dontFragmentSize = 0
 

--- a/internal/proto/dontfrag_test.go
+++ b/internal/proto/dontfrag_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pion/stun/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDontFragment(t *testing.T) {
@@ -20,13 +21,13 @@ func TestDontFragment(t *testing.T) {
 	})
 	t.Run("AddTo", func(t *testing.T) {
 		stunMsg := new(stun.Message)
-		assert.NoError(t, dontFrag.AddTo(stunMsg))
+		require.NoError(t, dontFrag.AddTo(stunMsg))
 
 		stunMsg.WriteHeader()
 		t.Run("IsSet", func(t *testing.T) {
 			decoded := new(stun.Message)
 			_, err := decoded.Write(stunMsg.Raw)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.True(t, dontFrag.IsSet(stunMsg))
 
 			allocated := wasAllocs(func() {

--- a/internal/proto/evenport.go
+++ b/internal/proto/evenport.go
@@ -12,7 +12,7 @@ import "github.com/pion/stun/v3"
 // reserve the next-higher port number.
 //
 // RFC 5766 Section 14.6.
-type EvenPort struct {
+type EvenPort struct { //nolint:recvcheck // pion/stun contract: AddTo needs a value receiver so unaddressable values satisfy stun.Setter, GetFrom needs a pointer receiver to decode into.
 	// ReservePort means that the server is requested to reserve
 	// the next-higher port number (on the same IP address)
 	// for a subsequent allocation.

--- a/internal/proto/evenport_test.go
+++ b/internal/proto/evenport_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pion/stun/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEvenPort(t *testing.T) {
@@ -23,7 +24,7 @@ func TestEvenPort(t *testing.T) {
 		p := EvenPort{
 			ReservePort: false,
 		}
-		assert.NoError(t, p.AddTo(m))
+		require.NoError(t, p.AddTo(m))
 
 		m.WriteHeader()
 		decoded := new(stun.Message)
@@ -39,7 +40,7 @@ func TestEvenPort(t *testing.T) {
 		evenPortAttr := EvenPort{
 			ReservePort: true,
 		}
-		assert.NoError(t, evenPortAttr.AddTo(m))
+		require.NoError(t, evenPortAttr.AddTo(m))
 		m.WriteHeader()
 		t.Run("GetFrom", func(t *testing.T) {
 			decoded := new(stun.Message)
@@ -58,7 +59,7 @@ func TestEvenPort(t *testing.T) {
 			t.Run("HandleErr", func(t *testing.T) {
 				m := new(stun.Message)
 				var handle EvenPort
-				assert.ErrorIs(t, handle.GetFrom(m), stun.ErrAttributeNotFound)
+				require.ErrorIs(t, handle.GetFrom(m), stun.ErrAttributeNotFound)
 
 				m.Add(stun.AttrEvenPort, []byte{1, 2, 3})
 				assert.True(t, stun.IsAttrSizeInvalid(handle.GetFrom(m)))

--- a/internal/proto/fuzz_test.go
+++ b/internal/proto/fuzz_test.go
@@ -64,8 +64,8 @@ func FuzzSetters(f *testing.F) {
 		m1.Add(attr.t, value)
 		if err := attr.g.GetFrom(m1); err != nil {
 			if errors.Is(err, stun.ErrAttributeNotFound) {
-				fmt.Println("unexpected 404") //nolint
-				panic(err)                    //nolint
+				fmt.Println("unexpected 404")
+				panic(err)
 			}
 
 			return
@@ -73,20 +73,20 @@ func FuzzSetters(f *testing.F) {
 
 		m2.WriteHeader()
 		if err := attr.g.AddTo(m2); err != nil {
-			fmt.Println("failed to add attribute to m2") //nolint
-			panic(err)                                   //nolint
+			fmt.Println("failed to add attribute to m2")
+			panic(err)
 		}
 
 		m3.WriteHeader()
 		v, err := m2.Get(attr.t)
 		if err != nil {
-			panic(err) //nolint
+			panic(err)
 		}
 		m3.Add(attr.t, v)
 
 		if !m2.Equal(m3) {
-			fmt.Println(m2, "not equal", m3) //nolint
-			panic("not equal")               //nolint
+			fmt.Println(m2, "not equal", m3)
+			panic("not equal")
 		}
 	})
 }
@@ -119,7 +119,7 @@ func FuzzChannelData(f *testing.F) {
 		d2 := &ChannelData{}
 		d2.Raw = channelData.Raw
 		if err := d2.Decode(); err != nil {
-			panic(err) //nolint
+			panic(err)
 		}
 	})
 }

--- a/internal/proto/lifetime.go
+++ b/internal/proto/lifetime.go
@@ -24,7 +24,7 @@ const DefaultLifetime = time.Minute * 10
 // until expiration.
 //
 // RFC 5766 Section 14.2.
-type Lifetime struct {
+type Lifetime struct { //nolint:recvcheck // pion/stun contract: AddTo needs a value receiver so unaddressable values satisfy stun.Setter, GetFrom needs a pointer receiver to decode into.
 	time.Duration
 }
 

--- a/internal/proto/lifetime_test.go
+++ b/internal/proto/lifetime_test.go
@@ -9,22 +9,23 @@ import (
 
 	"github.com/pion/stun/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func BenchmarkLifetime(b *testing.B) {
 	b.Run("AddTo", func(b *testing.B) {
 		b.ReportAllocs()
 		m := new(stun.Message)
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			l := Lifetime{time.Second}
-			assert.NoError(b, l.AddTo(m))
+			require.NoError(b, l.AddTo(m))
 			m.Reset()
 		}
 	})
 	b.Run("GetFrom", func(b *testing.B) {
 		m := new(stun.Message)
-		assert.NoError(b, Lifetime{time.Minute}.AddTo(m))
-		for i := 0; i < b.N; i++ {
+		require.NoError(b, Lifetime{time.Minute}.AddTo(m))
+		for range b.N {
 			l := Lifetime{}
 			assert.NoError(b, l.GetFrom(m))
 		}
@@ -43,7 +44,7 @@ func TestLifetime(t *testing.T) {
 			l := Lifetime{
 				Duration: time.Minute,
 			}
-			assert.NoError(t, l.AddTo(stunMsg))
+			require.NoError(t, l.AddTo(stunMsg))
 			stunMsg.Reset()
 		})
 		assert.False(t, allocated)
@@ -51,7 +52,7 @@ func TestLifetime(t *testing.T) {
 		l := &Lifetime{time.Second}
 		allocated = wasAllocs(func() {
 			// On heap.
-			assert.NoError(t, l.AddTo(stunMsg))
+			require.NoError(t, l.AddTo(stunMsg))
 			stunMsg.Reset()
 		})
 		assert.False(t, allocated)
@@ -59,7 +60,7 @@ func TestLifetime(t *testing.T) {
 	t.Run("AddTo", func(t *testing.T) {
 		m := new(stun.Message)
 		lifetime := Lifetime{time.Second * 10}
-		assert.NoError(t, lifetime.AddTo(m))
+		require.NoError(t, lifetime.AddTo(m))
 		m.WriteHeader()
 		t.Run("GetFrom", func(t *testing.T) {
 			decoded := new(stun.Message)
@@ -78,7 +79,7 @@ func TestLifetime(t *testing.T) {
 			t.Run("HandleErr", func(t *testing.T) {
 				m := new(stun.Message)
 				nHandle := new(Lifetime)
-				assert.ErrorIs(t, nHandle.GetFrom(m), stun.ErrAttributeNotFound)
+				require.ErrorIs(t, nHandle.GetFrom(m), stun.ErrAttributeNotFound)
 
 				m.Add(stun.AttrLifetime, []byte{1, 2, 3})
 				assert.True(t, stun.IsAttrSizeInvalid(nHandle.GetFrom(m)))

--- a/internal/proto/peeraddr.go
+++ b/internal/proto/peeraddr.go
@@ -16,7 +16,7 @@ import (
 // transport address if the peer is behind a NAT.)
 //
 // RFC 5766 Section 14.3.
-type PeerAddress struct {
+type PeerAddress struct { //nolint:recvcheck // pion/stun contract: AddTo needs a value receiver so unaddressable values satisfy stun.Setter, GetFrom needs a pointer receiver to decode into.
 	IP   net.IP
 	Port int
 }

--- a/internal/proto/peeraddr_test.go
+++ b/internal/proto/peeraddr_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pion/stun/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPeerAddress(t *testing.T) {
@@ -21,7 +22,7 @@ func TestPeerAddress(t *testing.T) {
 		assert.Equal(t, "111.11.1.2:333", a.String())
 	})
 	m := new(stun.Message)
-	assert.NoError(t, a.AddTo(m))
+	require.NoError(t, a.AddTo(m))
 
 	m.WriteHeader()
 	decoded := new(stun.Message)

--- a/internal/proto/relayedaddr.go
+++ b/internal/proto/relayedaddr.go
@@ -15,7 +15,7 @@ import (
 // client. It is encoded in the same way as XOR-MAPPED-ADDRESS.
 //
 // RFC 5766 Section 14.5.
-type RelayedAddress struct {
+type RelayedAddress struct { //nolint:recvcheck // pion/stun contract: AddTo needs a value receiver so unaddressable values satisfy stun.Setter, GetFrom needs a pointer receiver to decode into.
 	IP   net.IP
 	Port int
 }

--- a/internal/proto/relayedaddr_test.go
+++ b/internal/proto/relayedaddr_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pion/stun/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRelayedAddress(t *testing.T) {
@@ -21,7 +22,7 @@ func TestRelayedAddress(t *testing.T) {
 		assert.Equal(t, "111.11.1.2:333", a.String())
 	})
 	m := new(stun.Message)
-	assert.NoError(t, a.AddTo(m))
+	require.NoError(t, a.AddTo(m))
 
 	m.WriteHeader()
 	decoded := new(stun.Message)

--- a/internal/proto/reqfamily.go
+++ b/internal/proto/reqfamily.go
@@ -11,7 +11,7 @@ import (
 
 // RequestedAddressFamily represents the REQUESTED-ADDRESS-FAMILY Attribute as
 // defined in RFC 6156 Section 4.1.1.
-type RequestedAddressFamily byte
+type RequestedAddressFamily byte //nolint:recvcheck // pion/stun contract: AddTo needs a value receiver so unaddressable values satisfy stun.Setter, GetFrom needs a pointer receiver to decode into.
 
 const requestedFamilySize = 4
 

--- a/internal/proto/reqfamily_test.go
+++ b/internal/proto/reqfamily_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pion/stun/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRequestedAddressFamily(t *testing.T) {
@@ -24,7 +25,7 @@ func TestRequestedAddressFamily(t *testing.T) {
 	t.Run("IPv6", func(t *testing.T) {
 		stunMsg := new(stun.Message)
 		requestFamilyAddr := RequestedFamilyIPv6
-		assert.NoError(t, requestFamilyAddr.AddTo(stunMsg))
+		require.NoError(t, requestFamilyAddr.AddTo(stunMsg))
 
 		stunMsg.WriteHeader()
 		decoded := new(stun.Message)
@@ -41,7 +42,7 @@ func TestRequestedAddressFamily(t *testing.T) {
 		allocated := wasAllocs(func() {
 			// On stack.
 			r := RequestedFamilyIPv4
-			assert.NoError(t, r.AddTo(stunMsg))
+			require.NoError(t, r.AddTo(stunMsg))
 			stunMsg.Reset()
 		})
 		assert.False(t, allocated)
@@ -50,7 +51,7 @@ func TestRequestedAddressFamily(t *testing.T) {
 		*requestFamilyAttr = RequestedFamilyIPv4
 		allocated = wasAllocs(func() {
 			// On heap.
-			assert.NoError(t, requestFamilyAttr.AddTo(stunMsg))
+			require.NoError(t, requestFamilyAttr.AddTo(stunMsg))
 			stunMsg.Reset()
 		})
 		assert.False(t, allocated)
@@ -58,7 +59,7 @@ func TestRequestedAddressFamily(t *testing.T) {
 	t.Run("AddTo", func(t *testing.T) {
 		stunMsg := new(stun.Message)
 		requestFamilyAddr := RequestedFamilyIPv4
-		assert.NoError(t, requestFamilyAddr.AddTo(stunMsg))
+		require.NoError(t, requestFamilyAddr.AddTo(stunMsg))
 
 		stunMsg.WriteHeader()
 		t.Run("GetFrom", func(t *testing.T) {
@@ -78,14 +79,14 @@ func TestRequestedAddressFamily(t *testing.T) {
 			t.Run("HandleErr", func(t *testing.T) {
 				m := new(stun.Message)
 				var handle RequestedAddressFamily
-				assert.ErrorIs(t, handle.GetFrom(m), stun.ErrAttributeNotFound)
+				require.ErrorIs(t, handle.GetFrom(m), stun.ErrAttributeNotFound)
 
 				m.Add(stun.AttrRequestedAddressFamily, []byte{1, 2, 3})
 				assert.True(t, stun.IsAttrSizeInvalid(handle.GetFrom(m)))
 
 				m.Reset()
 				m.Add(stun.AttrRequestedAddressFamily, []byte{5, 0, 0, 0})
-				assert.NotNil(t, handle.GetFrom(m), "should not error on unknown value")
+				assert.Error(t, handle.GetFrom(m), "should not error on unknown value")
 			})
 		})
 	})

--- a/internal/proto/reqtrans.go
+++ b/internal/proto/reqtrans.go
@@ -37,7 +37,7 @@ func (p Protocol) String() string {
 // code point 17 (User Datagram Protocol).
 //
 // RFC 5766 Section 14.7.
-type RequestedTransport struct {
+type RequestedTransport struct { //nolint:recvcheck // pion/stun contract: AddTo needs a value receiver so unaddressable values satisfy stun.Setter, GetFrom needs a pointer receiver to decode into.
 	Protocol Protocol
 }
 

--- a/internal/proto/reqtrans_test.go
+++ b/internal/proto/reqtrans_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pion/stun/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRequestedTransport(t *testing.T) {
@@ -32,7 +33,7 @@ func TestRequestedTransport(t *testing.T) {
 			r := RequestedTransport{
 				Protocol: ProtoUDP,
 			}
-			assert.NoError(t, r.AddTo(stunMsg))
+			require.NoError(t, r.AddTo(stunMsg))
 			stunMsg.Reset()
 		})
 		assert.False(t, allocated)
@@ -42,7 +43,7 @@ func TestRequestedTransport(t *testing.T) {
 		}
 		allocated = wasAllocs(func() {
 			// On heap.
-			assert.NoError(t, r.AddTo(stunMsg))
+			require.NoError(t, r.AddTo(stunMsg))
 			stunMsg.Reset()
 		})
 		assert.False(t, allocated)
@@ -52,7 +53,7 @@ func TestRequestedTransport(t *testing.T) {
 		transAttr := RequestedTransport{
 			Protocol: ProtoUDP,
 		}
-		assert.NoError(t, transAttr.AddTo(m))
+		require.NoError(t, transAttr.AddTo(m))
 		m.WriteHeader()
 		t.Run("GetFrom", func(t *testing.T) {
 			decoded := new(stun.Message)
@@ -73,7 +74,7 @@ func TestRequestedTransport(t *testing.T) {
 			t.Run("HandleErr", func(t *testing.T) {
 				m := new(stun.Message)
 				var handle RequestedTransport
-				assert.ErrorIs(t, handle.GetFrom(m), stun.ErrAttributeNotFound)
+				require.ErrorIs(t, handle.GetFrom(m), stun.ErrAttributeNotFound)
 
 				m.Add(stun.AttrRequestedTransport, []byte{1, 2, 3})
 				assert.True(t, stun.IsAttrSizeInvalid(handle.GetFrom(m)))

--- a/internal/proto/rsrvtoken.go
+++ b/internal/proto/rsrvtoken.go
@@ -15,7 +15,7 @@ import "github.com/pion/stun/v3"
 // that relayed transport address for the allocation.
 //
 // RFC 5766 Section 14.9.
-type ReservationToken []byte
+type ReservationToken []byte //nolint:recvcheck // pion/stun contract: AddTo needs a value receiver so unaddressable values satisfy stun.Setter, GetFrom needs a pointer receiver to decode into.
 
 const reservationTokenSize = 8 // 8 bytes
 

--- a/internal/proto/rsrvtoken_test.go
+++ b/internal/proto/rsrvtoken_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pion/stun/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReservationToken(t *testing.T) {
@@ -17,7 +18,7 @@ func TestReservationToken(t *testing.T) {
 		allocated := wasAllocs(func() {
 			// On stack.
 			tk := ReservationToken(tok)
-			assert.NoError(t, tk.AddTo(stunMsg))
+			require.NoError(t, tk.AddTo(stunMsg))
 			stunMsg.Reset()
 		})
 		assert.False(t, allocated)
@@ -25,7 +26,7 @@ func TestReservationToken(t *testing.T) {
 		tk := make(ReservationToken, 8)
 		allocated = wasAllocs(func() {
 			// On heap.
-			assert.NoError(t, tk.AddTo(stunMsg))
+			require.NoError(t, tk.AddTo(stunMsg))
 			stunMsg.Reset()
 		})
 		assert.False(t, allocated)
@@ -35,7 +36,7 @@ func TestReservationToken(t *testing.T) {
 		tk := make(ReservationToken, 8)
 		tk[2] = 33
 		tk[7] = 1
-		assert.NoError(t, tk.AddTo(stunMsg))
+		require.NoError(t, tk.AddTo(stunMsg))
 
 		stunMsg.WriteHeader()
 		t.Run("HandleErr", func(t *testing.T) {
@@ -58,7 +59,7 @@ func TestReservationToken(t *testing.T) {
 			t.Run("HandleErr", func(t *testing.T) {
 				m := new(stun.Message)
 				var handle ReservationToken
-				assert.ErrorIs(t, handle.GetFrom(m), stun.ErrAttributeNotFound)
+				require.ErrorIs(t, handle.GetFrom(m), stun.ErrAttributeNotFound)
 
 				m.Add(stun.AttrReservationToken, []byte{1, 2, 3})
 				assert.True(t, stun.IsAttrSizeInvalid(handle.GetFrom(m)))

--- a/internal/proto/stun_conn_test.go
+++ b/internal/proto/stun_conn_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type mockConn struct {
@@ -63,16 +64,16 @@ func TestStunConn(t *testing.T) {
 		assert.Nil(t, stunConn.LocalAddr())
 		assert.True(t, testConn.didLocalAddr)
 
-		assert.NoError(t, stunConn.Close())
+		require.NoError(t, stunConn.Close())
 		assert.True(t, testConn.didClose)
 
-		assert.NoError(t, stunConn.SetDeadline(time.Time{}))
+		require.NoError(t, stunConn.SetDeadline(time.Time{}))
 		assert.True(t, testConn.didSetDeadline)
 
-		assert.NoError(t, stunConn.SetReadDeadline(time.Time{}))
+		require.NoError(t, stunConn.SetReadDeadline(time.Time{}))
 		assert.True(t, testConn.didSetReadDeadline)
 
-		assert.NoError(t, stunConn.SetWriteDeadline(time.Time{}))
+		require.NoError(t, stunConn.SetWriteDeadline(time.Time{}))
 		assert.True(t, testConn.didSetWriteDeadline)
 	})
 
@@ -84,13 +85,13 @@ func TestStunConn(t *testing.T) {
 		n, addr, err := stunConn.ReadFrom(nil)
 		assert.Zero(t, n)
 		assert.Nil(t, addr)
-		assert.Error(t, err, errInvalidTURNFrame)
+		assert.ErrorIs(t, err, errInvalidTURNFrame)
 	})
 
 	t.Run("Invalid ChannelData size", func(t *testing.T) {
 		n, err := consumeSingleTURNFrame([]byte{0x40, 0x00, 0x00, 0x12, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF})
-		assert.Equal(t, n, 0)
-		assert.Error(t, err, errIncompleteTURNFrame)
+		assert.Equal(t, 0, n)
+		assert.ErrorIs(t, err, errIncompleteTURNFrame)
 	})
 
 	t.Run("Padding", func(t *testing.T) {
@@ -99,7 +100,7 @@ func TestStunConn(t *testing.T) {
 		stunConn.buff = []byte{0x40, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
 
 		n, addr, err := stunConn.ReadFrom(nil)
-		assert.Equal(t, n, 8)
+		assert.Equal(t, 8, n)
 		assert.Nil(t, addr)
 		assert.NoError(t, err)
 	})

--- a/scripted_allocation_test.go
+++ b/scripted_allocation_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/pion/stun/v3"
 	"github.com/stretchr/testify/require"
+
 	"github.com/the-sarge/turn/v5/internal/client"
 )
 

--- a/turntest/respond.go
+++ b/turntest/respond.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/pion/stun/v3"
+
 	"github.com/the-sarge/turn/v5/internal/proto"
 )
 

--- a/turntest/turntest.go
+++ b/turntest/turntest.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/pion/stun/v3"
+
 	"github.com/the-sarge/turn/v5/internal/proto"
 )
 
@@ -41,7 +42,7 @@ const (
 type Options struct {
 	Realm    string
 	Username string
-	Password string //nolint:gosec // runtime test credential, not hardcoded.
+	Password string
 
 	// IPv6 listens and relays on [::1] instead of 127.0.0.1.
 	IPv6 bool

--- a/turntest/turntest_test.go
+++ b/turntest/turntest_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pion/stun/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	turn "github.com/the-sarge/turn/v5"
 	"github.com/the-sarge/turn/v5/turntest"
 )
@@ -41,7 +42,7 @@ func startClient(t *testing.T, srv *turntest.Server) *turn.Client {
 	if srv.Addr().Addr().Is6() {
 		network, listen = "udp6", "[::1]:0"
 	}
-	conn, err := net.ListenPacket(network, listen) //nolint:noctx // test socket
+	conn, err := net.ListenPacket(network, listen)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = conn.Close() })
 
@@ -105,7 +106,7 @@ func TestRejectChannelBind(t *testing.T) {
 	require.Error(t, alloc.PreparePeer(context.Background(), peer))
 
 	_, err = alloc.WriteTo([]byte{0x00}, peer)
-	assert.ErrorIs(t, err, net.ErrClosed)
+	require.ErrorIs(t, err, net.ErrClosed)
 	assert.ErrorIs(t, err, turn.ErrChannelBindFailed)
 }
 
@@ -166,7 +167,7 @@ func TestAllocationCount(t *testing.T) {
 func TestSecondAllocateMismatch(t *testing.T) {
 	srv := turntest.Start(t, options())
 
-	conn, err := net.ListenPacket("udp4", "0.0.0.0:0") //nolint:noctx // test socket
+	conn, err := net.ListenPacket("udp4", "0.0.0.0:0")
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = conn.Close() })
 
@@ -222,7 +223,7 @@ func TestDataIndicationAfterBindingExpiry(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = alloc.Close() })
 
-	peerConn, err := net.ListenPacket("udp4", "127.0.0.1:0") //nolint:noctx // test peer socket
+	peerConn, err := net.ListenPacket("udp4", "127.0.0.1:0")
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = peerConn.Close() })
 	peerUDP, ok := peerConn.LocalAddr().(*net.UDPAddr)


### PR DESCRIPTION
Brings turn onto the portfolio Go lint standard and formally retires Pion's lint configuration from this hard fork.

## Canonical config

`.golangci.yml` is a byte-identical copy of `the-sarge/infra` `config/golangci/.golangci.yml` at tag `golangci-standard/v1.0.0`.

```
sha256  a18cfc4fcdbc03b2c2e40c658f3b1cf27066b8ff62816786283663226d910dc8
```

golangci-lint stays pinned at v2.13.1, already in `scripts/tool-versions.env`.

The replaced file was the 159-line Pion config inherited from the upstream fork (57 enabled linters, Pion's SPDX header, `goheader`/`err113`/`varnamelen`/`lll`/`cyclop`/`gocognit` style opinions, `govet` `shadow`, `contextcheck`, `unparam`, and four formatters). This repository is a hard fork and follows the portfolio standard, not upstream's; the standard drops most of those style linters but is stricter where it counts (staticcheck `all`, gosec over tests, `nolintlint`, `testifylint`, `recvcheck`).

Pion's `exclusions` for `examples|main\.go`, `cmd`, and the `internal/proto/chandata_test.go` `b.Loop` carve-out are dropped with no loss: no `examples/`, `main.go`, or `cmd/` exists here, and `modernize` is not in the standard.

## Drift check

`Taskfile.yml` gains `LINT_STANDARD_SHA256` and a `lint-config-check` task that shasum-verifies `.golangci.yml` and fails pointing at the canonical copy. It is a dependency of `lint`, so `task ci` -> `task check` -> `task lint` enforces it on every PR. Verified in both directions: passes on the canonical file, fails on a one-line tamper.

## Findings: 264 total

| Pass | Count | Linters |
| --- | --- | --- |
| `golangci-lint fmt` | 14 | gci 14 |
| `run --fix` | 29 | intrange 11, nolintlint 9, testifylint 9 |
| Hand-fixed | 209 | testifylint 178, nolintlint 21, intrange 2, gci/gofumpt 8 (reflow after import insertion) |
| `//nolint` | 12 | recvcheck 12 |

`gofumpt` reported zero findings, and `golangci-lint fmt` and `run` agreed throughout — the plain-gofmt-vs-gofumpt composite-literal deadlock seen in the pilot did not appear here. `task format-check` (plain gofmt) stays green.

### Pass 1 - `golangci-lint fmt` (14)

Purely mechanical. gci's `[standard, default, localmodule]` sections split `github.com/the-sarge/turn/v5/...` out of the third-party block, so 14 files gained one blank line after `github.com/pion/stun/v3`.

### Pass 2 - `run --fix` (29)

Reviewed line by line, then built and tested before going further, per the pilot rule about never trusting `--fix`.

- **intrange 11** - `for i := 0; i < b.N; i++` to `for range b.N` in benchmarks.
- **nolintlint 9** - leading-space `// nolint:x` normalized to `//nolint:x`, and bare `//nolint` on `panic`/`fmt.Println` in `internal/proto/fuzz_test.go` deleted (they suppressed Pion's `forbidigo`, which the standard does not enable).
- **testifylint 9** - `assert.Equal(t, n, len(x))` to `assert.Len`, expected/actual reversals, `errors.As` wrappers to `assert.ErrorAs`/`assert.NotErrorAs`.

Two of those were latent test bugs rather than style: `internal/proto/stun_conn_test.go` passed `errInvalidTURNFrame` and `errIncompleteTURNFrame` to `assert.Error` as a *message argument*, so the sentinel was never checked. `--fix` turned both into real `assert.ErrorIs` assertions, and they pass.

There were no errorlint findings, so the errorlint autofix hazard from the pilot never came up. `internal/client/udp_conn.go` `handleChannelBindErrorResponse` is unchanged apart from a deleted `//nolint:err113` comment; the `*stun.TurnError` `errors.As` contract its tests match on is byte-identical.

### Pass 3 - hand fixes (209)

- **testifylint `require-error` 177.** The standard's `testifylint` requires error assertions to use `require`, not `assert`. Converted at the 177 reported call sites (`assert.NoError`/`Error`/`ErrorIs`/`ErrorAs`/`NotErrorIs` to `require.*`), adding the `require` import to the 13 `internal/proto` test files that only imported `assert`. No file lost its `assert` import. Re-linted afterwards to confirm none of the conversions landed inside a goroutine or an `Eventually` callback: `go-require` stayed at zero.
- **testifylint `go-require` 1.** `allocate_ctx_test.go` called the `require`-using helper `allocateSuccessResponse(t, authReq)` from inside `go func() { done <- cl.HandleInbound(...) }()`. The response is now built on the test goroutine and passed in.
- **intrange 2.** `for i := int32(0); i < conn.writeCount.Load(); i++` to `for i := range conn.writeCount.Load()` in the zero-lifetime characterization test. This also snapshots the write count once instead of re-reading an atomic the server goroutine is still advancing, which is what the scan intends.
- **nolintlint 21 - reverse churn.** Directives carrying Pion-era assumptions, all deleted rather than annotated, because the linters they name are not in the standard and the suppressions are dead: `cyclop` x3, `err113` x4, `nestif` x1, `maintidx,cyclop,gocyclo` x2, plus `noctx` x7 and `errcheck` x4 in tests (the standard excludes `noctx` in `_test.go` and excludes the three `Close` signatures from errcheck) and `gosec` on two `Password string` struct fields (G101 no longer fires).

### Suppressions - recvcheck x12, all reasoned

Every `stun` attribute type in `internal/proto` mixes receivers, and must:

```go
func (n ChannelNumber) AddTo(m *stun.Message) error   // value:   stun.Setter
func (n *ChannelNumber) GetFrom(m *stun.Message) error // pointer: decodes into
```

A value receiver on `AddTo` is what lets unaddressable values (`ChannelNumber(12)`, `Lifetime{time.Second}`, `proto.Data(b)`) satisfy `stun.Setter` at call sites throughout the client; a pointer receiver on `GetFrom` is what lets it decode into the receiver. Making them uniform breaks one or the other. Suppressed on the type declaration with that reason on `ChannelNumber`, `ConnectionID`, `Data`, `DontFragment`, `EvenPort`, `Lifetime`, `PeerAddress`, `RelayedAddress`, `RequestedAddressFamily`, `RequestedTransport`, `ReservationToken`.

`proto.Addr` is the twelfth and differs slightly: it travels as a `net.Addr` value and only `FromUDPAddr` mutates, so it carries its own reason.

## Validation

Exact-head `task preflight` at `5fc569a` against base `a961f9b`.

| Gate | Result |
| --- | --- |
| `task lint` | 0 issues |
| `task lint-config-check` | pass (and fails correctly on tamper) |
| `task preflight` | exit 0 |
| `task check` / `task verify` | exit 0 |
| `task format-check` (plain gofmt) | exit 0 |
| `go build ./...` | clean |
| `go vet ./...` | clean |
| `go test ./...` | all 4 packages pass |
| `go test -race ./...` | all 4 packages pass |
| `task dependency-gate` | mod verify, `tidy -diff`, govulncheck clean |
| `task platform-check` | darwin/amd64 + windows/amd64 cross-build clean |
| `task workflow-check` | actionlint clean |
| `task secret-scan` | 765 commits, no leaks |

`.github/workflows/ci.yml` is unchanged: it still resolves the toolchain from `go-version-file: go.mod` (go 1.27 / toolchain go1.27.0) and runs the single `task ci` step, which now includes the drift check. Local certification ran on go1.27.0 with `GOTOOLCHAIN=local`.

## What fought turn

Nothing structural. The volume is testifylint `require-error`, which no autofixer will touch because it changes control flow, so all 177 were converted by position from the JSON report and then verified by build, vet, `go test`, and `go test -race`. The only judgement calls were the 12 recvcheck suppressions and the decision to delete Pion-era `//nolint` directives outright instead of retrofitting explanations onto suppressions for linters that no longer run.

Well-formed, reasoned directives for linters the standard does not currently enable (`//nolint:err113 // test-local cause` and friends, ~30 sites) are left in place: nolintlint does not flag them, they document intent, and re-enabling those linters is a standard version bump rather than drift.
